### PR TITLE
FIX: Drop an extra space in redirect

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -29,7 +29,7 @@ if [ -n "$GH_TOKEN" ]; then
         git fetch --all 2> /dev/null
         git branch -u pushable/master
         git status
-        git push 2> /dev/null
+        git push 2>/dev/null
     fi
 fi
 


### PR DESCRIPTION
Drop an extra space in the git push redirect that slipped into PR ( https://github.com/conda-forge/conda-forge.github.io/pull/203 ).