### PR TITLE
Fixing CI skipping for automated PRs

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -165,7 +165,7 @@ def create_update_pr(clone, remote_head, fork_remote, upstream_remote):
         clone.git.add('-A')
         from git import Actor
         author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
-        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {} [ci skip].".format(conda_smithy.__version__),
+        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {}.".format(conda_smithy.__version__),
                                     author=author)
 
         remote_branch_already_exists = target_branch in fork_remote.refs
@@ -209,7 +209,7 @@ If the changes look good, then please go ahead and merge this PR.
 If you have any questions about the changes though, please feel free to ping the 'conda-forge/core' team (using the @ notation in a comment).
 
 Remember, for any changes to the recipe you would normally need to increment the version or the build number of the package.
-Since this is an infrastructural change, we don't actually need/want a new version to be uploaded to anaconda.org/conda-forge, so the version and build/number are left unchanged and the CI has been skipped.
+Since this is an infrastructural change, we don't actually need/want a new version to be uploaded to anaconda.org/conda-forge, so the version and build/number are left unchanged.
 
 Thanks!
 

--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -165,7 +165,7 @@ def create_update_pr(clone, remote_head, fork_remote, upstream_remote):
         clone.git.add('-A')
         from git import Actor
         author = Actor("conda-forge-admin", "pelson.pub+conda-forge@gmail.com")
-        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {}.".format(conda_smithy.__version__),
+        commit = clone.index.commit("MNT: Updated the feedstock for conda-smithy version {} [ci skip].".format(conda_smithy.__version__),
                                     author=author)
 
         remote_branch_already_exists = target_branch in fork_remote.refs
@@ -206,7 +206,7 @@ Hi! This is the friendly conda-forge-admin automated user.
 
 I've re-rendered this feedstock with the latest version of conda-smithy ({}) and noticed some changes.
 If the changes look good, then please go ahead and merge this PR.
-If you have any questions about the changes though, please feel free to ping the 'conda-forge/core' team (using the @ notation in a comment). 
+If you have any questions about the changes though, please feel free to ping the 'conda-forge/core' team (using the @ notation in a comment).
 
 Remember, for any changes to the recipe you would normally need to increment the version or the build number of the package.
 Since this is an infrastructural change, we don't actually need/want a new version to be uploaded to anaconda.org/conda-forge, so the version and build/number are left unchanged and the CI has been skipped.
@@ -214,7 +214,7 @@ Since this is an infrastructural change, we don't actually need/want a new versi
 Thanks!
 
                     """.format(conda_smithy.__version__))
-            pull = forge_feedstock.create_pull(title='MNT: Re-render the feedstock [ci skip]',
+            pull = forge_feedstock.create_pull(title='MNT: Re-render the feedstock',
                                                body=msg,
                                                head="conda-forge-admin:{}".format(target_branch), base=remote_head)
             print('Opened PR on {}'.format(pull.html_url))


### PR DESCRIPTION
Skipping ci comment has to be in commit message and not in the title of the PR

