### PR TITLE
Add agenda with minutes from 2016-04-08

### DIFF
--- a/minutes/2016-04-08.md
+++ b/minutes/2016-04-08.md
@@ -1,0 +1,500 @@
+<span>Continuum:</span>
+
+-   <span class="c0">People are balking here about the model of one repo
+    per recipe.  I'd like to discuss options for management of several
+    feedstocks simultaneously - if anyone knows good ways to do this.
+     Case in point: we have an intern adding description metadata to
+    many recipes.  Doing this in one repo is tedious, but doing it when
+    each recipe is a separate repo (PR for each), it is a
+    larger job.</span>^<span id="cmnt_ref1">[\[a\]](#cmnt1)</span><span
+    id="cmnt_ref2">[\[b\]](#cmnt2)</span>^
+
+<!-- -->
+
+-   <span class="c0">Feedstocks submodule</span>
+-   <span class="c0">GitPython, PyGithub, ruamel.yaml</span>
+-   <span class="c0">Are there general enough cases that helper scripts
+    would aid?</span>
+-   <span class="c0">Refactoring of existing code for feedstock updates
+    (smithy upgrades, updating feedstocks submodule)</span>
+-   <span class="c0">Useful webtools that might make this easier?</span>
+
+<!-- -->
+
+-   <span class="c0">Filipe’s networkx code</span>
+-   <span class="c0">Other ideas?</span>
+
+<!-- -->
+
+-   <span class="c0">ACTION: Phil to send Michael example of how he
+    edits multiple feedstocks at once.  Merging on conda-forge side will
+    continue to be done manually on github</span>
+
+<span class="c0">             (</span><span
+class="c12">[https://github.com/conda-forge/conda-smithy/pull/121\#issuecomment-206756642](https://www.google.com/url?q=https://github.com/conda-forge/conda-smithy/pull/121%23issuecomment-206756642&sa=D&ust=1460944544826000&usg=AFQjCNE4VrKnUJq-PPA-Xqu_rm_cluSpig)</span><span
+class="c0">)</span>
+
+<span class="c0"></span>
+
+<span class="c0"></span>
+
+<span class="c0">Build tools:</span>
+
+-   <span class="c0">Msbuild on Appveyor: causing issues with postgres.
+     Postgres recipe solution, or appveyor support request?</span>
+-   <span class="c0">Linux docker image?  Switch to Continuum image, or
+    pursue CentOS6 with devtoolset 4?</span>
+
+<!-- -->
+
+-   <span class="c0">Either way, what are the boundaries we should be
+    aware of as far as needing to ship system libraries?</span>
+
+<!-- -->
+
+-   <span class="c0">Libstdc++</span>
+-   <span class="c0">Libgfortran</span>
+-   <span class="c0">Libgomp</span>
+-   <span class="c0">Anything else?</span>^<span
+    id="cmnt_ref3">[\[c\]](#cmnt3)</span><span
+    id="cmnt_ref4">[\[d\]](#cmnt4)</span>^
+
+<!-- -->
+
+-   <span class="c0">ACTION: Look into cross compiling 64/32, Linux to
+    Mac?</span>
+-   <span class="c0">ACTION: Figure out if CentOS 5 is still
+    needed?</span>
+-   <span class="c0">ACTION: Need to come up with appropriate tests to
+    validate this.</span>
+
+<!-- -->
+
+-   <span class="c0">Appveyor support - how can we celebrate and thank
+    our sponsors in appropriate ways?</span>^<span
+    id="cmnt_ref5">[\[e\]](#cmnt5)</span>^
+
+<!-- -->
+
+-   <span class="c0">Generally on this point ( sorry to keep plugging
+    Jupyter ;) ) they have a nice page that shows generally who is
+    involved both at the code level and at the sponsorship level. Maybe
+    we don’t want to do this exactly, but it is a starting point.</span>
+-   <span
+    class="c12">[http://jupyter.org/about.html](https://www.google.com/url?q=http://jupyter.org/about.html&sa=D&ust=1460944544832000&usg=AFQjCNHl7ATyBRorOBrj1f1ExRqd3AOuPw)</span>
+
+<!-- -->
+
+-   <span class="c0">How to handle Fortran and OpenMP support
+    on Mac.</span>
+
+<!-- -->
+
+-   <span class="c0">Package a copy of gcc.</span>
+-   <span class="c0">Install a standard gcc binary</span>
+
+<!-- -->
+
+-   <span
+    class="c12">[https://gcc.gnu.org/wiki/GFortranBinaries\#MacOS](https://www.google.com/url?q=https://gcc.gnu.org/wiki/GFortranBinaries%23MacOS&sa=D&ust=1460944544833000&usg=AFQjCNG_APL0J0o6JfQrHkDGOUj9W4OyJw)</span>
+-   <span
+    class="c12">[https://r.research.att.com/tools/](https://www.google.com/url?q=https://r.research.att.com/tools/&sa=D&ust=1460944544834000&usg=AFQjCNE0OBcLRQNLWxMMj6-ZvixAkyUIHw)</span>
+-   <span
+    class="c12">[http://hpc.sourceforge.net/](https://www.google.com/url?q=http://hpc.sourceforge.net/&sa=D&ust=1460944544835000&usg=AFQjCNHnObdTF6HFp9rUnhFdPF_Y6koySg)</span>
+-   <span
+    class="c12">[https://github.com/timburrow/gcc-5.2-OSX/releases](https://www.google.com/url?q=https://github.com/timburrow/gcc-5.2-OSX/releases&sa=D&ust=1460944544836000&usg=AFQjCNFEJPr3DaR-zc_LtuTzddxb2MICDA)</span><span
+    class="c0"> (not sure how I feel about this one)</span>
+-   <span class="c0">Something else?</span>
+
+<!-- -->
+
+-   <span class="c0">Package a newer copy of Apple’s clang (ack!)
+    (should have OpenMP support though no Fortran)</span>
+
+<!-- -->
+
+-   <span
+    class="c12">[http://www.opensource.apple.com/source/clang/clang-700.0.72/](https://www.google.com/url?q=http://www.opensource.apple.com/source/clang/clang-700.0.72/&sa=D&ust=1460944544838000&usg=AFQjCNHR9Y6BBdWX7mDzVszN7t__-Dlc6w)</span>
+
+<!-- -->
+
+-   <span class="c0">Use something from Homebrew.</span>
+-   <span class="c0">Use another Mac package manager (MacPorts,
+    Fink, others?)</span>
+-   <span class="c0">ACTION: Michael will check with Ray Donnelly about
+    his thoughts on proceeding here.</span>
+
+<!-- -->
+
+-   <span class="c0">In general (Mac and Linux), how do we (or do we)
+    ship libraries that do not come on a standard system.</span>
+
+<!-- -->
+
+-   <span class="c0">Libgfortran (or statically link?)</span>
+
+<!-- -->
+
+-   <span class="c0">We have decided that we are just statically linking
+    libgfortran going forward.</span>
+-   <span class="c0">For now, we will do this manually by adding this to
+    recipes using gfortran.</span>
+-   <span class="c0">This means reviewers will need to keep this in mind
+    as recipes are proposed (should be rare though).</span>
+-   <span class="c0">Ultimately, we will want this to happen
+    automatically behind the scenes.</span>
+
+<!-- -->
+
+-   <span class="c0">Libgomp, Clang’s equivalent if any?</span>
+-   <span class="c0">GPU libraries (maybe should get a very
+    brief mention)</span>
+
+<!-- -->
+
+-   <span class="c0">Windows various.</span>
+
+<!-- -->
+
+-   <span class="c0">Status of 64-bit support with VS 2008.</span>
+
+<!-- -->
+
+-   <span class="c0">ACTION: John will update notes on PR with
+    workaround and close it. (COMPLETED)</span>
+
+<!-- -->
+
+-   <span class="c0">Added a note </span><span
+    class="c12">[here](https://www.google.com/url?q=https://github.com/conda-forge/conda-smithy/pull/107%23issue-145041617&sa=D&ust=1460944544843000&usg=AFQjCNGC_OB_pjVJmB2cBTje9HLgujdpzQ)</span><span
+    class="c0"> explaining that this will not merged.</span>
+-   <span class="c0">Also, has been closed. People are welcome to ping
+    me for the fix.</span>
+
+<!-- -->
+
+-   <span class="c0">Build tools that are permissible (MSVC, MSYS2,
+    MinGW, CygWin).</span>
+-   <span class="c0">What will the build system look like in the
+    future</span>
+-   <span class="c0">How do we handle packages that provide VC
+    projects/solutions, but no CMake.</span>
+-   <span class="c0">Instructions for getting usable Windows VMs.</span>
+
+<!-- -->
+
+-   <span class="c0">ACTION: Michael will publish his Vagrant/Salt stuff
+    amongst other VMs.</span>
+
+<span class="c0"></span>
+
+<span class="c0">(TABLED) Features:</span>
+
+-   <span class="c0">Controlling compiler optimizations (SSE,
+    AVX, others?)</span>
+-   <span class="c0">Selecting common API implementations (BLAS,
+    PyQt/PySide/others?, others?)</span>
+-   <span class="c0">GPU selection (OpenCL, CUDA) also combinations with
+    the above (ViennaCL).</span>
+-   <span class="c0">Installation and linkage to cuDNN</span>
+
+<span class="c0"></span>
+
+<span class="c0">(TABLED) Dependency tracking:</span>
+
+-   <span class="c0">How do we track what dependency are?</span>
+-   <span class="c0">Notification of dependency updates?</span>
+-   <span class="c0">What dependencies are we missing?</span>
+-   <span class="c0">Visualization of how they interact?</span>
+-   <span class="c0">Identifying weak spots (maintainers
+    vs usage)</span>
+
+<span class="c0"></span>
+
+<span class="c0">(TABLED) Automation:</span>
+
+-   <span class="c0">Overview of what is automated currently.</span>
+
+<!-- -->
+
+-   <span class="c0">Feedstocks submodule repo (adding and
+    updating commits)</span>
+-   <span class="c0">Webpage listing.</span>
+-   <span class="c0">Linter bot.</span>
+-   <span class="c0">Feedstock generation</span>
+
+<!-- -->
+
+-   <span class="c0">What still needs automation or can
+    be improved.</span>
+
+<!-- -->
+
+-   <span class="c0">After updating a feedstock.</span>
+
+<!-- -->
+
+-   <span class="c0">Should somehow update the submodule repo.
+    (cron job?)</span>
+
+<!-- -->
+
+-   <span class="c0">More features for linter bot.
+    (separate discussion)</span>
+-   <span class="c0">Automate removal of old packages (could be scary,
+    could help)</span>
+-   <span class="c0">How we run smithy updates to feedstocks.</span>
+-   <span class="c0">Check for recipes that are added twice (already
+    have a feedstock).</span>
+
+<span class="c0"></span>
+
+<span class="c0">(TABLED) Review process:</span>
+
+-   <span class="c0">What standards do we want to have for
+    recipes?</span>
+-   <span class="c0">Where should this be documented?</span>
+-   <span class="c0">What parts can be automated? (Linter bot)</span>
+
+<!-- -->
+
+-   <span class="c0">License checking</span>
+-   <span class="c0">Download tarballs</span>
+-   <span class="c0">Checksums</span>
+-   <span class="c0">Shellcheck for bash</span>
+-   <span class="c0">Something like shellcheck for batch</span>
+-   <span class="c0">Commenting on diffs</span>
+-   <span class="c0">Anything else? (may have forgotten other
+    neat ideas)</span>
+
+<span class="c0"></span>
+
+<span class="c0"></span>
+
+<span class="c0">Connecting with other communities:</span>
+
+-   <span class="c0">Bioconda/omnia: Bjorn Gruning, </span><span
+    class="c12">[https://github.com/conda/conda-recipes/commit/6d0224200653af63d5d1fb6950cbbc146d4e5d4a\#commitcomment-16981195](https://www.google.com/url?q=https://github.com/conda/conda-recipes/commit/6d0224200653af63d5d1fb6950cbbc146d4e5d4a%23commitcomment-16981195&sa=D&ust=1460944544859000&usg=AFQjCNGQyRR4tJANJVRJsdvrjLTwY0SLSQ)</span><span
+    class="c0"> </span>
+-   <span class="c0">Biometrics Group at Idiap</span>
+-   <span class="c0">NIPY</span>
+-   <span class="c0">menpo</span>
+-   <span class="c0">Existing Scientific Python communities</span>
+
+<!-- -->
+
+-   <span class="c0">Matplotlib</span>
+-   <span class="c0">Jupyter</span>
+-   <span class="c0">NumPy/SciPy</span>
+-   <span class="c0">SymPy</span>
+-   <span class="c0">Scikits (image, learn, others?)</span>
+-   <span class="c0">Pandas</span>
+-   <span class="c0">Dask</span>
+-   <span class="c0">Xarray</span>
+-   <span class="c0">Dynd</span>
+-   <span class="c0">Blaze</span>
+-   <span class="c0">Bokeh</span>
+-   <span class="c0">VisPy</span>
+-   <span class="c0">Toolz</span>
+-   <span class="c0">Astropy, Sunpy</span>
+-   <span class="c0">Others? (I know there are more, but I do
+    lose track)</span>
+
+<!-- -->
+
+-   <span class="c0">Inviting other conda-recipes groups to join.</span>
+-   <span class="c0">Outreach</span>
+
+<!-- -->
+
+-   <span class="c0">Our own Blog (-1) (Sorry, was confused.
+    - John)</span>
+-   <span class="c0">Posts on Continuum’s Blog? (+1)</span>
+-   <span class="c0">Do we need a Code of Conduct?
+    (Assigned: Filipe)</span>
+
+<!-- -->
+
+-   <span class="c0">Possibly look at Jupyter’s</span>
+-   <span class="c0">NumPy also has one, but I believe it is borrowed
+    from Jupyter.</span>
+
+<!-- -->
+
+-   <span class="c0">DISCUSSED: Going to conferences to give talks
+    about conda-forge.</span>
+-   <span class="c0">DISCUSSED: Happy to keep recruiting people from
+    other places.</span>
+-   <span class="c0">DISCUSSED: Will start inviting others to our
+    weekly meetings.</span>
+-   <span class="c0">DISCUSSED: Will allow people to add to an agenda.
+    (where should this be? GitHub?)</span>
+-   <span class="c0">DISCUSSED: Will aim to spend 5 mins on each
+    agenda item.</span>
+
+<span class="c0"></span>
+
+<span class="c0">(TABLED) Organizational:</span>
+
+-   <span class="c0">Platform for these notes?  Wki? Etherpad? Google
+    docs?</span>
+-   <span class="c0">Pursue NumFocus support?  Might be a good way to
+    remunerate Travis, CircleCI, and Appveyor</span>
+-   <span class="c0">How do we showcase, celebrate, (some other
+    word maybe?) organizations that are using conda-forge?</span>
+-   <span class="c0">Do we brand things (e.g. Python, iPython, etc.)? (I
+    feel uncomfortable making a decision on this without more feedback
+    from others at conda-forge, but maybe we should discuss
+    it briefly)</span>
+
+<span class="c0"></span>
+
+<span class="c0">Anaconda cloud storage limit: (Solved!)</span>
+
+-   <span
+    class="c12">[http://anaconda.org/conda-forge/settings/storage](https://www.google.com/url?q=http://anaconda.org/conda-forge/settings/storage&sa=D&ust=1460944544871000&usg=AFQjCNFdwqaoFtRknZAkyjbn_gO8GeaPHw)</span>^<span
+    id="cmnt_ref6">[\[f\]](#cmnt6)</span><span
+    id="cmnt_ref7">[\[g\]](#cmnt7)</span><span
+    id="cmnt_ref8">[\[h\]](#cmnt8)</span><span
+    id="cmnt_ref9">[\[i\]](#cmnt9)</span><span
+    id="cmnt_ref10">[\[j\]](#cmnt10)</span><span
+    id="cmnt_ref11">[\[k\]](#cmnt11)</span><span
+    id="cmnt_ref12">[\[l\]](#cmnt12)</span><span
+    id="cmnt_ref13">[\[m\]](#cmnt13)</span><span
+    id="cmnt_ref14">[\[n\]](#cmnt14)</span><span
+    id="cmnt_ref15">[\[o\]](#cmnt15)</span>^<span class="c0"> (Using 6.3
+    GB of unlimited storage ;-)</span>
+-   <span class="c0">When should we remove old packages?</span>
+
+<!-- -->
+
+-   <span class="c0">Number of build numbers to keep</span>
+-   <span class="c0">Should this be automated?</span>
+-   <span class="c0">DISCUSSED: Removal could break things. No
+    decision made. Looks like it might be unnecessary to think about
+    this for now.</span>
+
+<div class="c6">
+
+<span id="cmnt1">[\[a\]](#cmnt_ref1)</span><span class="c3">Could you
+please provide a little more info about what it is people are
+struggling?</span>
+
+<span class="c3"></span>
+
+<span class="c3">Would the feedstocks submodule repo help this?</span>
+
+<span class="c3"></span>
+
+<span class="c3">Are there some particular types of interactions with
+feedstocks that we should keep in mind?</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt2">[\[b\]](#cmnt_ref2)</span><span class="c3">Not sure
+what the solution is here. Discuss more use cases will help. Added some
+thoughts about what is done currently and thoughts on how it could be
+leveraged.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt3">[\[c\]](#cmnt_ref3)</span><span class="c3">Should this
+just be its own topic? This is a problem on Mac, as well. We will likely
+need to come up with something similar for both cases.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt4">[\[d\]](#cmnt_ref4)</span><span class="c3">I added such
+a topic below as it seems like this is a problem that crosses over a
+bit.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt5">[\[e\]](#cmnt_ref5)</span><span class="c3">This feels
+like it is between two places. Almost seems organizational
+though.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt6">[\[f\]](#cmnt_ref6)</span><span class="c3">Argh!
+ Travis asked our team to up your cap to 3 TB.  Apparently that never
+happened.  I will follow up.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt7">[\[g\]](#cmnt_ref7)</span><span class="c3">Interesting.
+I was wondering how space was being handled here. It would be good to
+get an idea of how this scales and what we need to keep in mind.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt8">[\[h\]](#cmnt_ref8)</span><span class="c3">--
+John</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt9">[\[i\]](#cmnt_ref9)</span><span class="c3">We notice
+that today. I removed gdal old binaries and we are OK for now.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt10">[\[j\]](#cmnt_ref10)</span><span class="c3">What is
+our usage now?</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt11">[\[k\]](#cmnt_ref11)</span><span class="c3">Now it is
+4.9 GB of 3.0 GB. (It was 10 GB before!)</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt12">[\[l\]](#cmnt_ref12)</span><span class="c3">Sounds
+believable. Maybe we need to start clearing out old packages at some
+point.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt13">[\[m\]](#cmnt_ref13)</span><span class="c3">So, this
+now says solved. Is it completely solved or is there something still in
+the works?</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt14">[\[n\]](#cmnt_ref14)</span><span class="c3">I believe
+it is completely solved. It say \*Using 6.3 GB of unlimited storage\*
+now.</span>
+
+</div>
+
+<div class="c6">
+
+<span id="cmnt15">[\[o\]](#cmnt_ref15)</span><span class="c3">Oh ok, I
+can't see the read out. So, had to ask. Thanks for clarifying. :)</span>
+
+</div>


### PR DESCRIPTION
Just converted the [Google Doc]( https://docs.google.com/document/d/1pXihskI9f12CCCKdV6ELT5zNZLx9UIDbKUmbT01PNW4/edit?pref=2&pli=1 ) to Markdown via HTML. Maybe not the prettiest, but it is nice to have this in the archive with everything else.