### PR TITLE
Use Travis' git globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ install:
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
-    # Use our git.
-    - conda install --yes --quiet -c conda-forge -n root git
-
     - git config --global user.name "Travis-CI on github.com/conda-forge/conda-forge.github.io"
     - git config --global user.email pelson.pub+conda-forge@gmail.com
     - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token


### PR DESCRIPTION
Reverts PR ( https://github.com/conda-forge/conda-forge.github.io/pull/292 ).

Appears there is some funny behavior when using our `git` with `conda-execute` and in the `root` environment. The easiest fix is to revert this change for now.