### PR TITLE
Link docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                 </p>
                 <code>
                     conda config --add channels conda-forge
-                </code> <br />
+                </code> <br>
                 <code>
                   conda install &lt;package-name&gt;
                 </code>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,9 @@
                 <code>
                   conda install &lt;package-name&gt;
                 </code>
+                <p> <br>
+                  Learn more about conda-forge by reading our <a href="https://conda-forge.github.io/docs">docs</a>.
+                </p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Adds a link to the docs from the about section of our home page. Uses the docs deployed to this repo. ( https://github.com/conda-forge/conda-forge.github.io/pull/265 )

cc @scopatz @pelson