### PR TITLE
Pin `libevent` to `2.0.*`

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -36,6 +36,7 @@ pinned = {
           'icu': 'icu 56.*',
           'jpeg': 'jpeg 9*',
           'libblitz': 'libblitz 0.10|0.10.*',
+          'libevent': 'libevent 2.0.*',
           'libmatio': 'libmatio 1.5.*',
           'libnetcdf': 'libnetcdf 4.4.*',
           'libpng': 'libpng >=1.6.21,<1.7',


### PR DESCRIPTION
Trying something different by proposing the pinning before we get a bunch of stuff built without a pinning. 😉

Based off of the linked ABI table. There seem to be a few big changes in the early part of the 2.0.x series. However, we are starting with 2.0.22 so am hoping that we will avoid further breaks by not going backwards.

http://upstream.rosalinux.ru/versions/libevent.html

xref: https://github.com/conda-forge/staged-recipes/pull/1491
xref: https://github.com/conda-forge/staged-recipes/pull/1507
