### PR TITLE
Passes `MetaData` the recipe directory

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -75,7 +75,7 @@ for package_name in os.listdir(feedstocks_path):
     if not os.path.exists(recipe):
         print("The {} feedstock is recipe less".format(package_name))
         continue
-    meta = MetaData(feedstock)
+    meta = MetaData(os.path.dirname(recipe))
 
     contributors = meta.meta.get('extra', {}).get('recipe-maintainers', [])
     if not isinstance(contributors, list):


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge.github.io/issues/139 🍀

Extends @ericdill's great work in this PR ( https://github.com/conda-forge/conda-forge.github.io/pull/142 ) with a minor tweak. Seems `MetaData` prefers the recipe directory to the `meta.yaml` file. This makes that change.