### PR TITLE
Require `git` for steps that use it

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -20,6 +20,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 """
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -2,6 +2,7 @@
 
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython


### PR DESCRIPTION
On old systems it is possible to have a version of `git` that does not support all of the arguments used in these scripts. Fortunately, `git` is packaged at conda-forge. :smile: So, we should simply use it when we need it instead of relying on a system to have an acceptable version.