### PR TITLE
git ignore doc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore doc build
+docs/_build/


### PR DESCRIPTION
Have git ignore the `docs/_build/` directory generated by `sphinx` after building the docs.