### PR TITLE
Revert "Require `git` for steps that use it."

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -20,7 +20,6 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 """
 # conda execute
 # env:
-#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -2,7 +2,6 @@
 
 # conda execute
 # env:
-#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython


### PR DESCRIPTION
Revert: https://github.com/conda-forge/conda-forge.github.io/pull/69

This reverts commit 13854c5d12629ec61f72c161a53c20436ba3c915.

This is reverted because the relevant certs are missing from our `git` package. Once they are added this won't be a problem any more.