### PR TITLE
Pin giflib

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -32,7 +32,7 @@ pinned = {
           'fontconfig': 'fontconfig 2.11.*',
           'freetype': 'freetype 2.6.*',
           'geos': 'geos 3.4.*',
-          'giflib': 'giflib 5.1.2|5.1.2.*',
+          'giflib': 'giflib 5.1.*',
           'hdf5': 'hdf5 1.8.17|1.8.17.*',
           'icu': 'icu 56.*',
           'jpeg': 'jpeg 9*',

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -32,6 +32,7 @@ pinned = {
           'fontconfig': 'fontconfig 2.11.*',
           'freetype': 'freetype 2.6.*',
           'geos': 'geos 3.4.*',
+          'giflib': 'giflib 5.1.2|5.1.2.*',
           'hdf5': 'hdf5 1.8.17|1.8.17.*',
           'icu': 'icu 56.*',
           'jpeg': 'jpeg 9*',


### PR DESCRIPTION
`giflib` is known to break backward compatibility sometimes on a patch version
 in the past: http://upstream.rosalinux.ru/versions/giflib.html
But new results: http://abi-laboratory.pro/tracker/timeline/giflib/ show that it is following semantic versioning. 