### PR TITLE
Drop channel manipulations with conda-smithy

### DIFF
--- a/src/conda_smithy.rst
+++ b/src/conda_smithy.rst
@@ -12,23 +12,7 @@ Here is how, and when, to re-render.
 How to re-render?
 -----------------
 
-First make sure you have both:
-    - both ``defaults`` and ``conda-forge`` channels in your ``.condarc`` and no other channel;
-    - the ``conda-forge`` channel should be on **top** of ``defaults`` to ensure package consistency via channel preference;
-    - updated version of ``conda`` and ``conda-build``.
-
-To ensure the channels are present and in the right order you can use:
-
-.. code-block:: shell
-
-    conda config --add channels defaults --force
-    conda config --add channels conda-forge --force
-
-
-You'll only need to run those commands once.
-You can check if you have both channels with ``conda info``.
-
-The next step is to install ``conda-smithy`` in your root environment
+First step is to install `conda-smithy` in your root environment
 
 .. code-block:: shell
     conda install -c conda-forge conda-smithy


### PR DESCRIPTION
These steps are no longer necessary with `conda-smithy` 2.0.0+ thanks to PR ( https://github.com/conda-forge/conda-smithy/pull/401 ). Instead `conda-forge.yml` determines the channels to use for re-rendering. These are the same channels added in the CIs for package downloads. If the source channels are not specified in `conda-forge.yml`, then it simply uses `conda-forge` first and then `defaults`. This is independent of the content of a user's `.condarc`.