### PR TITLE
Exclude `conda-forge-anvil` team from removal

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -136,6 +136,7 @@ for team_to_remove in set(teams.keys()) - set(packages_visited):
     if team_to_remove in ['Core',
                           'conda-forge.github.io',
                           'all-members',
+                          'conda-forge-anvil',
                           'conda-forge-webservices']:
         print('Keeping ', team_to_remove)
         continue


### PR DESCRIPTION
Excludes the `conda-forge-anvil` team from being listed for removal. This should be fine to go ahead with, but we may need to update it if we change the repo/team name ( https://github.com/conda-forge/conda-forge-anvil/issues/1 ).