### PR TITLE
Temporarily use Python 2 for team updates

### DIFF
--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -2,7 +2,7 @@
 
 # conda execute
 # env:
-#  - python
+#  - python 2.7.*
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six


### PR DESCRIPTION
Ran into what appears to be a bug with `conda-build-all` and Python 3 during team updates. It appears the problem goes away with Python 2. An issue has been filed upstream about the problem. In the interim as this does workaround the issue, would like to switch to Python 2 to clear the current batch of recipes. May be worthwhile keeping this switch until the cause of the bug is better understood and potentially fixed or worked around in a better way.

xref: https://github.com/SciTools/conda-build-all/issues/77