### PR TITLE
Checkout `master` when deploying docs

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -5,6 +5,10 @@
 set -e
 
 if [ -n "$GH_TOKEN" ]; then
+    # Make sure we are on the latest commit on `master` if we are planning to deploy the change.
+    if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
+        git checkout master
+    fi
     git checkout -b new_site_content
     # Generate html requires a GitHub token in order to query the available feedstocks.
     conda execute scripts/generate_html.py


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/192

It seems that one cause of the build failures is the commit used by a build is not [in sync with `master`]( https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/150086345#L120 ). This can happen if one restarts an old build or if `origin/master` has changed since the build started. As a result, the `push` fails because it is not a fast-forward push. Unfortunately, we don't get info on it as it is [redirected]( https://github.com/conda-forge/conda-forge.github.io/blob/767e25822b2eaf3809daa128b631c51023a683a4/.ci_scripts/update_docs#L16 ). The redirection is needed for security; so, it makes sense, but it just makes this problem a little trickier to debug. While this may not fix the whole issue, this should at least fix some of it.

A simple fix is to checkout `master` before generating the changes to deploy on Travis CI. This should put it back in sync with `master`. We have added such a change in this PR.

We could additionally update `master` w.r.t. `origin/master` right before deployment to ensure that we have any other commits that cause us issues. While this could fix some other issues (e.g. a PR merged during a build), it will likely make that merged PR fail. This will give us an ugly build failed status. Alternatively, if we let the old build fail, the merged PR will pass, which should give us a clean build status. As a result, we did not do this subsequent change after contemplation. Though if we change our minds, it can always be pursued later.

In short, this should fix our build issues. When it doesn't quite fix them, restarting should at least provide us an easy way to fix them (as it was unable to before).