### PR TITLE
Run CI on re-rendering PRs

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -165,7 +165,7 @@ def create_update_pr(clone, remote_head, fork_remote, upstream_remote):
         clone.git.add('-A')
         from git import Actor
         author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
-        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {}.\n\n[ci skip]".format(conda_smithy.__version__),
+        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {}.".format(conda_smithy.__version__),
                                     author=author)
 
         remote_branch_already_exists = target_branch in fork_remote.refs
@@ -214,7 +214,7 @@ Since this is an infrastructural change, we don't actually need/want a new versi
 Thanks!
 
                     """.format(conda_smithy.__version__))
-            pull = forge_feedstock.create_pull(title='MNT: Re-render the feedstock',
+            pull = forge_feedstock.create_pull(title='MNT: Re-render the feedstock [ci skip]',
                                                body=msg,
                                                head="conda-forge-admin:{}".format(target_branch), base=remote_head)
             print('Opened PR on {}'.format(pull.html_url))


### PR DESCRIPTION
While it was initially a good idea to disable CI on re-rendering PRs as so many were being sent out (as so much was out-of-date), it is beginning not to seem like the case any more. Feedstocks often have to pin to particular versions of `conda-build` or have other custom workarounds to avoid new bugs that affect the ability to build the desired package. As a result, it is easy to miss why this was done in a PR or whether it is still needed without having CI. Also, it often happens that changes in the underlying stack affect such simple PRs. Enabling CI gives us a heads-up so we can react accordingly. This PR removes the skip CI comment in the message so that we can see if a re-rendering PR is acceptable and correct things accordingly.

cc @pelson @ocefpaf