### PR TITLE
Update feedstock submodules manually

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -69,9 +69,15 @@ for package_name in to_be_deleted:
     print("Removing {}.".format(package_name))
     submodule = submodules[package_name].remove()
 
-feedstocks_repo.submodule_update(recursive=False)
-feedstocks_repo.git.submodule('foreach', 'git', 'fetch', 'origin', 'master')
-feedstocks_repo.git.submodule('foreach', 'git', 'reset', '--hard', 'origin/master')
+for each_submodule in feedstocks_repo.submodules:
+    print("Updating {}.".format(each_submodule.name))
+    each_submodule.branch.checkout(force=True)
+    each_submodule.update(
+        init=True,
+        recursive=False,
+        force=True,
+        to_latest_revision=True
+    )
 
 if feedstocks_repo.is_dirty():
     feedstocks_repo.git.commit('-a', '-m', 'Updated feedstocks submodules. [ci skip]')


### PR DESCRIPTION
Instead of running several implicit `for`-loops over the submodules in the `feedstocks` repo, run one update loop manually that fits the same criteria. Also print out info about each feedstock that is being updated. This last part is particularly important for Travis CI, which expects some kind of output every 10mins. This should easily meet that criteria.