### PR TITLE
Fix trailing whitespace

### DIFF
--- a/feedstocks.html
+++ b/feedstocks.html
@@ -50,7 +50,7 @@
                         <a class="page-scroll" href="./#about">About</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="./#contribute">Contribute</a>    
+                        <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
                 </ul>
             </div>
@@ -65,7 +65,7 @@
             <div class="col-lg-8 col-lg-offset-2">
                 <h2 class="text-center">Feedstocks on conda-forge</h2>
                 <ul class="list-group">
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/affine-feedstock" class="ci-badge">
@@ -73,16 +73,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/affine-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/affine-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/affine-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/affine-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/affine-feedstock">
                             affine
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/amqp-feedstock" class="ci-badge">
@@ -90,16 +90,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/amqp-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/amqp-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/amqp-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/amqp-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/amqp-feedstock">
                             amqp
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/antlr-feedstock" class="ci-badge">
@@ -107,16 +107,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/antlr-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/antlr-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/antlr-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/antlr-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/antlr-feedstock">
                             antlr
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/anyjson-feedstock" class="ci-badge">
@@ -124,16 +124,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/anyjson-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/anyjson-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/anyjson-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/anyjson-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/anyjson-feedstock">
                             anyjson
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/appdirs-feedstock" class="ci-badge">
@@ -141,16 +141,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/appdirs-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/appdirs-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/appdirs-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/appdirs-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/appdirs-feedstock">
                             appdirs
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/arm_pyart-feedstock" class="ci-badge">
@@ -158,16 +158,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/arm_pyart-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/arm_pyart-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/arm_pyart-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/arm_pyart-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/arm_pyart-feedstock">
                             arm_pyart
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/artview-feedstock" class="ci-badge">
@@ -175,16 +175,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/artview-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/artview-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/artview-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/artview-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/artview-feedstock">
                             artview
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/auditwheel-feedstock" class="ci-badge">
@@ -192,16 +192,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/auditwheel-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/auditwheel-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/auditwheel-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/auditwheel-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/auditwheel-feedstock">
                             auditwheel
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/autoconf-feedstock" class="ci-badge">
@@ -209,16 +209,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/autoconf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/autoconf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/autoconf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/autoconf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/autoconf-feedstock">
                             autoconf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/automake-feedstock" class="ci-badge">
@@ -226,16 +226,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/automake-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/automake-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/automake-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/automake-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/automake-feedstock">
                             automake
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/awesome-slugify-feedstock" class="ci-badge">
@@ -243,16 +243,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/awesome-slugify-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/awesome-slugify-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/awesome-slugify-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/awesome-slugify-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/awesome-slugify-feedstock">
                             awesome-slugify
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/basemap-data-hires-feedstock" class="ci-badge">
@@ -260,16 +260,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/basemap-data-hires-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/basemap-data-hires-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/basemap-data-hires-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/basemap-data-hires-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/basemap-data-hires-feedstock">
                             basemap-data-hires
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/basemap-feedstock" class="ci-badge">
@@ -277,16 +277,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/basemap-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/basemap-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/basemap-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/basemap-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/basemap-feedstock">
                             basemap
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/bdw-gc-feedstock" class="ci-badge">
@@ -294,16 +294,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/bdw-gc-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/bdw-gc-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/bdw-gc-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/bdw-gc-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/bdw-gc-feedstock">
                             bdw-gc
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/billiard-feedstock" class="ci-badge">
@@ -311,16 +311,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/billiard-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/billiard-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/billiard-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/billiard-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/billiard-feedstock">
                             billiard
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/bison-feedstock" class="ci-badge">
@@ -328,16 +328,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/bison-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/bison-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/bison-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/bison-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/bison-feedstock">
                             bison
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/boost-feedstock" class="ci-badge">
@@ -345,16 +345,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/boost-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/boost-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/boost-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/boost-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/boost-feedstock">
                             boost
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cartopy-feedstock" class="ci-badge">
@@ -362,16 +362,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cartopy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cartopy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cartopy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cartopy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cartopy-feedstock">
                             cartopy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cc-plugin-glider-feedstock" class="ci-badge">
@@ -379,16 +379,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cc-plugin-glider-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cc-plugin-glider-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cc-plugin-glider-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cc-plugin-glider-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cc-plugin-glider-feedstock">
                             cc-plugin-glider
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cdo-feedstock" class="ci-badge">
@@ -396,16 +396,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cdo-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cdo-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cdo-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cdo-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cdo-feedstock">
                             cdo
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/celery-feedstock" class="ci-badge">
@@ -413,16 +413,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/celery-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/celery-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/celery-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/celery-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/celery-feedstock">
                             celery
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cf_units-feedstock" class="ci-badge">
@@ -430,16 +430,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cf_units-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cf_units-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cf_units-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cf_units-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cf_units-feedstock">
                             cf_units
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/check-feedstock" class="ci-badge">
@@ -447,16 +447,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/check-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/check-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/check-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/check-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/check-feedstock">
                             check
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/click-plugins-feedstock" class="ci-badge">
@@ -464,16 +464,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/click-plugins-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/click-plugins-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/click-plugins-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/click-plugins-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/click-plugins-feedstock">
                             click-plugins
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cloudpickle-feedstock" class="ci-badge">
@@ -481,16 +481,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cloudpickle-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cloudpickle-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cloudpickle-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cloudpickle-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cloudpickle-feedstock">
                             cloudpickle
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cmake-feedstock" class="ci-badge">
@@ -498,16 +498,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cmake-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cmake-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cmake-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cmake-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cmake-feedstock">
                             cmake
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/codar2netcdf-feedstock" class="ci-badge">
@@ -515,16 +515,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/codar2netcdf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/codar2netcdf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/codar2netcdf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/codar2netcdf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/codar2netcdf-feedstock">
                             codar2netcdf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/compliance-checker-feedstock" class="ci-badge">
@@ -532,16 +532,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/compliance-checker-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/compliance-checker-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/compliance-checker-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/compliance-checker-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/compliance-checker-feedstock">
                             compliance-checker
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/conda-build-all-feedstock" class="ci-badge">
@@ -549,16 +549,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/conda-build-all-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/conda-build-all-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/conda-build-all-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-build-all-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/conda-build-all-feedstock">
                             conda-build-all
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/conda-execute-feedstock" class="ci-badge">
@@ -566,16 +566,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/conda-execute-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/conda-execute-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/conda-execute-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-execute-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/conda-execute-feedstock">
                             conda-execute
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/conda-smithy-feedstock" class="ci-badge">
@@ -583,16 +583,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/conda-smithy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/conda-smithy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/conda-smithy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-smithy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/conda-smithy-feedstock">
                             conda-smithy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/conda-testenv-feedstock" class="ci-badge">
@@ -600,16 +600,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/conda-testenv-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/conda-testenv-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/conda-testenv-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-testenv-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/conda-testenv-feedstock">
                             conda-testenv
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/contextlib2-feedstock" class="ci-badge">
@@ -617,16 +617,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/contextlib2-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/contextlib2-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/contextlib2-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/contextlib2-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/contextlib2-feedstock">
                             contextlib2
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/csa-feedstock" class="ci-badge">
@@ -634,16 +634,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/csa-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/csa-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/csa-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/csa-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/csa-feedstock">
                             csa
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/ctd-feedstock" class="ci-badge">
@@ -651,16 +651,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/ctd-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/ctd-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/ctd-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/ctd-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/ctd-feedstock">
                             ctd
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cycler-feedstock" class="ci-badge">
@@ -668,16 +668,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cycler-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cycler-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cycler-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cycler-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cycler-feedstock">
                             cycler
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/cyordereddict-feedstock" class="ci-badge">
@@ -685,16 +685,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/cyordereddict-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/cyordereddict-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/cyordereddict-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/cyordereddict-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/cyordereddict-feedstock">
                             cyordereddict
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/descartes-feedstock" class="ci-badge">
@@ -702,16 +702,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/descartes-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/descartes-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/descartes-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/descartes-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/descartes-feedstock">
                             descartes
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/dj-static-feedstock" class="ci-badge">
@@ -719,16 +719,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/dj-static-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/dj-static-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/dj-static-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/dj-static-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/dj-static-feedstock">
                             dj-static
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-autoslug-feedstock" class="ci-badge">
@@ -736,16 +736,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-autoslug-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-autoslug-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-autoslug-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-autoslug-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-autoslug-feedstock">
                             django-autoslug
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-celery-feedstock" class="ci-badge">
@@ -753,16 +753,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-celery-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-celery-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-celery-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-celery-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-celery-feedstock">
                             django-celery
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-debug-toolbar-feedstock" class="ci-badge">
@@ -770,16 +770,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-debug-toolbar-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-debug-toolbar-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-debug-toolbar-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-debug-toolbar-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-debug-toolbar-feedstock">
                             django-debug-toolbar
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-extensions-feedstock" class="ci-badge">
@@ -787,16 +787,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-extensions-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-extensions-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-extensions-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-extensions-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-extensions-feedstock">
                             django-extensions
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-feedstock" class="ci-badge">
@@ -804,16 +804,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-feedstock">
                             django
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-grappelli-feedstock" class="ci-badge">
@@ -821,16 +821,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-grappelli-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-grappelli-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-grappelli-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-grappelli-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-grappelli-feedstock">
                             django-grappelli
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-nested-inline-feedstock" class="ci-badge">
@@ -838,16 +838,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-nested-inline-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-nested-inline-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-nested-inline-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-nested-inline-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-nested-inline-feedstock">
                             django-nested-inline
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-redis-cache-feedstock" class="ci-badge">
@@ -855,16 +855,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-redis-cache-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-redis-cache-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-redis-cache-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-redis-cache-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-redis-cache-feedstock">
                             django-redis-cache
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-taggit-feedstock" class="ci-badge">
@@ -872,16 +872,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-taggit-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-taggit-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-taggit-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-taggit-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-taggit-feedstock">
                             django-taggit
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django-typed-models-feedstock" class="ci-badge">
@@ -889,16 +889,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django-typed-models-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django-typed-models-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django-typed-models-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django-typed-models-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django-typed-models-feedstock">
                             django-typed-models
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/django_polymorphic-feedstock" class="ci-badge">
@@ -906,16 +906,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/django_polymorphic-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/django_polymorphic-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/django_polymorphic-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/django_polymorphic-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/django_polymorphic-feedstock">
                             django_polymorphic
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/djangorestframework-feedstock" class="ci-badge">
@@ -923,16 +923,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/djangorestframework-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/djangorestframework-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/djangorestframework-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/djangorestframework-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/djangorestframework-feedstock">
                             djangorestframework
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/eigen-feedstock" class="ci-badge">
@@ -940,16 +940,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/eigen-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/eigen-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/eigen-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/eigen-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/eigen-feedstock">
                             eigen
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/epic2cf-feedstock" class="ci-badge">
@@ -957,16 +957,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/epic2cf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/epic2cf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/epic2cf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/epic2cf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/epic2cf-feedstock">
                             epic2cf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/esmf-feedstock" class="ci-badge">
@@ -974,16 +974,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/esmf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/esmf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/esmf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/esmf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/esmf-feedstock">
                             esmf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/esmpy-feedstock" class="ci-badge">
@@ -991,16 +991,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/esmpy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/esmpy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/esmpy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/esmpy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/esmpy-feedstock">
                             esmpy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/expat-feedstock" class="ci-badge">
@@ -1008,16 +1008,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/expat-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/expat-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/expat-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/expat-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/expat-feedstock">
                             expat
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/fftw-feedstock" class="ci-badge">
@@ -1025,16 +1025,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/fftw-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/fftw-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/fftw-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/fftw-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/fftw-feedstock">
                             fftw
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/fiona-feedstock" class="ci-badge">
@@ -1042,16 +1042,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/fiona-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/fiona-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/fiona-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/fiona-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/fiona-feedstock">
                             fiona
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/flann-feedstock" class="ci-badge">
@@ -1059,16 +1059,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/flann-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/flann-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/flann-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/flann-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/flann-feedstock">
                             flann
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/flex-feedstock" class="ci-badge">
@@ -1076,16 +1076,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/flex-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/flex-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/flex-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/flex-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/flex-feedstock">
                             flex
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/flopy-feedstock" class="ci-badge">
@@ -1093,16 +1093,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/flopy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/flopy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/flopy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/flopy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/flopy-feedstock">
                             flopy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/flower-feedstock" class="ci-badge">
@@ -1110,16 +1110,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/flower-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/flower-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/flower-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/flower-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/flower-feedstock">
                             flower
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/folium-feedstock" class="ci-badge">
@@ -1127,16 +1127,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/folium-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/folium-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/folium-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/folium-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/folium-feedstock">
                             folium
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/freeimage-feedstock" class="ci-badge">
@@ -1144,16 +1144,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/freeimage-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/freeimage-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/freeimage-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/freeimage-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/freeimage-feedstock">
                             freeimage
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/freexl-feedstock" class="ci-badge">
@@ -1161,16 +1161,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/freexl-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/freexl-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/freexl-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/freexl-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/freexl-feedstock">
                             freexl
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/freezegun-feedstock" class="ci-badge">
@@ -1178,16 +1178,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/freezegun-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/freezegun-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/freezegun-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/freezegun-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/freezegun-feedstock">
                             freezegun
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/functools32-feedstock" class="ci-badge">
@@ -1195,16 +1195,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/functools32-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/functools32-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/functools32-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/functools32-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/functools32-feedstock">
                             functools32
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/g2clib-feedstock" class="ci-badge">
@@ -1212,16 +1212,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/g2clib-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/g2clib-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/g2clib-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/g2clib-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/g2clib-feedstock">
                             g2clib
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gdal-feedstock" class="ci-badge">
@@ -1229,16 +1229,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gdal-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gdal-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gdal-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gdal-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gdal-feedstock">
                             gdal
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/geojson-feedstock" class="ci-badge">
@@ -1246,16 +1246,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/geojson-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/geojson-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/geojson-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/geojson-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/geojson-feedstock">
                             geojson
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/geopandas-feedstock" class="ci-badge">
@@ -1263,16 +1263,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/geopandas-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/geopandas-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/geopandas-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/geopandas-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/geopandas-feedstock">
                             geopandas
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/geopy-feedstock" class="ci-badge">
@@ -1280,16 +1280,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/geopy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/geopy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/geopy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/geopy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/geopy-feedstock">
                             geopy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/geos-feedstock" class="ci-badge">
@@ -1297,16 +1297,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/geos-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/geos-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/geos-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/geos-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/geos-feedstock">
                             geos
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gflags-feedstock" class="ci-badge">
@@ -1314,16 +1314,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gflags-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gflags-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gflags-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gflags-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gflags-feedstock">
                             gflags
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/giflib-feedstock" class="ci-badge">
@@ -1331,16 +1331,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/giflib-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/giflib-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/giflib-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/giflib-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/giflib-feedstock">
                             giflib
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/git-feedstock" class="ci-badge">
@@ -1348,16 +1348,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/git-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/git-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/git-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/git-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/git-feedstock">
                             git
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gitdb-feedstock" class="ci-badge">
@@ -1365,16 +1365,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gitdb-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gitdb-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gitdb-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gitdb-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gitdb-feedstock">
                             gitdb
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gitpython-feedstock" class="ci-badge">
@@ -1382,16 +1382,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gitpython-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gitpython-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gitpython-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gitpython-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gitpython-feedstock">
                             gitpython
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/glances-feedstock" class="ci-badge">
@@ -1399,16 +1399,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/glances-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/glances-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/glances-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/glances-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/glances-feedstock">
                             glances
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/glog-feedstock" class="ci-badge">
@@ -1416,16 +1416,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/glog-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/glog-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/glog-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/glog-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/glog-feedstock">
                             glog
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/glpk-feedstock" class="ci-badge">
@@ -1433,16 +1433,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/glpk-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/glpk-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/glpk-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/glpk-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/glpk-feedstock">
                             glpk
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gmp-feedstock" class="ci-badge">
@@ -1450,16 +1450,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gmp-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gmp-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gmp-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gmp-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gmp-feedstock">
                             gmp
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/google-apputils-feedstock" class="ci-badge">
@@ -1467,16 +1467,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/google-apputils-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/google-apputils-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/google-apputils-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/google-apputils-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/google-apputils-feedstock">
                             google-apputils
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gridgen-feedstock" class="ci-badge">
@@ -1484,16 +1484,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gridgen-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gridgen-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gridgen-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gridgen-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gridgen-feedstock">
                             gridgen
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gridutils-feedstock" class="ci-badge">
@@ -1501,16 +1501,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gridutils-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gridutils-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gridutils-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gridutils-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gridutils-feedstock">
                             gridutils
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gsl-feedstock" class="ci-badge">
@@ -1518,16 +1518,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gsl-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gsl-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gsl-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gsl-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gsl-feedstock">
                             gsl
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/gsw-feedstock" class="ci-badge">
@@ -1535,16 +1535,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/gsw-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/gsw-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/gsw-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/gsw-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/gsw-feedstock">
                             gsw
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/h5netcdf-feedstock" class="ci-badge">
@@ -1552,16 +1552,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/h5netcdf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/h5netcdf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/h5netcdf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/h5netcdf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/h5netcdf-feedstock">
                             h5netcdf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/h5py-feedstock" class="ci-badge">
@@ -1569,16 +1569,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/h5py-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/h5py-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/h5py-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/h5py-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/h5py-feedstock">
                             h5py
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/haversine-feedstock" class="ci-badge">
@@ -1586,16 +1586,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/haversine-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/haversine-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/haversine-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/haversine-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/haversine-feedstock">
                             haversine
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/hdf5-feedstock" class="ci-badge">
@@ -1603,16 +1603,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/hdf5-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/hdf5-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/hdf5-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/hdf5-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/hdf5-feedstock">
                             hdf5
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/hdfeos2-feedstock" class="ci-badge">
@@ -1620,16 +1620,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/hdfeos2-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/hdfeos2-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/hdfeos2-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/hdfeos2-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/hdfeos2-feedstock">
                             hdfeos2
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/hdfeos5-feedstock" class="ci-badge">
@@ -1637,16 +1637,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/hdfeos5-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/hdfeos5-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/hdfeos5-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/hdfeos5-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/hdfeos5-feedstock">
                             hdfeos5
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/hiredis-feedstock" class="ci-badge">
@@ -1654,16 +1654,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/hiredis-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/hiredis-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/hiredis-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/hiredis-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/hiredis-feedstock">
                             hiredis
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/httpretty-feedstock" class="ci-badge">
@@ -1671,16 +1671,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/httpretty-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/httpretty-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/httpretty-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/httpretty-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/httpretty-feedstock">
                             httpretty
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/icu-feedstock" class="ci-badge">
@@ -1688,16 +1688,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/icu-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/icu-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/icu-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/icu-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/icu-feedstock">
                             icu
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/isodate-feedstock" class="ci-badge">
@@ -1705,16 +1705,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/isodate-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/isodate-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/isodate-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/isodate-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/isodate-feedstock">
                             isodate
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/jasper-feedstock" class="ci-badge">
@@ -1722,16 +1722,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/jasper-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/jasper-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/jasper-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/jasper-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/jasper-feedstock">
                             jasper
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/jplephem-feedstock" class="ci-badge">
@@ -1739,16 +1739,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/jplephem-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/jplephem-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/jplephem-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/jplephem-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/jplephem-feedstock">
                             jplephem
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/jq-feedstock" class="ci-badge">
@@ -1756,16 +1756,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/jq-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/jq-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/jq-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/jq-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/jq-feedstock">
                             jq
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/json-c-feedstock" class="ci-badge">
@@ -1773,16 +1773,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/json-c-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/json-c-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/json-c-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/json-c-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/json-c-feedstock">
                             json-c
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/kombu-feedstock" class="ci-badge">
@@ -1790,16 +1790,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/kombu-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/kombu-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/kombu-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/kombu-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/kombu-feedstock">
                             kombu
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/leveldb-feedstock" class="ci-badge">
@@ -1807,16 +1807,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/leveldb-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/leveldb-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/leveldb-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/leveldb-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/leveldb-feedstock">
                             leveldb
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libatomic_ops-feedstock" class="ci-badge">
@@ -1824,16 +1824,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libatomic_ops-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libatomic_ops-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libatomic_ops-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libatomic_ops-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libatomic_ops-feedstock">
                             libatomic_ops
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libblitz-feedstock" class="ci-badge">
@@ -1841,16 +1841,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libblitz-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libblitz-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libblitz-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libblitz-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libblitz-feedstock">
                             libblitz
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libffi-feedstock" class="ci-badge">
@@ -1858,16 +1858,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libffi-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libffi-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libffi-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libffi-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libffi-feedstock">
                             libffi
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libiconv-feedstock" class="ci-badge">
@@ -1875,16 +1875,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libiconv-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libiconv-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libiconv-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libiconv-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libiconv-feedstock">
                             libiconv
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libmatio-feedstock" class="ci-badge">
@@ -1892,16 +1892,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libmatio-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libmatio-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libmatio-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libmatio-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libmatio-feedstock">
                             libmatio
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libmo_unpack-feedstock" class="ci-badge">
@@ -1909,16 +1909,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libmo_unpack-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libmo_unpack-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libmo_unpack-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libmo_unpack-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libmo_unpack-feedstock">
                             libmo_unpack
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libsodium-feedstock" class="ci-badge">
@@ -1926,16 +1926,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libsodium-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libsodium-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libsodium-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libsodium-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libsodium-feedstock">
                             libsodium
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libspatialindex-feedstock" class="ci-badge">
@@ -1943,16 +1943,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libspatialindex-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libspatialindex-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libspatialindex-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libspatialindex-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libspatialindex-feedstock">
                             libspatialindex
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libtool-feedstock" class="ci-badge">
@@ -1960,16 +1960,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libtool-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libtool-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libtool-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libtool-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libtool-feedstock">
                             libtool
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libunistring-feedstock" class="ci-badge">
@@ -1977,16 +1977,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libunistring-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libunistring-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libunistring-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libunistring-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libunistring-feedstock">
                             libunistring
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/libuuid-feedstock" class="ci-badge">
@@ -1994,16 +1994,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/libuuid-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/libuuid-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/libuuid-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/libuuid-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/libuuid-feedstock">
                             libuuid
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/lmdb-feedstock" class="ci-badge">
@@ -2011,16 +2011,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/lmdb-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/lmdb-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/lmdb-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/lmdb-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/lmdb-feedstock">
                             lmdb
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/luigi-feedstock" class="ci-badge">
@@ -2028,16 +2028,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/luigi-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/luigi-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/luigi-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/luigi-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/luigi-feedstock">
                             luigi
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/m4-feedstock" class="ci-badge">
@@ -2045,16 +2045,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/m4-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/m4-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/m4-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/m4-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/m4-feedstock">
                             m4
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mahotas-feedstock" class="ci-badge">
@@ -2062,16 +2062,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mahotas-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mahotas-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mahotas-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mahotas-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mahotas-feedstock">
                             mahotas
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/matplotlib-feedstock" class="ci-badge">
@@ -2079,16 +2079,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/matplotlib-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/matplotlib-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/matplotlib-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/matplotlib-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/matplotlib-feedstock">
                             matplotlib
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/metpy-feedstock" class="ci-badge">
@@ -2096,16 +2096,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/metpy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/metpy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/metpy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/metpy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/metpy-feedstock">
                             metpy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mingwpy-feedstock" class="ci-badge">
@@ -2113,16 +2113,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mingwpy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mingwpy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mingwpy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mingwpy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mingwpy-feedstock">
                             mingwpy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mo_pack-feedstock" class="ci-badge">
@@ -2130,16 +2130,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mo_pack-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mo_pack-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mo_pack-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mo_pack-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mo_pack-feedstock">
                             mo_pack
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/modflow2netcdf-feedstock" class="ci-badge">
@@ -2147,16 +2147,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/modflow2netcdf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/modflow2netcdf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/modflow2netcdf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/modflow2netcdf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/modflow2netcdf-feedstock">
                             modflow2netcdf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mox-feedstock" class="ci-badge">
@@ -2164,16 +2164,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mox-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mox-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mox-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mox-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mox-feedstock">
                             mox
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mpc-feedstock" class="ci-badge">
@@ -2181,16 +2181,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mpc-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mpc-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mpc-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mpc-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mpc-feedstock">
                             mpc
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mpfr-feedstock" class="ci-badge">
@@ -2198,16 +2198,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mpfr-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mpfr-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mpfr-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mpfr-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mpfr-feedstock">
                             mpfr
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/mpir-feedstock" class="ci-badge">
@@ -2215,16 +2215,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/mpir-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/mpir-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/mpir-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/mpir-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/mpir-feedstock">
                             mpir
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/msinttypes-feedstock" class="ci-badge">
@@ -2232,16 +2232,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/msinttypes-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/msinttypes-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/msinttypes-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/msinttypes-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/msinttypes-feedstock">
                             msinttypes
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/munch-feedstock" class="ci-badge">
@@ -2249,16 +2249,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/munch-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/munch-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/munch-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/munch-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/munch-feedstock">
                             munch
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/nco-feedstock" class="ci-badge">
@@ -2266,16 +2266,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/nco-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/nco-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/nco-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/nco-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/nco-feedstock">
                             nco
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/ncurses-feedstock" class="ci-badge">
@@ -2283,16 +2283,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/ncurses-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/ncurses-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/ncurses-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/ncurses-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/ncurses-feedstock">
                             ncurses
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/netcdf-cxx4-feedstock" class="ci-badge">
@@ -2300,16 +2300,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/netcdf-cxx4-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/netcdf-cxx4-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/netcdf-cxx4-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/netcdf-cxx4-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/netcdf-cxx4-feedstock">
                             netcdf-cxx4
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/netcdf-fortran-feedstock" class="ci-badge">
@@ -2317,16 +2317,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/netcdf-fortran-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/netcdf-fortran-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/netcdf-fortran-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/netcdf-fortran-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/netcdf-fortran-feedstock">
                             netcdf-fortran
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/netcdf4-feedstock" class="ci-badge">
@@ -2334,16 +2334,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/netcdf4-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/netcdf4-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/netcdf4-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/netcdf4-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/netcdf4-feedstock">
                             netcdf4
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/nn-feedstock" class="ci-badge">
@@ -2351,16 +2351,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/nn-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/nn-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/nn-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/nn-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/nn-feedstock">
                             nn
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/obvious-ci-feedstock" class="ci-badge">
@@ -2368,16 +2368,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/obvious-ci-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/obvious-ci-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/obvious-ci-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/obvious-ci-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/obvious-ci-feedstock">
                             obvious-ci
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/oniguruma-feedstock" class="ci-badge">
@@ -2385,16 +2385,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/oniguruma-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/oniguruma-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/oniguruma-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/oniguruma-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/oniguruma-feedstock">
                             oniguruma
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/opencv-feedstock" class="ci-badge">
@@ -2402,16 +2402,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/opencv-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/opencv-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/opencv-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/opencv-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/opencv-feedstock">
                             opencv
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/openjpeg-feedstock" class="ci-badge">
@@ -2419,16 +2419,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/openjpeg-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/openjpeg-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/openjpeg-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/openjpeg-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/openjpeg-feedstock">
                             openjpeg
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/owslib-feedstock" class="ci-badge">
@@ -2436,16 +2436,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/owslib-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/owslib-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/owslib-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/owslib-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/owslib-feedstock">
                             owslib
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pandoc-feedstock" class="ci-badge">
@@ -2453,16 +2453,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pandoc-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pandoc-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pandoc-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pandoc-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pandoc-feedstock">
                             pandoc
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pep8-naming-feedstock" class="ci-badge">
@@ -2470,16 +2470,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pep8-naming-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pep8-naming-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pep8-naming-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pep8-naming-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pep8-naming-feedstock">
                             pep8-naming
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/perl-feedstock" class="ci-badge">
@@ -2487,16 +2487,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/perl-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/perl-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/perl-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/perl-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/perl-feedstock">
                             perl
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/petulant-bear-feedstock" class="ci-badge">
@@ -2504,16 +2504,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/petulant-bear-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/petulant-bear-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/petulant-bear-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/petulant-bear-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/petulant-bear-feedstock">
                             petulant-bear
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pint-feedstock" class="ci-badge">
@@ -2521,16 +2521,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pint-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pint-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pint-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pint-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pint-feedstock">
                             pint
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pixman-feedstock" class="ci-badge">
@@ -2538,16 +2538,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pixman-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pixman-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pixman-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pixman-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pixman-feedstock">
                             pixman
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pkg-config-feedstock" class="ci-badge">
@@ -2555,16 +2555,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pkg-config-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pkg-config-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pkg-config-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pkg-config-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pkg-config-feedstock">
                             pkg-config
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/poliastro-feedstock" class="ci-badge">
@@ -2572,16 +2572,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/poliastro-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/poliastro-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/poliastro-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/poliastro-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/poliastro-feedstock">
                             poliastro
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/proj.4-feedstock" class="ci-badge">
@@ -2589,16 +2589,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/proj.4-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/proj.4-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/proj.4-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/proj.4-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/proj.4-feedstock">
                             proj.4
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/prompt_toolkit-feedstock" class="ci-badge">
@@ -2606,16 +2606,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/prompt_toolkit-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/prompt_toolkit-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/prompt_toolkit-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/prompt_toolkit-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/prompt_toolkit-feedstock">
                             prompt_toolkit
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/protobuf-feedstock" class="ci-badge">
@@ -2623,16 +2623,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/protobuf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/protobuf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/protobuf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/protobuf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/protobuf-feedstock">
                             protobuf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyaxiom-feedstock" class="ci-badge">
@@ -2640,16 +2640,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyaxiom-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyaxiom-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyaxiom-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyaxiom-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyaxiom-feedstock">
                             pyaxiom
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyelftools-feedstock" class="ci-badge">
@@ -2657,16 +2657,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyelftools-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyelftools-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyelftools-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyelftools-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyelftools-feedstock">
                             pyelftools
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyepsg-feedstock" class="ci-badge">
@@ -2674,16 +2674,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyepsg-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyepsg-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyepsg-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyepsg-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyepsg-feedstock">
                             pyepsg
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyfftw-feedstock" class="ci-badge">
@@ -2691,16 +2691,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyfftw-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyfftw-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyfftw-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyfftw-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyfftw-feedstock">
                             pyfftw
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyflann-feedstock" class="ci-badge">
@@ -2708,16 +2708,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyflann-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyflann-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyflann-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyflann-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyflann-feedstock">
                             pyflann
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pygc-feedstock" class="ci-badge">
@@ -2725,16 +2725,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pygc-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pygc-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pygc-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pygc-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pygc-feedstock">
                             pygc
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pygeoif-feedstock" class="ci-badge">
@@ -2742,16 +2742,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pygeoif-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pygeoif-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pygeoif-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pygeoif-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pygeoif-feedstock">
                             pygeoif
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pygithub-feedstock" class="ci-badge">
@@ -2759,16 +2759,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pygithub-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pygithub-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pygithub-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pygithub-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pygithub-feedstock">
                             pygithub
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pygridgen-feedstock" class="ci-badge">
@@ -2776,16 +2776,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pygridgen-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pygridgen-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pygridgen-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pygridgen-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pygridgen-feedstock">
                             pygridgen
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pygridtools-feedstock" class="ci-badge">
@@ -2793,16 +2793,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pygridtools-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pygridtools-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pygridtools-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pygridtools-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pygridtools-feedstock">
                             pygridtools
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyinotify-feedstock" class="ci-badge">
@@ -2810,16 +2810,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyinotify-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyinotify-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyinotify-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyinotify-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyinotify-feedstock">
                             pyinotify
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyncml-feedstock" class="ci-badge">
@@ -2827,16 +2827,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyncml-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyncml-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyncml-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyncml-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyncml-feedstock">
                             pyncml
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pynco-feedstock" class="ci-badge">
@@ -2844,16 +2844,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pynco-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pynco-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pynco-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pynco-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pynco-feedstock">
                             pynco
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pynio-feedstock" class="ci-badge">
@@ -2861,16 +2861,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pynio-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pynio-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pynio-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pynio-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pynio-feedstock">
                             pynio
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyproj-feedstock" class="ci-badge">
@@ -2878,16 +2878,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyproj-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyproj-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyproj-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyproj-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyproj-feedstock">
                             pyproj
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pyshp-feedstock" class="ci-badge">
@@ -2895,16 +2895,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pyshp-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pyshp-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pyshp-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pyshp-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pyshp-feedstock">
                             pyshp
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pystache-feedstock" class="ci-badge">
@@ -2912,16 +2912,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pystache-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pystache-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pystache-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pystache-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pystache-feedstock">
                             pystache
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pytest-benchmark-feedstock" class="ci-badge">
@@ -2929,16 +2929,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pytest-benchmark-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pytest-benchmark-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pytest-benchmark-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pytest-benchmark-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pytest-benchmark-feedstock">
                             pytest-benchmark
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pytest-cov-feedstock" class="ci-badge">
@@ -2946,16 +2946,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pytest-cov-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pytest-cov-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pytest-cov-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pytest-cov-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pytest-cov-feedstock">
                             pytest-cov
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pytest-django-feedstock" class="ci-badge">
@@ -2963,16 +2963,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pytest-django-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pytest-django-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pytest-django-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pytest-django-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pytest-django-feedstock">
                             pytest-django
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pytest-mpl-feedstock" class="ci-badge">
@@ -2980,16 +2980,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pytest-mpl-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pytest-mpl-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pytest-mpl-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pytest-mpl-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pytest-mpl-feedstock">
                             pytest-mpl
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/pytest-runner-feedstock" class="ci-badge">
@@ -2997,16 +2997,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/pytest-runner-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/pytest-runner-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/pytest-runner-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/pytest-runner-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/pytest-runner-feedstock">
                             pytest-runner
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/python-cdo-feedstock" class="ci-badge">
@@ -3014,16 +3014,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/python-cdo-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/python-cdo-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/python-cdo-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/python-cdo-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/python-cdo-feedstock">
                             python-cdo
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/python-gflags-feedstock" class="ci-badge">
@@ -3031,16 +3031,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/python-gflags-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/python-gflags-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/python-gflags-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/python-gflags-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/python-gflags-feedstock">
                             python-gflags
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/python-leveldb-feedstock" class="ci-badge">
@@ -3048,16 +3048,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/python-leveldb-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/python-leveldb-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/python-leveldb-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/python-leveldb-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/python-leveldb-feedstock">
                             python-leveldb
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/qimage2ndarray-feedstock" class="ci-badge">
@@ -3065,16 +3065,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/qimage2ndarray-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/qimage2ndarray-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/qimage2ndarray-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/qimage2ndarray-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/qimage2ndarray-feedstock">
                             qimage2ndarray
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/qutip-feedstock" class="ci-badge">
@@ -3082,16 +3082,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/qutip-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/qutip-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/qutip-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/qutip-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/qutip-feedstock">
                             qutip
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/rank_filter-feedstock" class="ci-badge">
@@ -3099,16 +3099,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/rank_filter-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/rank_filter-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/rank_filter-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/rank_filter-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/rank_filter-feedstock">
                             rank_filter
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/rasterio-feedstock" class="ci-badge">
@@ -3116,16 +3116,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/rasterio-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/rasterio-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/rasterio-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/rasterio-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/rasterio-feedstock">
                             rasterio
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/regex-feedstock" class="ci-badge">
@@ -3133,16 +3133,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/regex-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/regex-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/regex-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/regex-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/regex-feedstock">
                             regex
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/requests-toolbelt-feedstock" class="ci-badge">
@@ -3150,16 +3150,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/requests-toolbelt-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/requests-toolbelt-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/requests-toolbelt-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/requests-toolbelt-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/requests-toolbelt-feedstock">
                             requests-toolbelt
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/rtree-feedstock" class="ci-badge">
@@ -3167,16 +3167,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/rtree-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/rtree-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/rtree-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/rtree-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/rtree-feedstock">
                             rtree
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/ruamel.ordereddict-feedstock" class="ci-badge">
@@ -3184,16 +3184,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/ruamel.ordereddict-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/ruamel.ordereddict-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/ruamel.ordereddict-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/ruamel.ordereddict-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/ruamel.ordereddict-feedstock">
                             ruamel.ordereddict
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/ruamel.yaml-feedstock" class="ci-badge">
@@ -3201,16 +3201,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/ruamel.yaml-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/ruamel.yaml-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/ruamel.yaml-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/ruamel.yaml-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/ruamel.yaml-feedstock">
                             ruamel.yaml
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/runipy-feedstock" class="ci-badge">
@@ -3218,16 +3218,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/runipy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/runipy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/runipy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/runipy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/runipy-feedstock">
                             runipy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/seawater-feedstock" class="ci-badge">
@@ -3235,16 +3235,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/seawater-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/seawater-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/seawater-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/seawater-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/seawater-feedstock">
                             seawater
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/setproctitle-feedstock" class="ci-badge">
@@ -3252,16 +3252,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/setproctitle-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/setproctitle-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/setproctitle-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/setproctitle-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/setproctitle-feedstock">
                             setproctitle
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/setuptools_scm-feedstock" class="ci-badge">
@@ -3269,16 +3269,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/setuptools_scm-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/setuptools_scm-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/setuptools_scm-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/setuptools_scm-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/setuptools_scm-feedstock">
                             setuptools_scm
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/shapely-feedstock" class="ci-badge">
@@ -3286,16 +3286,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/shapely-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/shapely-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/shapely-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/shapely-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/shapely-feedstock">
                             shapely
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/siphon-feedstock" class="ci-badge">
@@ -3303,16 +3303,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/siphon-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/siphon-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/siphon-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/siphon-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/siphon-feedstock">
                             siphon
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/smmap-feedstock" class="ci-badge">
@@ -3320,16 +3320,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/smmap-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/smmap-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/smmap-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/smmap-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/smmap-feedstock">
                             smmap
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/sox-feedstock" class="ci-badge">
@@ -3337,16 +3337,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/sox-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/sox-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/sox-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/sox-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/sox-feedstock">
                             sox
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/splauncher-feedstock" class="ci-badge">
@@ -3354,16 +3354,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/splauncher-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/splauncher-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/splauncher-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/splauncher-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/splauncher-feedstock">
                             splauncher
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/static-feedstock" class="ci-badge">
@@ -3371,16 +3371,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/static-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/static-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/static-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/static-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/static-feedstock">
                             static
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/suds-jurko-feedstock" class="ci-badge">
@@ -3388,16 +3388,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/suds-jurko-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/suds-jurko-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/suds-jurko-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/suds-jurko-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/suds-jurko-feedstock">
                             suds-jurko
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/tensorflow-feedstock" class="ci-badge">
@@ -3405,16 +3405,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/tensorflow-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/tensorflow-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/tensorflow-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/tensorflow-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/tensorflow-feedstock">
                             tensorflow
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/texinfo-feedstock" class="ci-badge">
@@ -3422,16 +3422,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/texinfo-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/texinfo-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/texinfo-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/texinfo-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/texinfo-feedstock">
                             texinfo
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/tifffile-feedstock" class="ci-badge">
@@ -3439,16 +3439,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/tifffile-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/tifffile-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/tifffile-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/tifffile-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/tifffile-feedstock">
                             tifffile
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/trmm_rsl-feedstock" class="ci-badge">
@@ -3456,16 +3456,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/trmm_rsl-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/trmm_rsl-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/trmm_rsl-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/trmm_rsl-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/trmm_rsl-feedstock">
                             trmm_rsl
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/typing-feedstock" class="ci-badge">
@@ -3473,16 +3473,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/typing-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/typing-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/typing-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/typing-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/typing-feedstock">
                             typing
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/udunits2-feedstock" class="ci-badge">
@@ -3490,16 +3490,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/udunits2-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/udunits2-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/udunits2-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/udunits2-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/udunits2-feedstock">
                             udunits2
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/ulmo-feedstock" class="ci-badge">
@@ -3507,16 +3507,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/ulmo-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/ulmo-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/ulmo-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/ulmo-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/ulmo-feedstock">
                             ulmo
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/vcrpy-feedstock" class="ci-badge">
@@ -3524,16 +3524,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/vcrpy-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/vcrpy-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/vcrpy-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/vcrpy-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/vcrpy-feedstock">
                             vcrpy
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/vigra-feedstock" class="ci-badge">
@@ -3541,16 +3541,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/vigra-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/vigra-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/vigra-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/vigra-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/vigra-feedstock">
                             vigra
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/vincent-feedstock" class="ci-badge">
@@ -3558,16 +3558,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/vincent-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/vincent-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/vincent-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/vincent-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/vincent-feedstock">
                             vincent
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/wcwidth-feedstock" class="ci-badge">
@@ -3575,16 +3575,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/wcwidth-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/wcwidth-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/wcwidth-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/wcwidth-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/wcwidth-feedstock">
                             wcwidth
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/webcolors-feedstock" class="ci-badge">
@@ -3592,16 +3592,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/webcolors-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/webcolors-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/webcolors-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/webcolors-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/webcolors-feedstock">
                             webcolors
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/wera2netcdf-feedstock" class="ci-badge">
@@ -3609,16 +3609,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/wera2netcdf-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/wera2netcdf-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/wera2netcdf-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/wera2netcdf-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/wera2netcdf-feedstock">
                             wera2netcdf
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/wicken-feedstock" class="ci-badge">
@@ -3626,16 +3626,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/wicken-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/wicken-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/wicken-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/wicken-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/wicken-feedstock">
                             wicken
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/windrose-feedstock" class="ci-badge">
@@ -3643,16 +3643,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/windrose-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/windrose-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/windrose-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/windrose-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/windrose-feedstock">
                             windrose
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/wradlib-feedstock" class="ci-badge">
@@ -3660,16 +3660,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/wradlib-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/wradlib-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/wradlib-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/wradlib-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/wradlib-feedstock">
                             wradlib
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/x264-feedstock" class="ci-badge">
@@ -3677,16 +3677,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/x264-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/x264-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/x264-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/x264-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/x264-feedstock">
                             x264
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/xarray-feedstock" class="ci-badge">
@@ -3694,16 +3694,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/xarray-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/xarray-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/xarray-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/xarray-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/xarray-feedstock">
                             xarray
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/xonsh-feedstock" class="ci-badge">
@@ -3711,16 +3711,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/xonsh-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/xonsh-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/xonsh-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/xonsh-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/xonsh-feedstock">
                             xonsh
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/yasm-feedstock" class="ci-badge">
@@ -3728,16 +3728,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/yasm-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/yasm-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/yasm-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/yasm-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/yasm-feedstock">
                             yasm
                         </a>
                     </li>
-                  
+
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/yt-feedstock" class="ci-badge">
@@ -3745,16 +3745,16 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/yt-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/yt-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/yt-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/yt-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/yt-feedstock">
                             yt
                         </a>
                     </li>
-                  
+
                 </ul>
             </div>
         </div>

--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -65,7 +65,7 @@
             <div class="col-lg-8 col-lg-offset-2">
                 <h2 class="text-center">Feedstocks on conda-forge</h2>
                 <ul class="list-group">
-                  {% for feedstock in gh_feedstocks %}
+{% for feedstock in gh_feedstocks %}
                     <li class="list-group-item">
                         <span class="label pull-right">
                             <div href="https://circleci.com/gh/conda-forge/{{feedstock.package_name}}-feedstock" class="ci-badge">
@@ -82,7 +82,7 @@
                             {{ feedstock.package_name }}
                         </a>
                     </li>
-                  {% endfor %}
+{% endfor %}
                 </ul>
             </div>
         </div>

--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -73,10 +73,10 @@
                             </div>
                             <div href="https://travis-ci.org/conda-forge/{{feedstock.package_name}}-feedstock" class="ci-badge">
                                 <img src="https://travis-ci.org/conda-forge/{{feedstock.package_name}}-feedstock.svg?branch=master" />
-                            </div> 
+                            </div>
                             <div href="https://ci.appveyor.com/project/conda-forge/{{feedstock.package_name}}-feedstock/branch/master" class="ci-badge">
                                 <img src="https://ci.appveyor.com/api/projects/status/github/conda-forge/{{feedstock.package_name}}-feedstock?svg=True">
-                            </div>                            
+                            </div>
                         </span>
                         <a href="https://github.com/conda-forge/{{ feedstock.name }}">
                             {{ feedstock.package_name }}


### PR DESCRIPTION
Removes trailing whitespace from `feedstock.html` and ` feedstocks.html.tmpl` to make sure it doesn't get added again. Used this `sed` command to clean up `feedstock.html`.

    sed -i.bkup 's/[ ]*$//' feedstocks.html