### PR TITLE
Use our git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ install:
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
+    # Use our git.
+    - conda install --yes --quiet -c conda-forge -n root git
+
     - git config --global user.name "Travis-CI on github.com/conda-forge/conda-forge.github.io"
     - git config --global user.email pelson.pub+conda-forge@gmail.com
     - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token


### PR DESCRIPTION
This should avoid some of the pain points of having an older git that Travis CI provides. We already do this with `conda-execute` scripts that we run. This just ensures that we use our (conda-forge's) `git` even when we are not running a vanilla script.

This can be considered a follow-up to PR ( https://github.com/conda-forge/conda-forge.github.io/pull/69 ), which switched all the `conda-execute` scripts over to our `git.