### PR TITLE
Temporarily pin `conda` to `4.1.x`

### DIFF
--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -11,6 +11,7 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 # env:
 #  - git
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -3,6 +3,7 @@
 # conda execute
 # env:
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -4,6 +4,7 @@
 # env:
 #  - git
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -3,6 +3,7 @@
 # conda execute
 # env:
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -22,6 +22,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 # env:
 #  - git
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -4,6 +4,7 @@
 # env:
 #  - git
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -3,6 +3,7 @@
 # conda execute
 # env:
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -8,6 +8,7 @@ This is super useful if you are a conda-forge administrator and you are automati
 # env:
 #  - git
 #  - python
+#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython


### PR DESCRIPTION
Temporarily pin `conda` to `4.1.x` on CI so that `conda-smithy` works. Seems this is needed to get docs and feedstock update scripts working again.

Working on a fix in PR ( https://github.com/conda-forge/conda-smithy/pull/394 ). Can revert after we have a patch release with a fix.

cc @conda-forge/core