### PR TITLE
Unpin `conda`/`conda-env` to work with `conda-execute`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,6 @@ install:
     # Now do the things we need to do to install it.
     - conda install conda-execute --yes --quiet -c conda-forge
 
-    # Pin conda and conda-env to workaround a compatibility
-    # issue with conda-execute and conda 4.1.0. See the
-    # linked issue for more details.
-    #
-    # https://github.com/pelson/conda-execute/issues/21
-    #
-    - conda install --yes --quiet conda=4.0.8 conda-env=2.4.5
-
 script:
     - if [ $ACTION = "update_docs" ]; then
         echo "Updating docs";


### PR DESCRIPTION
`conda`/`conda-env` were previously pinned in PR ( https://github.com/conda-forge/conda-forge.github.io/pull/174 ) as `conda-execute` and `conda` 4.1.0 did not play nicely together as explained in this issue ( https://github.com/pelson/conda-execute/issues/21 ). However, `conda-execute` has since been fixed and 0.6.0 release made.

The 0.6.0 release that fixed `conda-execute` now requires `conda` 4.1.0 or better to run. As a result, this pinning is now blocking the feedstock and doc update script from running. See this [log]( https://travis-ci.org/conda-forge/conda-forge.github.io/builds/141276080 ) as an example.

This PR should solve both problems as they are one in the same.

cc @pelson