### PR TITLE
FIX: Fetch doc remotes before using them

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -26,8 +26,8 @@ if [ -n "$GH_TOKEN" ]; then
         # Update the remotes before pushing and check the status.
         # This should give us more info if the push will not be
         # a simple fast-forward push.
-        git branch -u pushable/master
         git fetch --all 2> /dev/null
+        git branch -u pushable/master
         git status
         git push 2> /dev/null
     fi


### PR DESCRIPTION
Follow-up on PR ( https://github.com/conda-forge/conda-forge.github.io/pull/203 ). Was running `git branch -u` before `git fetch --all`, which caused a [problem]( https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/184464808#L255 ). This swaps the ordering, which should fix this bug.