### PR TITLE
Script to see what is missing from conda-forge.

### DIFF
--- a/scripts/whats_missing.py
+++ b/scripts/whats_missing.py
@@ -1,0 +1,46 @@
+import argparse
+from conda.api import get_index
+import conda.resolve
+
+parser = argparse.ArgumentParser()
+parser.add_argument('packages', nargs='+')
+parser.add_argument('--platform', default=None)
+
+args = parser.parse_args()
+
+
+forge_index = get_index(channel_urls=['conda-forge'],
+                        prepend=False, platform=args.platform)
+defaults_index = get_index(channel_urls=['defaults'],
+                        prepend=False, platform=args.platform)
+
+pkgs_in_forge = {pkg['name'] for pkg in forge_index.values()}
+
+forge_on_top = defaults_index.copy()
+forge_on_top.update(forge_index)
+
+r = conda.resolve.Resolve(forge_on_top)
+
+specs = args.packages
+result = r.solve(specs)
+
+print('Resolved with: {}\n'.format(', '.join(sorted(result))))
+
+
+forge_packages = []
+for pkg in sorted(result):
+    resolved_pkg = forge_on_top[pkg]
+    name = resolved_pkg['name']
+    if pkg in forge_index:
+        forge_packages.append(name)
+    else:
+        if name in pkgs_in_forge:
+            print("{: <25}:\t exists in conda-forge, but has been trumped by {} "
+                    "(availables: {})".format(name, pkg,
+                                              ', '.join(fqn for fqn, info in forge_index.items()
+                                                        if info['name'] == name)))
+        else:
+            print("{: <25}:\t doesn't exist in conda-forge".format(name))
+
+print('Found {} of {} packages from conda-forge. ({})'
+      ''.format(len(forge_packages), len(result), ', '.join(forge_packages)))

--- a/scripts/whats_missing.py
+++ b/scripts/whats_missing.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - conda
+# channels:
+#  - conda-forge
+# run_with: python
+
 import argparse
 from conda.api import get_index
 import conda.resolve


### PR DESCRIPTION
Adds a pretty rudimentary script to see what is missing on conda-forge. For instance:

```
$ python scripts/whats_missing.py cartopy "python 2.7*" --platform win-64
Using Anaconda Cloud api site https://api.anaconda.org
Fetching package metadata: ..
Fetching package metadata: ....
Solving package specifications: .........
Resolved with: bzip2-1.0.6-vc9_2.tar.bz2, cartopy-0.14.0-np110py27_1.tar.bz2, cycler-0.10.0-py27_0.tar.bz2, freetype-2.5.5-vc9_0.tar.bz2, funcsigs-0.4-py27_0.tar.bz2, geos-3.4.2-vc9_1.tar.bz2, jpeg-8d-vc9_0.tar.bz2, libpng-1.6.17-vc9_1.tar.bz2, libtiff-4.0.6-vc9_1.tar.bz2, lxml-3.6.0-py27_0.tar.bz2, matplotlib-1.5.1-np110py27_0.tar.bz2, mkl-11.3.1-0.tar.bz2, mock-1.3.0-py27_0.tar.bz2, nose-1.3.7-py27_0.tar.bz2, numpy-1.10.4-py27_0.tar.bz2, openssl-1.0.2g-vc9_0.tar.bz2, owslib-0.10.3-py27_0.tar.bz2, pbr-1.3.0-py27_0.tar.bz2, pillow-3.1.1-py27_0.tar.bz2, pip-8.1.1-py27_1.tar.bz2, proj.4-4.9.1-py27_vc9_2.tar.bz2, pyepsg-0.2.0-py27_0.tar.bz2, pyparsing-2.0.3-py27_0.tar.bz2, pyproj-1.9.5.1-py27_0.tar.bz2, pyqt-4.11.4-py27_5.tar.bz2, pyshp-1.2.3-py27_0.tar.bz2, python-2.7.11-4.tar.bz2, python-dateutil-2.5.1-py27_0.tar.bz2, pytz-2016.3-py27_0.tar.bz2, qt-4.8.7-vc9_7.tar.bz2, requests-2.9.1-py27_0.tar.bz2, scipy-0.17.0-np110py27_0.tar.bz2, setuptools-20.3-py27_0.tar.bz2, shapely-1.5.13-np110py27_1.tar.bz2, sip-4.16.9-py27_2.tar.bz2, six-1.10.0-py27_0.tar.bz2, tk-8.5.18-vc9_0.tar.bz2, vs2008_runtime-9.00.30729.1-0.tar.bz2, wheel-0.29.0-py27_0.tar.bz2, zlib-1.2.8-vc9_2.tar.bz2

bzip2                    :	 doesn't exist in conda-forge
freetype                 :	 doesn't exist in conda-forge
funcsigs                 :	 doesn't exist in conda-forge
jpeg                     :	 doesn't exist in conda-forge
libpng                   :	 doesn't exist in conda-forge
libtiff                  :	 doesn't exist in conda-forge
lxml                     :	 doesn't exist in conda-forge
matplotlib               :	 exists in conda-forge, but has been trumped by matplotlib-1.5.1-np110py27_0.tar.bz2 (availables matplotlib-1.5.0-np110py35_0.tar.bz2, matplotlib-1.5.0-np19py35_0.tar.bz2)
mkl                      :	 doesn't exist in conda-forge
mock                     :	 doesn't exist in conda-forge
nose                     :	 doesn't exist in conda-forge
numpy                    :	 doesn't exist in conda-forge
openssl                  :	 doesn't exist in conda-forge
pbr                      :	 doesn't exist in conda-forge
pillow                   :	 doesn't exist in conda-forge
pip                      :	 doesn't exist in conda-forge
pyparsing                :	 doesn't exist in conda-forge
pyqt                     :	 doesn't exist in conda-forge
python                   :	 doesn't exist in conda-forge
python-dateutil          :	 doesn't exist in conda-forge
pytz                     :	 doesn't exist in conda-forge
qt                       :	 doesn't exist in conda-forge
requests                 :	 doesn't exist in conda-forge
scipy                    :	 doesn't exist in conda-forge
setuptools               :	 doesn't exist in conda-forge
sip                      :	 doesn't exist in conda-forge
six                      :	 doesn't exist in conda-forge
tk                       :	 doesn't exist in conda-forge
vs2008_runtime           :	 doesn't exist in conda-forge
wheel                    :	 doesn't exist in conda-forge
zlib                     :	 doesn't exist in conda-forge
Found 9 of 40 packages from conda-forge. (cartopy, cycler, geos, owslib, proj.4, pyepsg, pyproj, pyshp, shapely)
```


Obviously a whole load of improvements available here, but this lays down a place to start from.