### PR TITLE
Update feedstocks (forcibly)

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -73,7 +73,8 @@ for package_name in to_be_deleted:
     submodule = submodules[package_name].remove()
 
 feedstocks_repo.submodule_update(recursive=False)
-feedstocks_repo.git.submodule('foreach', 'git', 'pull', 'origin', 'master')
+feedstocks_repo.git.submodule('foreach', 'git', 'fetch', 'origin', 'master')
+feedstocks_repo.git.submodule('foreach', 'git', 'reset', '--hard', 'origin/master')
 
 if feedstocks_repo.is_dirty():
     feedstocks_repo.git.commit('-a', '-m', 'Updated feedstocks submodules. [ci skip]')


### PR DESCRIPTION
It is possible due to formatting issues or other problems that we are unable to run `git pull` on each submodule. This is because we will need to overwrite changes in the feedstock to update it. To fix this we need to fetch the remote and then reset hard to the new location. This makes that change.