### PR TITLE
Use generic VM for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # The language in this case has no bearing - we are going to be making use of conda for a
 # python distribution for the scientific python stack.
-language: python
+language: generic
 
 sudo: false
 


### PR DESCRIPTION
Switch to using the generic VM for Travis CI as we use conda to get everything we need. This should improve VM boot time.