### PR TITLE
MNT, BUG: Fix doc deployment

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -19,7 +19,8 @@ if [ -n "$GH_TOKEN" ]; then
     git diff
     # Only build the docs for commits on master.
     if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
-        git commit -am "Re-ran make.py. [ci skip]" | true
+        git add -A
+        git commit -m "Re-ran make.py. [ci skip]" || true
         git remote add pushable https://${GH_TOKEN}@github.com/conda-forge/conda-forge.github.io.git/ > /dev/null
         git push pushable new_site_content:master 2> /dev/null
     fi


### PR DESCRIPTION
Adds on to PR ( https://github.com/conda-forge/conda-forge.github.io/pull/265 ) that changes doc deployment to this domain. Fixes doc deployment to ensure that untracked files are picked up along with modifications to tracked files.

cc @scopatz @pelson