### PR TITLE
feedstocks: Add submodules quietly

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -10,9 +10,11 @@
 # run_with: python
 
 import os
+import shutil
 
 import conda_smithy.feedstocks as feedstocks
 from git import Repo
+from git.exc import GitCommandError
 
 import argparse
 
@@ -43,15 +45,21 @@ for feedstock in forge_feedstocks:
 
         # Add the new submodule.
         try:
-            feedstocks_repo.create_submodule(feedstock.package_name, repo_subdir,
-                                             url=feedstock.clone_url)
-        except ValueError:
+            feedstocks_repo.git.submodule(
+                "add",
+                "--name",
+                feedstock.package_name,
+                feedstock.clone_url,
+                repo_subdir
+            )
+        except GitCommandError:
             warnings.warn(
                     "Unable to add the submodule {}. "
                     "This is likely because the repo has no commits, "
                     "which likely means something went wrong with feedstock generation. "
                     "Will skip adding this submodule and continue.".format(feedstock.package_name)
             )
+            shutil.rmtree(abs_subdir)
 
 
 # Pick out the feedstocks which exist on the repo, but are no longer on conda-forge.


### PR DESCRIPTION
Fixes: https://github.com/conda-forge/conda-forge.github.io/issues/54
Related: https://github.com/conda-forge/conda-forge.github.io/pull/66

It turns out that GitPython will leave the repo in an incomplete state (modifies `.gitmodules` and keeps the repo around) after it fails to add a submodule. Here we have opted to call `git` directly via GitPython's interface to work around this problem. This allows us to handle the same error as before and not have to worry that the repo is in an incomplete state. For good measure, we clean up the repo that was cloned as `git` does not do this for us. However, it does not leave `.gitmodules` with modifications when it fails.

Tried this out locally to make sure it actually worked as intended.