### PR TITLE
initial hotfix script

### DIFF
--- a/scripts/hotfix.py
+++ b/scripts/hotfix.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - conda
+#  - anaconda-client
+# run_with: python
+
+''' This script can be used to hotfix package dependencies.
+
+Usage example: conda execute conda-forge.github.io/scripts/hotfix.py conda-forge /tmp/infile.txt -r 'boost 1.60.*'
+
+# An example for infile:
+bob.blitz 2.0.8 np111py27_6 linux-64: boost
+bob.blitz 2.0.8 np111py34_6 linux-64: boost
+bob.blitz 2.0.8 np111py35_6 linux-64: boost
+bob.core 2.1.2 py27_0 linux-64     :
+bob.core 2.1.2 py27_1 linux-64     :
+
+infile can be created using the output of the list_deps.py script with small modifications. For example:
+$ conda execute conda-forge.github.io/scripts/list_deps.py conda-forge --package bob.blitz --dependencies 'boost$' --platform linux-64
+# remove the first line
+Fetching package metadata: ..
+bob.blitz 2.0.8 np110py27_0 linux-64: boost
+bob.blitz 2.0.8 np110py27_1 linux-64: boost
+bob.blitz 2.0.8 np110py27_2 linux-64: boost
+bob.blitz 2.0.8 np110py27_3 linux-64: boost
+bob.blitz 2.0.8 np110py27_4 linux-64: boost
+...
+
+$ conda execute conda-forge.github.io/scripts/list_deps.py conda-forge --package bob.core --platform linux-64
+# remove the first line
+# remove the lines that have "boost 1.60.*" or "boost 1.61.*" in them.
+# remove everything in all lines after the ":" character.
+Fetching package metadata: ..
+bob.core 2.1.2 py27_0 linux-64     : bob.blitz, libgcc, python 2.7*
+bob.core 2.1.2 py27_1 linux-64     : bob.blitz, libgcc, python 2.7*
+bob.core 2.1.2 py27_2 linux-64     : bob.blitz, python 2.7*
+bob.core 2.1.2 py27_3 linux-64     : bob.blitz, python 2.7*
+bob.core 2.1.2 py27_4 linux-64     : bob.blitz, python 2.7*
+bob.core 2.1.2 py27_5 linux-64     : bob.blitz, boost 1.60.*, python 2.7*
+bob.core 2.1.2 py27_6 linux-64     : bob.blitz, boost 1.61.*, python 2.7*
+...
+
+'''
+
+import argparse
+import datetime
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+
+
+def download_package(channel, name, version, build_string, platform, save_path):
+  # I am using wget here but maybe conda has an api for this?
+  url = 'https://anaconda.org/{channel}/{name}/{version}/download/{platform}/{name}-{version}-{build_string}.tar.bz2'
+  url = url.format(channel=channel, name=name, version=version, platform=platform, build_string=build_string)
+  print('Downloading: {}'.format(url))
+  subprocess.call(
+    ['wget',
+     '--quiet',
+     url,
+     '-O',
+     save_path])
+
+
+def hotfix_package(channel, name, version, build_string, platform, dependency, replace):
+  with tempfile.TemporaryDirectory() as tmpdir:
+
+    # download the package
+    save_path = os.path.join(tmpdir, '{}-{}-{}.tar.bz2'.format(name, version, build_string))
+    download_package(channel, name, version,
+                     build_string, platform, save_path)
+
+    # extract it
+    pkgdir = os.path.join(tmpdir, 'package')
+    os.makedirs(pkgdir)
+    with tarfile.open(save_path) as tar:
+      tar.extractall(pkgdir)
+
+    # patch the info/index.json file
+    info_file = os.path.join(pkgdir, 'info', 'index.json')
+    with open(info_file) as f:
+      data = json.load(f)
+
+    # keep the old dependency list as a dictionary of timestamps
+    timestamp = str(datetime.datetime.now())
+    if 'depends_history' in data:
+      data['depends_history'][timestamp] = list(data['depends'])
+    else:
+      data['depends_history'] = {timestamp: list(data['depends'])}
+
+    # replace the dependency or add it if it does not exist.
+    if dependency in data['depends']:
+      i = data['depends'].index(dependency)
+      data['depends'][i] = replace
+    elif dependency == '':
+      data['depends'].append(replace)
+    else:
+      print('dependency not found! not hotfixing the package.')
+      return
+    with open(info_file, 'w') as f:
+      json.dump(data, f, sort_keys=True, indent=2)
+
+    # repackage
+    os.chdir(pkgdir)
+    files = os.listdir(pkgdir)
+    with tarfile.open(save_path, 'w:bz2') as tar:
+      for name in files:
+        tar.add(name)
+
+    # upload and replace
+    # maybe we need to add --force here?
+    args = ['anaconda', 'upload', '--user', channel, save_path]
+    print(' '.join(args))
+    subprocess.call(args)
+
+
+def main(args):
+  # An example for infile:
+
+  # these lines dependency will be replaced
+  # bob.blitz 2.0.8 np111py27_6 linux-64: boost
+  # bob.blitz 2.0.8 np111py34_6 linux-64: boost
+  # bob.blitz 2.0.8 np111py35_6 linux-64: boost
+
+  # these lines args.replace will be added to the depends list
+  # bob.core 2.1.2 py27_0 linux-64     :
+  # bob.core 2.1.2 py27_1 linux-64     :
+  for line in args.infile:
+    name, dependency = line.split(':', 1)
+    dependency = dependency.strip()
+    name, version, build_string, platform = name.split()
+    hotfix_package(args.channel, name, version, build_string, platform, dependency, args.replace)
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument('channel')
+  parser.add_argument('infile', type=argparse.FileType('r'))
+  parser.add_argument('-r', '--replace', required=True)
+
+  args = parser.parse_args()
+
+  main(args)


### PR DESCRIPTION
The issue was originally raised here: https://github.com/conda-forge/conda-forge.github.io/issues/126 but a lot of discussions has happened here. Here is a summary of the problem and different solutions to it.

The problem:
When we package a program, we make mistakes but they get published on anaconda.org and people start using them:
- Sometimes the metadata of a package changes. For instance, it's license and/or summary.
- We forget or miss to correctly specify the correct dependencies and this leads to creation of broken environments in future. For example, before we used to have just `boost 1.60.0` and all packages that were linking against it were listing `boost` only in their dependencies. But when we decided to update `boost` to `boost 1.61.0` https://github.com/conda-forge/boost-feedstock/pull/9 we had to look for all packages that were linking against `boost` and pin `boost` on version `1.60.*` there (since `boost` breaks API compatibility with each minor version). This resulted in a large _but necessary_ effort of pinning `boost` in other feedstocks. This included not only feedstocks that listed `boost` as a dependency like this: https://github.com/conda-forge/bob.blitz-feedstock/commit/342fcf2bdfeadb7d6d68171b2b9bcaa20d66d50d but also other feedstocks which were linking against `boost` but were not listing `boost` as a dependency like this: https://github.com/conda-forge/bob.core-feedstock/commit/cf03ad6aaed13ac9c8244bc4b6672522832de2d2
  This is all fine but the problem is that those old packages which did not pin `boost` are also available in the channel and conda dependency resolver will pick those packages and create an environment with them with any `boost` version.  Something like this `conda create -n test boost=1.62.0 bob.blitz_built_with_boost_1.60_but_not_pinned` will be created and results in a broken environment. An example can be seen here: https://circleci.com/gh/conda-forge/staged-recipes/5795

There are mainly 3 solutions to this:
# Solution 1: deleting the old packages. (current solution)

`pros`: security is slightly higher compared to other approaches. easier to do.

`cons`: it will take away reproducibility in a very hard way. We end up deleting a lot of packages since this happens often and will happen more as we continue to upgrade our stack.
# Solution 2: hotfixing packages

 with the script I provided here.

`pros`: Does not delete old packages and lets you use these packages in future as you may want to.

`cons`: md5sum of packages will change. If people are attempting to achieve reproducibility down to the MD5 level, they will be unable to do so. (And yes, we know people who are doing this.)

`concerns`: 
- people are afraid that admins modifying packages could lead to security issues. But IMO this is a different issue and unrelated since right now we have no means to check that packages uploaded to anaconda.org/conda-forge were uploaded by our CI or were modified by one of the admins.
- conda has a local package cache and will ignore our hotfixes. Is it true? if it is we can probably provide an easy fix.

`possible workarounds`:
1.  One thing we're considering is that instead of overwriting a package when a replacement is uploaded, we move the old package aside by appending its MD5 prefix to the URL. That way it is no longer available in the index, but still available for explicit request.
2. We can add the md5sum of all folders except the info folder in a package in our info folder and users use that md5sum for reproducibility. So later when you download a package which is hotfixed you can make sure everything has stayed the same except the info folder. 
3. We create a bot to do the hotfixes in a CI so that we are sure nothing else is changed.
# Solution 3: change conda to use only the latest build when creating an environment unless explicitly specified.

`pros`: That's what build numbers are for.

`cons`: conda is not a rolling release distribution and you are promised that you can create old environments today and they still work (at least in the defaults channel). I am not talking about reproducibility here, I am talking about creating new environments with an old dependency (say numpy 0.6) and let conda create a working environment for me. I don't want warnings and a broken environment at the end; I want something that actually works.

With your proposal, we need to rebuild all of our packages again (numpy 0.6 for example) to reflect those broken dependency changes with a new build number. So if some dependencies get updated in future and they were not pinned and we could not foresee it, we need to release a new build number of numpy 0.1 till 1.11 just to make sure that unpinned dependency gets pinned in ALL numpy versions now.
# Solution 4: Archive broken packages in another label in the channel.

`pros`: not controversial. reproducibility with environment.yml files still possible.

`cons`: Those packages cannot be used anymore in a normal way. We still have no means to verify archived packages integrity unless you had its md5 before.
