### PR TITLE
Initialize submodules first

### DIFF
--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -71,6 +71,11 @@ for package_name in to_be_deleted:
 
 for each_submodule in feedstocks_repo.submodules:
     print("Updating {}.".format(each_submodule.name))
+    each_submodule.update(
+        init=True,
+        recursive=False,
+        force=True
+    )
     each_submodule.branch.checkout(force=True)
     each_submodule.update(
         init=True,

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -71,12 +71,15 @@ for package_name in to_be_deleted:
 
 for each_submodule in feedstocks_repo.submodules:
     print("Updating {}.".format(each_submodule.name))
+    # Update and initialize the submodule as it may not exist.
     each_submodule.update(
         init=True,
         recursive=False,
         force=True
     )
+    # Checkout the master branch so the repo can be updated to latest.
     each_submodule.branch.checkout(force=True)
+    # Update the submodule based on the current repo's state.
     each_submodule.update(
         init=True,
         recursive=False,


### PR DESCRIPTION
Before trying to checkout the `master` branch or updating the submodule to the latest commit, simply make sure the submodule exists. As they are not all created when cloning the `feedstocks` repo this is very important. Once the submodule is populated, we can switch to the branch setup to track the remote and update the submodule to the latest commit.