### PR TITLE
Add info for non-fast-forward doc pushes

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -17,7 +17,14 @@ if [ -n "$GH_TOKEN" ]; then
     if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
         git commit -am "Re-ran make.py. [ci skip]" | true
         git remote add pushable https://${GH_TOKEN}@github.com/conda-forge/conda-forge.github.io.git/ > /dev/null
-        git push pushable new_site_content:master 2> /dev/null
+
+        # Update the remotes before pushing and check the status.
+        # This should give us more info if the push will not be
+        # a simple fast-forward push.
+        git branch -u pushable/master
+        git fetch --all 2> /dev/null
+        git status
+        git push 2> /dev/null
     fi
 fi
 


### PR DESCRIPTION
This tries to improve the doc update script by letting us know if a non-fast-forward push is going to occur. It does this by updating the remote before a push and checking to see if there are new commits on the remote branch relative to ours. Unlike with the feedstocks repo, trying to rebase will more likely generate conflicts that require manual resolution. We can just as easily restart in these cases. Though more than likely the need for a restart has been obviated by the fact that something else has already updated the docs. As a result, it is simpler to just fail and let the end user know a bit more about why.
