### PR TITLE
Fix references to feedstocks page

### DIFF
--- a/feedstocks.html
+++ b/feedstocks.html
@@ -56,7 +56,7 @@
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="feedstocks.html">Packages</a>
+                        <a href="feedstocks">Packages</a>
                     </li>
                     <li>
                         <a href="./status">Status</a>
@@ -9034,7 +9034,7 @@
             <a href="https://conda-forge.github.io">Home</a> |
             <a href="index.html#about">About</a> |
             <a href="index.html#contribute">Contribute</a> |
-            <a href="feedstocks.html">Feedstocks</a> |
+            <a href="feedstocks">Feedstocks</a> |
             <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
             </p>
             <br/>

--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -56,7 +56,7 @@
                         <a class="page-scroll" href="./#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="feedstocks.html">Packages</a>
+                        <a href="feedstocks">Packages</a>
                     </li>
                     <li>
                         <a href="./status">Status</a>
@@ -94,7 +94,7 @@
             <a href="https://conda-forge.github.io">Home</a> |
             <a href="index.html#about">About</a> |
             <a href="index.html#contribute">Contribute</a> |
-            <a href="feedstocks.html">Feedstocks</a> |
+            <a href="feedstocks">Feedstocks</a> |
             <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
             </p>
             <br/>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
                         <a class="page-scroll" href="#contribute">Contribute</a>
                     </li>
                     <li>
-                        <a href="feedstocks.html">Packages</a>
+                        <a href="feedstocks">Packages</a>
                     </li>
                     <li>
                         <a href="status">Status</a>
@@ -140,7 +140,7 @@
                       <ul class="fa-ul ul-instructions">
                       <li><i class="mega-octicon fa-3x octicon-search"></i>
                           Search for the appropriate feedstock repository.
-                          The <a href="feedstocks.html">list of existing feedstocks</a> is a good place to start.
+                          The <a href="feedstocks">list of existing feedstocks</a> is a good place to start.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-issue-opened"></i>
                           Take a look to see if the issue has already been raised on the feedstock's issue tracker.
@@ -160,7 +160,7 @@
                       <ul class="fa-ul ul-instructions">
                       <li><i class="mega-octicon fa-3x octicon-search"></i>
                           Search for the appropriate feedstock repository.
-                          The <a href="feedstocks.html">list of existing feedstocks</a> is a good place to start.
+                          The <a href="feedstocks">list of existing feedstocks</a> is a good place to start.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-repo-forked"></i>
                           Fork the feedstock you wish to update
@@ -211,7 +211,7 @@
             <a href="index.html">Home</a> |
             <a href="index.html#about">About</a> |
             <a href="index.html#contribute">Contribute</a> |
-            <a href="feedstocks.html">Feedstocks</a> |
+            <a href="feedstocks">Feedstocks</a> |
             <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
             </p>
             <br/>


### PR DESCRIPTION
Replace all references to `feedstocks.html` with `feedstocks`. This is a step towards solving issue ( https://github.com/conda-forge/conda-forge.github.io/issues/214 ). However, it is something we can go ahead with now. We don't need to complete the other steps for this to work.

xref: http://stackoverflow.com/a/29200325
xref: https://github.com/jekyll/jekyll/pull/3452

Edit: Restored to original content in this post as it is again correct and good to go. Also included a couple xrefs.