### PR TITLE
FIX: Push docs upstream explicitly

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -29,7 +29,7 @@ if [ -n "$GH_TOKEN" ]; then
         git fetch --all 2> /dev/null
         git branch -u pushable/master
         git status
-        git push 2>/dev/null
+        git push pushable new_site_content:master 2> /dev/null
     fi
 fi
 

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -26,13 +26,10 @@ if [ -n "$GH_TOKEN" ]; then
         # Update the remotes before pushing and check the status.
         # This should give us more info if the push will not be
         # a simple fast-forward push.
-        PUSH_DEFAULT="$(git config --get push.default)"
-        git config push.default upstream
         git fetch --all 2> /dev/null
         git branch -u pushable/master
         git status
         git push 2>/dev/null
-        git config push.default "${PUSH_DEFAULT}"
     fi
 fi
 


### PR DESCRIPTION
Unfortunately specifying the branch to push upstream is not quite working right. The easiest thing is to simply specify where to push as was the case before. This should just work as it had.