### PR TITLE
Pin qt/pyqt

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -46,6 +46,8 @@ pinned = {
           'openblas': 'openblas 0.2.18|0.2.18.*',
           'openssl': 'openssl 1.0.*',
           'proj.4': 'proj.4 4.9.3',
+          'pyqt': 'pyqt 4.11.*',
+          'qt': 'qt 4.8.*',
           'readline': 'readline 6.2*',
           'sox': 'sox 14.4.2',
           'sqlite': 'sqlite 3.13.*',


### PR DESCRIPTION
Now that `defaults` moved to Qt 5 we should pin our packages to `pyqt 4.11.*` and `qt 4.8.*` until we have versions of `Qt 5` and `pyqt 5` compiled with `jpeg 9*`.