### PR TITLE
Pin libxml2

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -42,6 +42,7 @@ pinned = {
           'libpng': 'libpng >=1.6.23,<1.7',
           'libsvm': 'libsvm 3.21|3.21.*',
           'libtiff': 'libtiff 4.0.*',
+          'libxml2': 'libxml2 2.9.3',
           'ncurses': 'ncurses 5.9*',
           'netcdf-cxx4': 'netcdf-cxx4 4.3.*',
           'netcdf-fortran': 'netcdf-fortran 4.4.*',


### PR DESCRIPTION
It seems that `libxml2 2.9.4` has a bug so it is safer to pin to `2.9.4` until we sort this out. See https://mailman-mail5.webfaction.com/pipermail/lxml/2016-September/007759.html

Ping @rsignell-usgs and @kwilcox 

PS: I am pining `lxml` and `pycsw` in a moment.