### PR TITLE
Feedstocks: Warn user about empty repos

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -16,6 +16,8 @@ from git import Repo
 
 import argparse
 
+import warning
+
 parser = argparse.ArgumentParser(description='Update the conda-forge/feedstocks repo.')
 parser.add_argument('feedstocks_repo', help="The location of the checked out conda-forge/feedstocks repo.")
 
@@ -40,8 +42,16 @@ for feedstock in forge_feedstocks:
             feedstocks_repo.submodules[feedstock.package_name].remove()
 
         # Add the new submodule.
-        feedstocks_repo.create_submodule(feedstock.package_name, repo_subdir,
-                                         url=feedstock.clone_url)
+        try:
+            feedstocks_repo.create_submodule(feedstock.package_name, repo_subdir,
+                                             url=feedstock.clone_url)
+        except ValueError:
+            warning.warn(
+                    "Unable to add the submodule {}. "
+                    "This is likely because the repo has no commits, "
+                    "which likely means something went wrong with feedstock generation. "
+                    "Will skip adding this submodule and continue.".format(feedstock.package_name)
+            )
 
 
 # Pick out the feedstocks which exist on the repo, but are no longer on conda-forge.


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/54

In some cases, feedstock generation fails. When this happens, repos could be created, but have not commits in them. As a result, we can't add them as a submodule because we don't have a commit to point to. This resulted in a failure. However, the error message provided was a bit uninformative for those unfamiliar with the code. Also, it stops adding other working repos. As there may be cases where we have a broken repo and we don't want this grinding to a halt, here we raise a warning that both explains what is going on and let's us proceed through the working repos.