### PR TITLE
Add minutes from the exception VC meeting on 2016-04-22

### DIFF
--- a/minutes/2016-04-22.md
+++ b/minutes/2016-04-22.md
@@ -1,0 +1,21 @@
+## 2016-04-22 Exceptional meeting regarding VC pinning mechanism
+
+14:00 UTC
+
+Hangout Link: [](https://hangouts.google.com/call/uqi4wwchj5hnpdetsbzmaer7hue)[https://hangouts.google.com/call/uqi4wwchj5hnpdetsbzmaer7hue](https://hangouts.google.com/call/uqi4wwchj5hnpdetsbzmaer7hue)
+
+Subject: **How do we want to express recipes for particular VS versions.**
+
+*   New conda-build release - may be necessary for VS builds: [](https://github.com/conda/conda-build/releases/tag/1.20.1)[https://github.com/conda/conda-build/releases/tag/1.20.1](https://github.com/conda/conda-build/releases/tag/1.20.1)
+
+        *   Rebuild Eigen to test that the latest version works - if so we can drop [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)'s conda-smithy branch that tries to fix appveyor.
+    *   This has all been done and works now. In some cases Python 3.4 64-bit  builds on Windows have issues. That is still not understood.
+
+*   Current guidance at [](https://github.com/conda-forge/staged-recipes/wiki/VC-features)[https://github.com/conda-forge/staged-recipes/wiki/VC-features](https://github.com/conda-forge/staged-recipes/wiki/VC-features) and [](https://github.com/conda/conda/wiki/VC-features)[https://github.com/conda/conda/wiki/VC-features](https://github.com/conda/conda/wiki/VC-features). 
+*   How   should a simple recipe look? The following is problematic in   conda-build currently because the VS version isn't determined until the   build environment has been resolved (i.e. after the metadata has been   parsed, currently):
+
+*   Should conda-build automatically express the msvc_runtime dependency?
+*   If we had pinning capabilities within conda-build, does that become easier?
+*   Whatever we choose, how do we maintain compatibility with **defaults**?
+
+Notes:


### PR DESCRIPTION
A bit overdue, but this adds the agenda/minutes from the exceptional VC meeting.

In attendance were: @183amir @jakirkham @msarahan @patricksnape @pelson

Going to let this sit for a bit and make sure everyone has seen this.

If I missed anyone and/or anything, it was not intentional. Please just politely remind me and I will address whatever errata is here in the notes and the hackpad.

Thanks everyone for such a productive meeting.