### PR TITLE
Tweaks to fork feedstocks

### DIFF
--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -34,7 +34,7 @@ import conda_smithy.feedstocks as feedstocks
 
 parser = argparse.ArgumentParser(description="Fork your maintained feedstocks.")
 parser.add_argument("--feedstocks-dir", help="The location of the feedstocks.",
-                    default="~/Developer/Conda/conda-forge/feedstocks/feedstocks")
+                    default="./feedstocks")
 args = parser.parse_args()
 
 feedstocks_dir = os.path.abspath(os.path.expanduser(args.feedstocks_dir))

--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -62,5 +62,16 @@ for each_feedstock in os.listdir(feedstocks_dir):
         each_feedstock_repo = each_feedstock
         if not each_feedstock_repo.endswith("-feedstock"):
             each_feedstock_repo += "-feedstock"
-        repo = gh_org.get_repo(each_feedstock_repo)
-        gh_me.create_fork(repo)
+        repo = git.Repo(each_feedstock_dir)
+        remote_repo = gh_org.get_repo(each_feedstock_repo)
+        fork_resp = gh_me.create_fork(remote_repo)
+
+        # Add the remote repos locally.
+        for user, url in [
+                (remote_repo.owner.login, remote_repo.clone_url),
+                (fork_resp.owner.login, fork_resp.ssh_url)
+        ]:
+            try:
+                remote = repo.create_remote(user, url)
+            except git.exc.GitCommandError:
+                pass


### PR DESCRIPTION
This is a follow-up on PR ( https://github.com/conda-forge/conda-forge.github.io/pull/242 ). Still forks feedstocks one maintains as before, but makes the following tweaks.

* Picks a more sensible default argument.
* Adds the remotes by user/org locally.
* If remotes already exist, skip them.