### PR TITLE
Match pr to feedstocks

### DIFF
--- a/scripts/match-pr-to-feedstocks.py
+++ b/scripts/match-pr-to-feedstocks.py
@@ -184,7 +184,7 @@ def _fuzzy_match(name, feedstock_index, threshold, limit):
     result = []
     for match in matches:
         pkg, score = match
-        if score > threshold:
+        if score >= threshold:
             result.append((pkg, score, feedstock_index[pkg]))
 
     return result

--- a/scripts/match-pr-to-feedstocks.py
+++ b/scripts/match-pr-to-feedstocks.py
@@ -108,6 +108,22 @@ def build_pr_index(filename, gh_org='conda-forge', staged_recipes_repo='staged-r
         print('pull requests index written to {}'.format(filename))
 
 
+@cli.command('compare-indices', help='compare pr index to feedstock index.')
+@click.argument('pr-index')
+@click.argument('feedstock-index')
+@click.option('--threshold', default=85, help='only return matches with scores above threshold')
+@click.option('--limit', default=2, help='maximum number of matches')
+def compare_indices(pr_index, feedstock_index, threshold, limit):
+    pr_index = json.load(open(pr_index))
+    feedstock_index = json.load(open(feedstock_index))
+    matches = {}
+    for pr, name in list(pr_index.items()):
+        m = _fuzzy_match(name, feedstock_index, threshold=threshold, limit=limit)
+        if len(m) > 0:
+            matches[(pr, name)] = m
+    print(matches)
+
+
 @cli.command('check-pr', help='check pr against feedstock index.')
 @click.argument('pr', type=int)
 @click.argument('feedstock-index')

--- a/scripts/match-pr-to-feedstocks.py
+++ b/scripts/match-pr-to-feedstocks.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env conda-execute
+
+# conda execute
+# env:
+#  - python
+#  - click
+#  - jinja2
+#  - requests
+#  - ruamel.yaml
+#  - conda-smithy
+#  - pygithub
+#  - fuzzywuzzy
+# channels:
+#  - conda-forge
+# run_with: python
+
+import click
+import conda_smithy.feedstocks as feedstocks
+import jinja2
+import json
+import requests
+import ruamel.yaml
+import os
+
+from github import Github
+import conda_smithy.github as smithy_github
+from fuzzywuzzy import process
+
+
+# patch over differences between PY2 and PY3
+try:
+    text_type = unicode
+except NameError:
+    text_type = str
+
+
+class NullUndefined(jinja2.Undefined):
+    def __unicode__(self):
+        return text_type(self._undefined_name)
+
+    def __getattr__(self, name):
+        return text_type('{}.{}'.format(self, name))
+
+    def __getitem__(self, name):
+        return '{}["{}"]'.format(self, name)
+
+
+env = jinja2.Environment(undefined=NullUndefined)
+
+
+@click.group()
+def cli():
+    """Match package names in pr against existing feedstocks.
+
+    Tools to match package names in from all the recipes in a pr against
+    the existing conda-forge feedstocks.
+    """
+    pass
+
+
+@cli.command('build-feedstock-index', help='create json index of feedstocks.')
+@click.argument('filename')
+@click.option('--gh-org', default='conda-forge', help='Set Github organization name.')
+def build_feedstock_index(filename, gh_org='conda-forge'):
+    "Iterate over feedstocks and return dict of pkg-name:feedstock"
+    pkg_index = {}
+    for repo in feedstocks.feedstock_repos(gh_org):
+        try:
+            meta = repo.get_file_contents(path='recipe/meta.yaml').decoded_content
+            pkg_name = _extract_package_name(meta)
+        except (AttributeError, KeyError):
+            # unable to parse the bob.io.image-feedstock
+            print('Unable to parse meta.yaml for {}'.format(repo.url))
+            print('guessing pkg name from feedstock url')
+            pkg_name = repo.url.split('/')[-1].split('-feedstock')[0].lower()
+        pkg_index[pkg_name] = repo.full_name
+
+    with open(filename, 'w') as f:
+        json.dump(pkg_index, f)
+        print('feedstocks index written to {}'.format(filename))
+
+
+def _extract_package_name(meta):
+    """Extract package name from meta.yaml"""
+    content = env.from_string(meta.decode('utf8')).render(os=os)
+    meta = ruamel.yaml.load(content, ruamel.yaml.RoundTripLoader)
+    return meta['package']['name'].lower()
+
+
+if __name__ == '__main__':
+    cli()

--- a/scripts/match-pr-to-feedstocks.py
+++ b/scripts/match-pr-to-feedstocks.py
@@ -172,7 +172,7 @@ def _format_output(matches, threshold, limit):
     print('-------------------------------------------')
     print('match(es) found using threshold={}, limit={}'.format(*vals))
     print('-------------------------------------------')
-    for k, repo in matches.items():
+    for k, repo in sorted(matches.items()):
         for recipe in repo:
             if len(recipe) > 0:
                 print('{} matches --> pkg={}, score={}, feedstock={}'.format(k, *recipe))


### PR DESCRIPTION
Adds cli to parse and compare open pr (or a pkg name string) against existing feedstocks. Usage below.

Caveats: We have false positives between packages named say python-\* etc. i.e. python-cobra matches python and yt. It is possible to make the fuzzy matching smarter but I think it is useful now. Fuzzy matches are controlled by a threshold (0-100) and limit (max number of matches to return). I've set the defaults to (85, 2). threshold=100 looks for exact matches.

currently, 20 recipes in five open pr's are exact matches for packages in the feedstocks (pr 1049, 1019, 642, 557, 537) 

Usage: match-pr-to-feedstocks.py [OPTIONS] COMMAND [ARGS]...

  Match package names in pr against existing feedstocks.

  Tools to match package names in from all the recipes in a pr against the
  existing conda-forge feedstocks.

Options:
  --help  Show this message and exit.

Commands:
  build-feedstock-index  create json index of feedstocks.
  build-pr-index         create json index of pull requests.
  check-pkg              check pkg name against feedstock index.
  check-pr               check pr against feedstock index.
  compare-indices        compare pr index to feedstock index.
