### PR TITLE
Require conda-build-all 1.0.2 in regenerate script

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -23,6 +23,7 @@ Whilst it is out of date, the following pseudo code was used to outline this mod
 #  - git
 #  - python
 #  - conda-smithy >=1.1.2
+#  - conda-build-all >=1.0.2
 #  - gitpython
 #  - pygithub
 # channels:


### PR DESCRIPTION
It appears that re-renderings do not proceed correctly without having at least `conda-build-all` 1.0.2. Particularly with respect to re-renderings of feedstocks containing R dependencies. This pins `conda-build-all` to an acceptable version, which should hopefully fix that issue.