### PR TITLE
Keep the staged-recipes team

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -137,7 +137,8 @@ for team_to_remove in set(teams.keys()) - set(packages_visited):
                           'conda-forge.github.io',
                           'all-members',
                           'conda-forge-anvil',
-                          'conda-forge-webservices']:
+                          'conda-forge-webservices',
+                          'staged-recipes']:
         print('Keeping ', team_to_remove)
         continue
     print("THE {} TEAM NEEDS TO BE REMOVED.".format(team_to_remove))


### PR DESCRIPTION
Make sure to keep the `staged-recipes` team when checking for teams that need to be removed in `update_teams.py`.