### PR TITLE
Ignore `conda-forge-webservices` when checking for team removal

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -137,7 +137,10 @@ for old_member in member_handles - all_members:
 
 # Remove any teams which don't belong any more (because there is no longer a feedstock).
 for team_to_remove in set(teams.keys()) - set(packages_visited):
-    if team_to_remove in ['Core', 'conda-forge.github.io', 'all-members']:
+    if team_to_remove in ['Core',
+                          'conda-forge.github.io',
+                          'all-members',
+                          'conda-forge-webservices']:
         print('Keeping ', team_to_remove)
         continue
     print("THE {} TEAM NEEDS TO BE REMOVED.".format(team_to_remove))


### PR DESCRIPTION
Related: https://github.com/conda-forge/conda-forge.github.io/issues/84

Ignore the `conda-forge-webservices` team when checking for teams that should be removed.

cc @pelson