### PR TITLE
Ensure that `environ` is defined

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -79,7 +79,7 @@ for package_name in os.listdir(feedstocks_path):
     env = jinja2.Environment(undefined=NullUndefined)
 
     with open(recipe) as fh:
-        contents = env.from_string(''.join(fh)).render()
+        contents = env.from_string(''.join(fh)).render(environ={})
     data = yaml.safe_load(contents)
 
     contributors = data.get('extra', {}).get('recipe-maintainers', [])


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/93

Not sure if this is enough, but it feels like the simplest first step. Just defines `environ` as an empty dictionary. We can certainly add stuff to the dictionary or use `mock` if we need a better strategy. For now, going to try the simplest strategy to fix this and see how it goes. In the worst case, everything is still just as broken as it is now.