### PR TITLE
Update libxml2 pin

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -42,7 +42,7 @@ pinned = {
           'libpng': 'libpng >=1.6.23,<1.7',
           'libsvm': 'libsvm 3.21|3.21.*',
           'libtiff': 'libtiff 4.0.*',
-          'libxml2': 'libxml2 2.9.3',
+          'libxml2': 'libxml2 2.9.*',
           'ncurses': 'ncurses 5.9*',
           'netcdf-cxx4': 'netcdf-cxx4 4.3.*',
           'netcdf-fortran': 'netcdf-fortran 4.4.*',


### PR DESCRIPTION
Thanks to https://github.com/conda-forge/libxml2-feedstock/pull/23 we can drop the restrictive pinning.