### PR TITLE
Skip CI Feedstock Update

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -11,7 +11,7 @@ if [ -n "$GH_TOKEN" ]; then
     git diff
     # Only build the docs for commits on master.
     if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
-        git commit -am "Re-ran make.py." | true
+        git commit -am "Re-ran make.py. [ci skip]" | true
         git remote add pushable https://${GH_TOKEN}@github.com/conda-forge/conda-forge.github.io.git/ > /dev/null
         git push pushable new_site_content:master 2> /dev/null
     fi


### PR DESCRIPTION
Basically, when the docs get updated currently, they push a commit that triggers the CI again. However, the second run will basically make no changes to the feedstock listing and the feedstocks should be pretty nearly the same. However, it will trigger a GitHub rate limit part way through. Given this rate limit currently applies to staged-recipes too, this messes up our ability to merge anything at staged-recipes for ~1hr. Plus, it gives us false positives (failing builds), which we grow custom to ignoring.

It seems that we should just disable CI with our new commit. This PR does that. This shouldn't have any effect on us triggering the build manually. Though there is basically no need for that since Nightli.es has taken that job over for us by triggering our build automatically at ~5UTC daily.

Thoughts on this change?

cc @pelson @ocefpaf 