### PR TITLE
Pin OpenBLAS to 0.2.18

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -45,6 +45,7 @@ pinned = {
           'libsvm': 'libsvm 3.21|3.21.*',
           'libtiff': 'libtiff 4.0.*',
           'ncurses': 'ncurses 5.9*',
+          'openblas': 'openblas 0.2.18|0.2.18.*',
           'openssl': 'openssl 1.0.*',
           'readline': 'readline 6.2*',
           'sox': 'sox 14.4.2',


### PR DESCRIPTION
Appears we are not pinning OpenBLAS here. So this changes that. For the most part, this is the pinning we are using throughout conda-forge. However, there are a few notable exceptions that also need to be updated to follow the BLAS standard.

cc @pelson @conda-forge/openblas