### PR TITLE
MNT, BUG: Fix doc deployment (part 2)

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -19,7 +19,7 @@ if [ -n "$GH_TOKEN" ]; then
     git diff
     # Only build the docs for commits on master.
     if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
-        git add -A
+        git add -A :/
         git commit -m "Re-ran make.py. [ci skip]" || true
         git remote add pushable https://${GH_TOKEN}@github.com/conda-forge/conda-forge.github.io.git/ > /dev/null
         git push pushable new_site_content:master 2> /dev/null


### PR DESCRIPTION
Fixes `git add` syntax used in PR ( https://github.com/conda-forge/conda-forge.github.io/pull/271 ). Uses new `git` syntax for adding changes from the full repo. Apparently `git add -A` is no longer sufficient. Doing this to try and get doc deployments to this domain to work. ( https://github.com/conda-forge/conda-forge.github.io/pull/265 )

cc @scopatz @pelson