### PR TITLE
Link status page from feedstock page

### DIFF
--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -55,6 +55,9 @@
                     <li class="active">
                         <a href="feedstocks.html">Packages</a>
                     </li>
+                    <li>
+                        <a href="./status">Status</a>
+                    </li>
 
                 </ul>
             </div>


### PR DESCRIPTION
Add a link from the feedstock page to the status page. Minor oversight on my part that this was not done in PR ( https://github.com/conda-forge/conda-forge.github.io/pull/210 ).