### PR TITLE
Added automatic updating of the feedstocks repo.

### DIFF
--- a/.ci_scripts/update_feedstocks_repo
+++ b/.ci_scripts/update_feedstocks_repo
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Expected to be run in a TravisCI context.
+
+set -e
+
+if [ -n "$GH_TOKEN" ]; then
+    git clone https://${GH_TOKEN}@github.com/conda-forge/feedstocks.git feedstocks_repo
+    conda execute -v ./scripts/update_feedstocks_submodules.py ./feedstocks_repo
+    cd ./feedstocks_repo
+    git push origin master > /dev/null
+fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
        - secure: "Lwj/rVoBIEATGVq93byY2H47lSVqUCyyGs8W3cIfnlZS6+xF/Xw+xQj2TPJR4ffYm95mtku+VT8/39dceKiWMdtdIclLoP2MAM3SKVDbjgiGVRBpcImBIkLecvaBMb3OukDY4q8/jn2FzzqR27RhffF7reCwK3PcBcIrKgg7zDzdmQviGiRXQ8JQSf2qYETiT1Iy4BuYOkgxH2R3Y382p3dnSHUjT/4Yr3krIl6Vmjq13LIS+LRYhbKlclca0fohsbPqq1gZyXsLJF4rrIblZWzjYLlD+kM218HfIy0Qdhvf+xawn6LmlR/UCAw4aluX2RINV+QypKrmILklzasNVG7CBCRBmU3O2cpU6ZIPZXwX+AyxOzhII/MwUWf5+KbfWR6niObFvn3gG/ABcNzuXoLP0aIv0njIITAsRcPToHVAp4r5fDRTuViJnUlFlizIJaw71ovl5TzSAEcDmxyTi3E8R9OIuBx9ZIcT3Np2hNF0OshEoF4k76LIK84RPGrMnZhruT+G75zX5LI9eBJZI1fNUbRz0OL2olu5+ZAZCTM7ZrnPQtDzDsyU7mohB7pK3jRqJrb/RXU9NPDcRJtaPl3FhTsKNOh/SKeC4aFbdDhjhjtcXBopstSzNKorHZcbI8cONcLxQwDDJU2VSu7/YJemwC/md8u/zL3TjbWKGnQ="
 
     matrix:
-#        - ACTION="feedstocks_repo"
+        - ACTION="feedstocks_repo"
         - ACTION="update_docs"
 
 install:
@@ -31,8 +31,12 @@ install:
     - conda install conda-execute --yes --quiet -c conda-forge
 
 script:
-    - if (( "$ACTION" == "update_docs" )); then
+    - if [ $ACTION = "update_docs" ]; then
+        echo "Updating docs";
         source ./.ci_scripts/update_docs;
+      elif [ "$ACTION" = "feedstocks_repo" ]; then
+        echo "Updating feedstock repo";
+        source ./.ci_scripts/update_feedstocks_repo;
       fi
 
 # We store the files that are downloaded from continuum.io, but not the environments that are created.

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -12,10 +12,17 @@ import os
 
 import conda_smithy.feedstocks as feedstocks
 
-
 from jinja2 import Environment, FileSystemLoader
 
-html_source = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+import argparse
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('--html-source', help="The location of the conda-forge.github.io checkout.",
+                   default=os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+args = parser.parse_args()
+
+html_source = args.html_source
 loader = FileSystemLoader(html_source)
 env = Environment(loader=loader)
 

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - conda-smithy
+#  - gitpython
+# channels:
+#  - conda-forge
+# run_with: python
+
+import os
+
+import conda_smithy.feedstocks as feedstocks
+from git import Repo
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('feedstocks_repo', help="The location of the checked out conda-forge/feedstocks repo.")
+
+args = parser.parse_args()
+
+feedstocks_repo = Repo(args.feedstocks_repo)
+
+for feedstock in feedstocks.feedstock_repos('conda-forge'):
+    repo_subdir = os.path.join('feedstocks', feedstock.package_name)
+    abs_subdir = os.path.join(feedstocks_repo.working_tree_dir, repo_subdir)
+    sm_names = [sm.name for sm in feedstocks_repo.submodules]
+    if not os.path.exists(abs_subdir):
+        print('Adding {} to submodules.'.format(feedstock.package_name))
+
+        # For situations where the submodule already exists, but not in the expected locations, just
+        # remove it, and re-add.
+        if feedstock.package_name in sm_names:
+            feedstocks_repo.submodules[feedstock.package_name].remove()
+
+        # Add the new submodule.
+        feedstocks_repo.create_submodule(feedstock.package_name, repo_subdir,
+                                         url=feedstock.clone_url,
+                                         branch='master')
+
+feedstocks_repo.submodule_update(recursive=False)
+
+if feedstocks_repo.is_dirty():
+    feedstocks_repo.index.add(['.gitmodules'])
+    feedstocks_repo.index.commit("Updated feedstocks submodules.")


### PR DESCRIPTION
Added automatic updating of conda-forge/feedstocks.

In hindsight, the conda-forge.github.io/feedstocks.html page is a bit redundant now, but may be that we can use it as a nice "way-in" for newcomers.