### PR TITLE
Add link to available packages to the navigation

### DIFF
--- a/feedstocks.html
+++ b/feedstocks.html
@@ -52,6 +52,9 @@
                     <li>
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
+                    <li class="active">
+                        <a href="feedstocks.html">Available packages</a>
+                    </li>
                 </ul>
             </div>
             <!-- /.navbar-collapse -->

--- a/feedstocks.html
+++ b/feedstocks.html
@@ -53,7 +53,7 @@
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="feedstocks.html">Available packages</a>
+                        <a href="feedstocks.html">Packages</a>
                     </li>
                 </ul>
             </div>

--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -52,6 +52,10 @@
                     <li>
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
+                    <li class="active">
+                        <a href="feedstocks.html">Available packages</a>
+                    </li>
+
                 </ul>
             </div>
             <!-- /.navbar-collapse -->

--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -53,7 +53,7 @@
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="feedstocks.html">Available packages</a>
+                        <a href="feedstocks.html">Packages</a>
                     </li>
 
                 </ul>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
                         <a class="page-scroll" href="#contribute">Contribute</a>
                     </li>
                     <li>
-                        <a href="feedstocks.html">Available packages</a>
+                        <a href="feedstocks.html">Packages</a>
                     </li>
                 </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,10 @@
                         <a class="page-scroll" href="#about">About</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="#contribute">Contribute</a>    
+                        <a class="page-scroll" href="#contribute">Contribute</a>
+                    </li>
+                    <li>
+                        <a href="feedstocks.html">Available packages</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/74

This solves the problem that one had to scroll down to the contributing section to find a link to the available packages.