### PR TITLE
Unpin `conda-build` in team update script

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -6,7 +6,7 @@
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six
-#  - conda-build 1.20.1
+#  - conda-build
 # channels:
 #  - conda-forge
 # run_with: python


### PR DESCRIPTION
Addendum to PR ( https://github.com/conda-forge/conda-forge.github.io/pull/307 ).

Seems we missed that there is this pinning of `conda-build`. This releases that pinning and should fix related issues.