### PR TITLE
Require `git` for steps that use it (Pt. 2)

### DIFF
--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -2,6 +2,7 @@
 
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -20,6 +20,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 """
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -2,6 +2,7 @@
 
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - gitpython

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -10,6 +10,7 @@ This is super useful if you are a conda-forge administrator and you are automati
 #  - python
 #  - conda-smithy
 #  - pygithub
+#  - gitpython
 #  - six
 # channels:
 #  - conda-forge

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -6,6 +6,7 @@ This is super useful if you are a conda-forge administrator and you are automati
 """
 # conda execute
 # env:
+#  - git
 #  - python
 #  - conda-smithy
 #  - pygithub


### PR DESCRIPTION
As our `git` now works correctly with certs, we are re-adding `git` to the requirements of scripts that use `git`.

xref: https://github.com/conda-forge/conda-forge.github.io/pull/69
xref: https://github.com/conda-forge/conda-forge.github.io/pull/71