### PR TITLE
Update outdated pins

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -284,7 +284,7 @@ for feedstock, git_ref, meta_content, recipe in feedstock_gen:
 
                 for pos, dep in enumerate(section):
                     for name, pin in pinned.items():
-                        if re.match(r"^\s*%s\s*$" % name, dep) and dep != pin:
+                        if re.match(r"^\s*%s\s*$" % name, dep.split(" ", 1)[0]) and dep != pin:
                             replacements['- ' + str(dep)] = '- ' + pin
             if replacements:
                 current_build_number = recipe['build']['number']


### PR DESCRIPTION
Previously this script was able to update recipes with outdated pins. However, fixes made to the script to avoid partial dependency name matches, have had an adverse effect on updating outdated dependency pinnings. A simple fix would be to just split the pinning from the dependency's name and compare the name alone as we do here. This should still avoid partial name matches, but should also update old dependency pins. There are some subtle pinnings that we don't handle with this strategy. That being said, we haven't tended to use those particular forms of pinnings yet. If we do, we might want to take a closer look at `conda` or `conda-build` to find something more robust for this sort of parsing and comparison.

cc @krischer @croth1

xref: https://github.com/conda-forge/conda-forge.github.io/commit/483127828ea72dd4e7ed4def7a3c13211762171b#commitcomment-20474240