### PR TITLE
Suggest conda-forge as fallback channel, not default

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
                   <a href="https://github.com/conda-forge">conda-forge</a> package into an existing conda environment:
                 </p>
                 <code>
-                    conda config --add channels conda-forge
+                    conda config --append channels conda-forge
                 </code> <br />
                 <code>
                   conda install &lt;package-name&gt;


### PR DESCRIPTION
`conda config --add channels conda-forge` inserts conda-forge as the first channel to be searched.  This generally leads to the replacement of many default packages the user may not have intended to modify.  (If this is the recommended approach it should be clearly explained)

Using the `--append` argument instead uses conda-forge only for packages not provided in the default channels, which is a more sensible default for new users.  `--append` also clearly adds to the end of a list, where `--add` is ambiguous.