### PR TITLE
Update Hackpad URL to point to the org

### DIFF
--- a/minutes/README.md
+++ b/minutes/README.md
@@ -1,4 +1,3 @@
 A directory containing the minutes from previous hangouts.
 
-Future hangouts have an agenda at https://hackpad.com/conda-forge-meeting-notes-WZIa4PBQ6sz.
-
+Future hangouts have an agenda at ( https://conda-forge.hackpad.com/ ).


### PR DESCRIPTION
Related: https://github.com/conda-forge/conda-forge.github.io/issues/101

Updates the URL for Hackpads to point to the organization instead of the one off Hackpad. This should allow us to have multiple Hackpads and break up agendas on a per meeting basis. Further the minutes could be added to their own Hackpad and be converted to Markdown to archive them after the meeting. Feedback welcome.