### PR TITLE
Skip CI on feedstocks repo commits

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -73,4 +73,4 @@ feedstocks_repo.submodule_update(recursive=False)
 feedstocks_repo.git.submodule('foreach', 'git', 'pull', 'origin', 'master')
 
 if feedstocks_repo.is_dirty():
-    feedstocks_repo.git.commit('-a', '-m', 'Updated feedstocks submodules.')
+    feedstocks_repo.git.commit('-a', '-m', 'Updated feedstocks submodules. [ci skip]')


### PR DESCRIPTION
Add `[ci skip]` to commit messages on the feedstocks repo. This ensures CI will not be run on that repo when making updates to the submodules. Currently CI is not being run on the feedstocks repo. However, if the proposal in issue ( https://github.com/conda-forge/conda-forge.github.io/issues/214 ) is carried out, we will be running CI on the feedstocks repo and this will be appropriate. In the long run, this script will be removed from here, but until we have all the kinks worked out we may still need it for a transition period. Thus why this change is proposed. As there are no blockers on it, we can merge this whenever.