### PR TITLE
FIX: Push branch upstream

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -26,10 +26,13 @@ if [ -n "$GH_TOKEN" ]; then
         # Update the remotes before pushing and check the status.
         # This should give us more info if the push will not be
         # a simple fast-forward push.
+        PUSH_DEFAULT="$(git config --get push.default)"
+        git config push.default upstream
         git fetch --all 2> /dev/null
         git branch -u pushable/master
         git status
         git push 2>/dev/null
+        git config push.default "${PUSH_DEFAULT}"
     fi
 fi
 


### PR DESCRIPTION
Configures git to push upstream temporarily and then reverts the setting if necessary.

This is a follow-up on PR ( https://github.com/conda-forge/conda-forge.github.io/pull/203 ).