### PR TITLE
Revert conda pins

### DIFF
--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -13,7 +13,6 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -12,7 +12,6 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 #  - git
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/fork_my_feedstocks.py
+++ b/scripts/fork_my_feedstocks.py
@@ -11,7 +11,6 @@ It also requires all the feedstocks be cloned somewhere like with the `feedstock
 # env:
 #  - git
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -3,7 +3,6 @@
 # conda execute
 # env:
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -4,7 +4,6 @@
 # env:
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -5,7 +5,6 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -4,7 +4,6 @@
 # env:
 #  - git
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -6,7 +6,6 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/lint_feedstocks.py
+++ b/scripts/lint_feedstocks.py
@@ -5,7 +5,6 @@
 #  - git
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -3,7 +3,6 @@
 # conda execute
 # env:
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -5,7 +5,6 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -4,7 +4,6 @@
 # env:
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy >=1.1
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -22,7 +22,6 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 # env:
 #  - git
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -23,7 +23,6 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 #  - git
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -24,7 +24,6 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy >=1.1.2
 #  - gitpython
 #  - pygithub

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -5,7 +5,6 @@
 #  - git
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -6,7 +6,6 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -4,7 +4,6 @@
 # env:
 #  - git
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -3,7 +3,6 @@
 # conda execute
 # env:
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -5,7 +5,6 @@
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -4,7 +4,6 @@
 # env:
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -9,7 +9,6 @@ This is super useful if you are a conda-forge administrator and you are automati
 #  - git
 #  - python
 #  - conda 4.1.*
-#  - conda-env 2.5.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -10,7 +10,6 @@ This is super useful if you are a conda-forge administrator and you are automati
 #  - python
 #  - conda 4.1.*
 #  - conda-env 2.5.*
-#  - conda-build 1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython

--- a/scripts/watch_only_my_feedstocks.py
+++ b/scripts/watch_only_my_feedstocks.py
@@ -8,7 +8,6 @@ This is super useful if you are a conda-forge administrator and you are automati
 # env:
 #  - git
 #  - python
-#  - conda 4.1.*
 #  - conda-smithy
 #  - pygithub
 #  - gitpython


### PR DESCRIPTION
Reverts https://github.com/conda-forge/conda-forge.github.io/pull/282
Reverts https://github.com/conda-forge/conda-forge.github.io/pull/280

Requires a new version of `conda-smithy` be released with PR ( https://github.com/conda-forge/conda-smithy/pull/394 ) included before proceeding forward.

This unpins `conda`, `conda-env`, and `conda-build` so as to use the latest versions of all of these.