### PR TITLE
Pin conda-build to 1.x

### DIFF
--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -13,6 +13,7 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -12,6 +12,7 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 #  - git
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -4,6 +4,7 @@
 # env:
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -5,6 +5,7 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -5,6 +5,7 @@
 #  - git
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -6,6 +6,7 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -5,6 +5,7 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -4,6 +4,7 @@
 # env:
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -23,6 +23,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 #  - git
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -24,6 +24,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -5,6 +5,7 @@
 #  - git
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -6,6 +6,7 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -5,6 +5,7 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -4,6 +4,7 @@
 # env:
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -9,6 +9,7 @@ This is super useful if you are a conda-forge administrator and you are automati
 #  - git
 #  - python
 #  - conda 4.1.*
+#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -10,6 +10,7 @@ This is super useful if you are a conda-forge administrator and you are automati
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
+#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython


### PR DESCRIPTION
Given that pinning `conda` to 4.1.x was not sufficient, this tries to add some more pinnings. In particular, it pins `conda-env` to 2.5.x to match with `conda` and `conda-build` to 1.x. The last one is being done to see if it might help with this same [assertion error]( https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/181544137#L249 ).