### PR TITLE
Add tick_my_feedstocks.py

### DIFF
--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -415,7 +415,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
             'https://api.github.com/repos/{}/contents/recipe/meta.yaml'.format(
                 fork.full_name),
             json=patch.data,
-            auth=(user.login, gh_password))
+            auth=(gh_user, gh_password))
         if not r.ok:
             error_dict["Couldn't apply patch"].append(update.fs.name)
             continue

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -49,16 +49,25 @@ IMPORTANT NOTES:
   tests may still pass successfully.
 """
 # TODO pass token/user to pygithub for push. (Currently uses system config.)
+#  This is likely also why regeneration uses temporary CI dirs and not
+#  defined ones (e.g
+#  https://circleci.com/gh/conda-forge/tmp0bnegy33-feedstock.svg instead of
+#  https://circleci.com/gh/conda-forge/debtcollector-feedstock.svg)
+#  (Could also be an issue with conda_forge.configure_feedstock)
 # TODO Modify --dry-run flag to list which repos need forks.
 # TODO Modify --dry-run flag to list which forks are dirty.
 # TODO Modify --dry-run to also cover regeneration
 # TODO Add support for skipping repos that are deprecated. (e.g. fake-factory)
+# TODO skip upgrading from a stable release to a dev release (e.g. ghost.py)
 # TODO Test python 2.7 compatability (should work, but untested.)
 # TODO Test python 3.4 compatability (should work, but untested.)
 # TODO Test python 3.6 compatability (should work, but untested.)
 # TODO Deeper check of dependency changes in meta.yaml.
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 # TODO Check if already-forked feedstocks have open pulls.
+# TODO maintainer_can_modify flag when submitting pull
+#   Note that this isn't supported by pygithub yet, so would require
+#   switching back to requests
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -48,7 +48,6 @@ IMPORTANT NOTES:
   conda-forge tests are lightweight, even if the requirements have changed the
   tests may still pass successfully.
 """
-# TODO Finish refactoring meta yaml as a class
 # TODO pass token/user to pygithub for push. (Currently uses system config.)
 # TODO Modify --dry-run flag to list which repos need forks.
 # TODO Modify --dry-run flag to list which forks are dirty.
@@ -58,12 +57,8 @@ IMPORTANT NOTES:
 # TODO Test python 3.4 compatability (should work, but untested.)
 # TODO Test python 3.6 compatability (should work, but untested.)
 # TODO Deeper check of dependency changes in meta.yaml.
-# TODO reset build number back to zero
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
-# TODO Check special case of feedstocks renamed with 'python-' prefixes
 # TODO Check if already-forked feedstocks have open pulls.
-# TODO Clean up redundant version strings (see pypi_sha())
-# TODO Deal with having to change compression types in the new version
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -439,25 +439,32 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
             print('  {}'.format(update[0].full_name))
 
 
-if __name__ == "__main__":
+def main():
+    """
+    Parse command-line arguments and tun tick_feedstocks
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument('--password',
                         default=None,
-                        dest='password',
+                        dest='gh_password',
                         help='GitHub password or oauth token')
     parser.add_argument('--user',
                         default=None,
-                        dest='user',
+                        dest='gh_user',
                         help='GitHub username')
     parser.add_argument('--no-regenerate',
-                        action=store_true,
+                        action='store_true',
                         dest='no_regenerate',
                         help="If present, don't regenerate feedstocks after updating")
-    parse.add_argument('--dry-run',
-                       action=store_true
-                       dest='dry_run'
-                       help='If present, skip applying patches, forking, and regenerating feedstocks'
-    args=parser.parse_args()
+    parser.add_argument('--dry-run',
+                        action='store_true',
+                        dest='dry_run',
+                        help='If present, skip applying patches, forking, and regenerating feedstocks')
+    args = parser.parse_args()
 
-    tick_feedstocks(args['password'], args['user'],
-                    args['no_regenerate'], args['dry_run'])
+    tick_feedstocks(args.gh_password, args.gh_user,
+                    args.no_regenerate, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -371,8 +371,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     can_be_updated = deque()
     status_error_dict = defaultdict(list)
     up_to_date_count = 0
-    pbar = tqdm(feedstocks, desc='Checking feedstock statuses...')
-    for feedstock in pbar:
+    for feedstock in tqdm(feedstocks, desc='Checking feedstock statuses...'):
         status = feedstock_status(feedstock)
         if status.success and status.needs_update:
             can_be_updated.append(fs_status(feedstock, status))
@@ -390,8 +389,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     successful_updates = deque()
     patch_error_dict = defaultdict(list)
     error_dict = defaultdict(list)
-    pbar = tqdm(indep_updates, desc='Updating feedstocks')
-    for update in pbar:
+    for update in tqdm(indep_updates, desc='Updating feedstocks'):
         # generate basic patch
         patch = basic_patch(update.status.data.text,
                             update.status.data.yaml_strs,

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -449,7 +449,11 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
         r = requests.put(
             'https://api.github.com/repos/{}/contents/recipe/meta.yaml'.format(
                 fork.full_name),
-            json=patch.data,
+            json={'message':
+                  'Tick version to {}'.format(update.status.data.pypi_version),
+                  'content': patch.data,
+                  'sha': update.status.data.blob_sha
+                  },
             auth=(gh_user, gh_password))
         if not r.ok:
             error_dict["Couldn't apply patch"].append(update.fs.name)

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -191,7 +191,7 @@ def feedstock_status(feedstock):
     """
     Return whether or not a feedstock is out of date and any information needed to update it.
     :param github.Repository.Repository feedstock:
-    :return: `tpl(bool,bool,obj)` -- bools indicating success and either None or a tuple of data
+    :return: `tpl(bool,bool,None|status_data)` -- bools indicating success and either None or a status_data tuple
     """
 
     meta_yaml = feedstock.get_contents('recipe/meta.yaml')

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -379,7 +379,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
         else:
             up_to_date_count += 1
 
-    package_names = set([x[0].name[:-10] for x in can_be_updated])
+    package_names = set([x.fs.name[:-10] for x in can_be_updated])
 
     indep_updates = [x for x in can_be_updated
                      if len(x.status.data.reqs & package_names) < 1]

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -18,7 +18,7 @@
 # run_with: python
 
 """
-Usage: python tick_my_feedstocks.py [--password <github_password_or_oauth>] [--user <github_username>] [--no-regenerate --dry-run]
+Usage: python tick_my_feedstocks.py [--password <github_password_or_oauth>] [--user <github_username>] [--no-regenerate --no-rerender --dry-run]
 
 NOTE that your oauth token should have these abilities:
 * public_repo
@@ -474,14 +474,20 @@ def main():
                         action='store_true',
                         dest='no_regenerate',
                         help="If present, don't regenerate feedstocks after updating")
+    parser.add_argument('--no-rererender',
+                        action='store_true',
+                        dest='no_rerender',
+                        help="If present, don't regenerate feedstocks after updating")
     parser.add_argument('--dry-run',
                         action='store_true',
                         dest='dry_run',
                         help='If present, skip applying patches, forking, and regenerating feedstocks')
     args = parser.parse_args()
 
-    tick_feedstocks(args.gh_password, args.gh_user,
-                    args.no_regenerate, args.dry_run)
+    tick_feedstocks(args.gh_password,
+                    args.gh_user,
+                    args.no_regenerate and args.no_rerender,
+                    args.dry_run)
 
 
 if __name__ == "__main__":

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -221,9 +221,8 @@ def feedstock_status(feedstock):
     """
 
     meta_yaml = feedstock.get_contents('recipe/meta.yaml')
-
-    # yaml_dict = parsed_meta_yaml(meta_yaml.decoded_content)
     text = meta_yaml.decoded_content.decode('utf-8')
+
     yaml_dict = parsed_meta_yaml(text)
     if yaml_dict is None:
         return fs_tuple(False, False, 'Couldn\'t parse meta.yaml')

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -494,7 +494,7 @@ def main():
 
     tick_feedstocks(args.gh_password,
                     args.gh_user,
-                    args.no_regenerate and args.no_rerender,
+                    args.no_regenerate or args.no_rerender,
                     args.dry_run)
 
 

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -225,7 +225,7 @@ def feedstock_status(feedstock):
 
     yaml_dict = parsed_meta_yaml(text)
     if yaml_dict is None:
-        return fs_tuple(False, False, 'Couldn\'t parse meta.yaml')
+        return fs_tuple(False, False, "Couldn't parse meta.yaml")
 
     yaml_strs = dict()
     for x, y in [('version', ('package', 'version')),
@@ -238,7 +238,7 @@ def feedstock_status(feedstock):
 
     pypi_version = pypi_version_str(feedstock.full_name[12:-10])
     if pypi_version is False:
-        return fs_tuple(False, False, 'Couldn\'t find package in PyPI')
+        return fs_tuple(False, False, "Couldn't find package in PyPI")
 
     if parse_version(yaml_strs['version']) >= parse_version(pypi_version):
         return fs_tuple(True, False, None)

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -366,7 +366,10 @@ def regenerate_fork(fork):
     return True
 
 
-def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run=False):
+def tick_feedstocks(gh_password=None,
+                    gh_user=None,
+                    no_regenerate=False,
+                    dry_run=False):
     """
     Finds all of the feedstocks a user maintains that can be updated without
     a dependency conflict with other feedstocks the user maintains,
@@ -377,7 +380,6 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     :param bool no_regenerate: If True, don't regenerate feedstocks before submitting pull requests
     :param bool dry_run: If True, do not apply generate patches, fork feedstocks, or regenerate
     """
-
     if gh_password is None:
         gh_password = os.getenv('GH_TOKEN')
         if gh_password is None:
@@ -484,7 +486,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
 
         pull_count += 1
 
-    print('{} Total feedstocks checked.')
+    print('{} total feedstocks checked.'.format(len(feedstocks)))
     print('  {} were up-to-date.'.format(up_to_date_count))
     print('  {} were independent of other out-of-date feedstocks'.format(
         len(indep_updates)))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -8,6 +8,7 @@
 #  - beautifulsoup4
 #  - gitpython
 #  - jinja2
+#  - lxml
 #  - pygithub >=1.29
 #  - pyyaml
 #  - requests

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -57,6 +57,7 @@ IMPORTANT NOTES:
 # TODO Check special case of feedstocks renamed with 'python-' prefixes
 # TODO Check if already-forked feedstocks have open pulls.
 # TODO Clean up redundant version strings (see pypi_sha())
+# TODO Deal with having to change compression types in the new version
 
 import argparse
 from base64 import b64encode
@@ -128,7 +129,7 @@ def pypi_org_sha(package_name, version, bundle_type):
     :param str package_name: Name of package (PROPER case)
     :param str version: version for which to get sha
     :param str bundle_type: ".tar.gz", ".zip" - format of bundle
-    :returns: `str` -- SHA256 for a source bundle
+    :returns: `str|None` -- SHA256 for a source bundle, None if can't be found
     """
     r = requests.get('https://pypi.org/project/{}/{}/#files'.format(
         package_name,
@@ -153,9 +154,10 @@ def pypi_org_sha(package_name, version, bundle_type):
 
 def pypi_sha(source_fn, source_version, pypi_version):
     """
-    :param str source_fn:
-    :param str source_version:
-    :param str pypi_version:
+    :param str source_fn: The source bundle string - <package>-<version>.<compression>
+    :param str source_version: The version number in source_fn
+    :param str pypi_version: The version to be retrieved from PyPI.
+    :returns: `str|None` -- SHA256 for a source bundle, None if can't be found
     """
     package_name = '-'.join(source_fn.split('-')[:-1])
     bundle_type = source_fn.split(source_version)[-1]
@@ -169,8 +171,8 @@ def pypi_sha(source_fn, source_version, pypi_version):
 
 def pypi_version_str(package_name):
     """
-    Retrive the latest version of a package in pypi
-    :param str package_name:
+    Retrive the latest version of a package in PyPI
+    :param str package_name: The name of the package
     :return: `str` -- Version string
     """
     r = requests.get(pypi_pkg_uri(package_name))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -198,7 +198,7 @@ def user_feedstocks(user):
     :return: `list` -- list of conda-forge feedstocks the user maintains
     """
     feedstocks = []
-    for team in tqdm(user.get_teams(), desc='Getting my feedstocks...'):
+    for team in tqdm(user.get_teams(), desc='Finding feedstock teams...'):
 
         # Each conda-forge team manages one feedstock
         # If a team has more than one repo, skip it.
@@ -380,7 +380,8 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     successful_forks = []
     successful_updates = []
     error_dict = defaultdict(list)
-    for update in tqdm(indep_updates):
+    pbar = tqdm(indep_updates, desc='Updating feedstocks')
+    for update in pbar:
         # generate basic patch
         patch = basic_patch(update[1].data.text,
                             update[1].data.yaml_strs,

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -82,7 +82,7 @@ import yaml
 
 pypi_pkg_uri = 'https://pypi.python.org/pypi/{}/json'.format
 
-fs_tuple = namedtuple('fs_status', ['success', 'needs_update ', 'data'])
+fs_tuple = namedtuple('fs_tuple', ['success', 'needs_update', 'data'])
 
 status_data_tuple = namedtuple('status_data', ['text', 'yaml_strs',
                                                'pypi_version', 'reqs',

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -61,7 +61,6 @@ import argparse
 from base64 import b64encode
 from bs4 import BeautifulSoup
 from collections import defaultdict
-from collections import deque
 from collections import namedtuple
 import conda_smithy
 import conda_smithy.configure_feedstock
@@ -368,7 +367,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
 
     feedstocks = user_feedstocks(user)
 
-    can_be_updated = deque()
+    can_be_updated = list()
     status_error_dict = defaultdict(list)
     up_to_date_count = 0
     for feedstock in tqdm(feedstocks, desc='Checking feedstock statuses...'):
@@ -385,8 +384,8 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     indep_updates = [x for x in can_be_updated
                      if len(x.status.data.reqs & package_names) < 1]
 
-    successful_forks = deque()
-    successful_updates = deque()
+    successful_forks = list()
+    successful_updates = list()
     patch_error_dict = defaultdict(list)
     error_dict = defaultdict(list)
     for update in tqdm(indep_updates, desc='Updating feedstocks'):

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -431,17 +431,17 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
 
     pull_count = 0
     for update in tqdm(successful_updates, desc='Submitting pulls...'):
-        r = requests.post(update.fs.pulls_url.split('{')[0],
-                          json={'title': 'Ticked version, '
-                                'regenerated if needed. '
-                                '(Double-check reqs!)',
-                                'head': '{}:master'.format(gh_user),
-                                'base': 'master'},
-                          auth=(gh_user, gh_password))
-        if not r.ok:
-            error_dict["Couldn't create pull"].append(r)
-        else:
-            pull_count += 1
+        try:
+            update.fs.create_pull(title='Ticked version, '
+                                  'regenerated if needed. '
+                                  '(Double-check reqs!)',
+                                  body='',
+                                  head='{}:master'.format(gh_user),
+                                  base='master')
+        except GithubException:
+            continue
+
+        pull_count += 1
 
     print('{} Total feedstocks checked.')
     print('  {} were up-to-date.'.format(up_to_date_count))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -153,7 +153,7 @@ class Feedstock_Meta_Yaml:
         elif 'md5' in self._yaml_dict['source']:
             self.checksum_type = 'md5'
         else:
-            raise KeyError('Missing meta.yam key for checksum')
+            raise KeyError('Missing meta.yaml key for checksum')
 
         splitter = '-{}.'.format(self._yaml_dict['package']['version'])
         self.pypi_package, self.bundle_type = \

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -87,7 +87,6 @@ from tqdm import tqdm
 import yaml
 
 
-pypi_pkg_uri = 'https://pypi.python.org/pypi/{}/json'.format
 
 fs_tuple = namedtuple('fs_tuple', ['success', 'needs_update', 'data'])
 
@@ -179,9 +178,10 @@ def pypi_version_str(package_name):
     """
     Retrive the latest version of a package in PyPI
     :param str package_name: The name of the package
-    :return: `str` -- Version string
+    :return: `str|bool` -- Version string, False if unsuccessful
     """
-    r = requests.get(pypi_pkg_uri(package_name))
+    r = requests.get('https://pypi.python.org/pypi/{}/json'.format(
+        package_name))
     if not r.ok:
         return False
     return r.json()['info']['version'].strip()

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -510,19 +510,14 @@ def tick_feedstocks(gh_password=None,
 
     can_be_updated = list()
     status_error_dict = defaultdict(list)
-    up_to_date_count = 0
     for feedstock in tqdm(feedstocks, desc='Checking feedstock statuses...'):
         status = feedstock_status(feedstock)
-        if status.success:
-            if status.data is None:
-                up_to_date_count += 1
-            else:
-                can_be_updated.append(fs_status(feedstock, status.data))
-        else:
+        if status.success and status.data is not None:
+            can_be_updated.append(fs_status(feedstock, status.data))
+        elif not status.success:
             status_error_dict[status.data].append(feedstock.name)
 
     package_names = set([x.fs.name[:-10] for x in can_be_updated])
-
     indep_updates = [x for x in can_be_updated
                      if len(x.sd.meta_yaml.reqs & package_names) < 1]
 
@@ -605,7 +600,7 @@ def tick_feedstocks(gh_password=None,
         pull_count += 1
 
     print('{} total feedstocks checked.'.format(len(feedstocks)))
-    print('  {} were up-to-date.'.format(up_to_date_count))
+    print('  {} were out-of-date.'.format(len(can_be_updated)))
     print('  {} were independent of other out-of-date feedstocks'.format(
         len(indep_updates)))
     print('  {} had pulls submitted.'.format(pull_count))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -18,7 +18,11 @@
 # run_with: python
 
 """
-Usage: python tick_my_feedstocks.py [--password <github_password_or_oauth>] [--user <github_username>] [--no-regenerate --no-rerender --dry-run]
+Usage:
+python tick_my_feedstocks.py
+[--password <github_password_or_oauth>]
+[--user <github_username>]
+[--no-regenerate --no-rerender --dry-run]
 
 NOTE that your oauth token should have these abilities:
 * public_repo
@@ -53,6 +57,7 @@ IMPORTANT NOTES:
 # TODO Test python 3.4 compatability (should work, but untested.)
 # TODO Test python 3.6 compatability (should work, but untested.)
 # TODO Deeper check of dependency changes in meta.yaml.
+# TODO reset build number back to zero
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 # TODO Check special case of feedstocks renamed with 'python-' prefixes
 # TODO Check if already-forked feedstocks have open pulls.
@@ -213,7 +218,7 @@ def basic_patch(text, replace_dict):
     find and replace old versions and hashes, and create a patch.
     :param str text: The raw text of the current meta.yaml
     :param dict[tpl] replace_dict: keys are IDs of text to be replaced. First val in tpl is original text, second is replacement.
-    :return: `patch_tuple` -- True and encoded patch if success, false and error otherwise
+    :return: `patch_tuple` -- True and encoded patch if success, false and error string otherwise
     """
     for key in replace_dict:
         if text.find(replace_dict[key][0]) < 0:
@@ -247,7 +252,7 @@ def user_feedstocks(user):
 
 def feedstock_status(feedstock):
     """
-    Return whether or not a feedstock is out of date and any information needed to update it.
+    Return whether a feedstock is out of date and any information needed to update it.
     :param github.Repository.Repository feedstock:
     :return: `tpl(bool,bool,None|status_data)` -- bools indicating success and either None or a status_data tuple
     """

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -387,8 +387,8 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     indep_updates = [x for x in can_be_updated
                      if len(x.status.data.reqs & package_names) < 1]
 
-    successful_forks = []
-    successful_updates = []
+    successful_forks = deque()
+    successful_updates = deque()
     patch_error_dict = defaultdict(list)
     error_dict = defaultdict(list)
     pbar = tqdm(indep_updates, desc='Updating feedstocks')

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -381,9 +381,9 @@ def feedstock_status(feedstock):
     try:
         meta_yaml = Feedstock_Meta_Yaml(
             fs_contents.decoded_content.decode('utf-8'))
-    except (UndefinedError, KeyError):
+    except (UndefinedError, KeyError) as e:
         # TODO fix this to use the passed error message
-        return result_tuple(False, "Couldn't parse meta.yaml")
+        return result_tuple(False, e.args[0])
 
     pypi_version = pypi_version_str(meta_yaml.pypi_package)
     if pypi_version is False:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -408,7 +408,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
         # make fork
         fork = even_feedstock_fork(user, update.fs)
         if fork is None:
-            error_dict["Couldn't Fork"].append(update.fs.name)
+            error_dict["Couldn't fork"].append(update.fs.name)
             continue
 
         # patch fork
@@ -418,7 +418,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
             json=patch.data,
             auth=(user.login, gh_password))
         if not r.ok:
-            error_dict["Couldn't Apply Patch"].append(update.fs.name)
+            error_dict["Couldn't apply patch"].append(update.fs.name)
             continue
 
         successful_updates.append(update)
@@ -443,18 +443,18 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
     print('  {} had pulls submitted.'.format(len(successful_updates)))
     print('-----')
 
-    for msg, cur_dict in [("Couldn't Check Status", status_error_dict),
-                          ("Couldn't Create Patch", patch_error_dict)]:
+    for msg, cur_dict in [("Couldn't check status", status_error_dict),
+                          ("Couldn't create patch", patch_error_dict)]:
         if len(cur_dict) > 0:
             print('{}:'.format(msg))
             for error_msg in cur_dict:
-                print('  {} ({})'.format(error_msg,
+                print('  {} ({}):'.format(error_msg,
                                          len(cur_dict[error_msg])))
                 for name in cur_dict[error_msg]:
                     print('    {}'.format(name))
 
-    for error_msg in ["Couldn't Fork",
-                      "Couldn't Apply Patch"]:
+    for error_msg in ["Couldn't fork",
+                      "Couldn't apply patch"]:
         if error_msg not in error_dict:
             continue
         print('{} ({}):'.format(error_msg, len(error_dict[error_msg])))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -2,7 +2,7 @@
 
 # conda execute
 # env:
-#  - python =3.5
+#  - python ==3.5
 #  - conda-build
 #  - conda-smithy
 #  - beautifulsoup4
@@ -44,7 +44,6 @@ IMPORTANT NOTES:
   tests may still pass successfully.
 """
 
-# TODO test command line invocation
 # TODO debug .create_pull()
 # TODO pass token/user to pygithub for push. (Currently uses system config.)
 # TODO Test --no-regenerate flag

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -2,7 +2,7 @@
 
 # conda execute
 # env:
-#  - python >=3.5
+#  - python =3.5
 #  - conda-build
 #  - conda-smithy
 #  - beautifulsoup4
@@ -54,6 +54,7 @@ IMPORTANT NOTES:
 # TODO Add support for skipping repos that are deprecated. (e.g. fake-factory)
 # TODO Test python 2.7 compatability (should work, but untested.)
 # TODO Test python 3.4 compatability (should work, but untested.)
+# TODO Test python 3.6 compatability (should work, but untested.)
 # TODO Deeper check of dependency changes in meta.yaml.
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -56,7 +56,7 @@ IMPORTANT NOTES:
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 # TODO Check special case of feedstocks renamed with 'python-' prefixes
 # TODO Check if already-forked feedstocks have open pulls.
-# TODO Refactor basic patch around find/replace
+# TODO Clean up redundant version strings (see pypi_sha())
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -22,16 +22,14 @@ TKTKTK
 """
 
 # TODO strip out rerender.sh if possible
-# TODO when pygithub gets updated, add .create_pull() code
+# TODO debug .create_pull()
 # TODO Add --no-rerender option (stub until .create_pull())
 # TODO Add support for skipping repos (e.g. fake-factory)
 # TODO verify python 2.7 compatability
 
 import argparse
 from base64 import b64encode
-from base64 import b64decode
 from bs4 import BeautifulSoup
-import codecs
 from collections import defaultdict
 from collections import namedtuple
 import conda_smithy
@@ -46,8 +44,7 @@ import os
 from pkg_resources import parse_version
 import re
 import requests
-import shutil
-import subprocess
+# import subprocess
 import tempfile
 from tqdm import tqdm
 import yaml
@@ -200,7 +197,7 @@ def feedstock_status(feedstock):
     meta_yaml = feedstock.get_contents('recipe/meta.yaml')
 
     # yaml_dict = parsed_meta_yaml(meta_yaml.decoded_content)
-    text = codecs.decode(b64decode(meta_yaml.content))
+    text = meta_yaml.decoded_content.decode('utf-8')
     yaml_dict = parsed_meta_yaml(text)
     if yaml_dict is None:
         return fs_tuple(False, False, 'Couldn\'t parse meta.yaml')
@@ -391,7 +388,6 @@ def tick_feedstocks(gh_password=None, gh_user=None):
         successful_updates.append(update)
         successful_forks.append(fork)
 
-    subprocess.run(['conda', 'update', '-y', 'conda-smithy'])
     for fork in tqdm(successful_forks, desc='Rerendering feedstocks...'):
         rerender_fork(fork)
 

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -350,49 +350,6 @@ def pypi_version_str(package_name):
     return r.json()['info']['version'].strip()
 
 
-def parsed_meta_yaml(text):
-    """
-    :param str text: The raw text in conda-forge feedstock meta.yaml file
-    :return: `dict|None` -- parsed YAML dict if successful, None if not
-    """
-    try:
-        yaml_dict = yaml.load(Template(text).render(),
-                              Loader=yaml.BaseLoader)
-    except UndefinedError:
-        # assume we hit a RECIPE_DIR reference in the vars and can't parse it.
-        # just erase for now
-        try:
-            yaml_dict = yaml.load(
-                Template(re.sub('{{ (environ\[")?RECIPE_DIR("])? }}/',
-                                '',
-                                text)
-                         ).render(),
-                Loader=yaml.BaseLoader)
-        except:
-            return None
-    except:
-        return None
-
-    return yaml_dict
-
-
-def basic_patch(text, replace_dict):
-    """
-    Given a meta.yaml file, version strings, and appropriate hashes,
-    find and replace old versions and hashes, and create a patch.
-    :param str text: The raw text of the current meta.yaml
-    :param dict[tpl] replace_dict: keys are IDs of text to be replaced. First val in tpl is original text, second is replacement.
-    :return: `patch_tuple` -- True and encoded patch if success, false and error string otherwise
-    """
-    for key in replace_dict:
-        if text.find(replace_dict[key][0]) < 0:
-            return patch_tuple(False,
-                               "Couldn't find current {} in meta.yaml".format(key))
-            text = text.replace(replace_dict[key][0], replace_dict[key][1])
-
-    return patch_tuple(True, b64encode(text.encode('utf-8')).decode('utf-8'))
-
-
 def user_feedstocks(user):
     """
     :param github.AuthenticatedUser.AutheticatedUser user:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -149,10 +149,10 @@ def basic_patch(text, yaml_strs, pypi_version, blob_sha):
     """
     Given a meta.yaml file, version strings, and appropriate hashes,
     find and replace old versions and hashes, and create a patch.
-    :param str text: The raw text
-    :param dict yaml_strs:
-    :param str pypi_version:
-    :param str blob_sha:
+    :param str text: The raw text of the current meta.yaml
+    :param dict yaml_strs: Dict with 'source_fn', 'version', and 'sha256' values parsed from yaml
+    :param str pypi_version: The new version string from PyPI  
+    :param str blob_sha: the commit SHA code.
     :return: `tpl(bool,str|dict)` -- True if success and commit dict for github, false and error otherwise
     """
     pypi_sha = pypi_org_sha(

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -86,12 +86,21 @@ import tempfile
 from tqdm import tqdm
 import yaml
 
+# Find places where Jinja variables are set
+jinja_set_regex = re.compile('{% *set +([^ ]+) *= "?([^ "]+)"? *%}')
 
+# Find places where YAML variables are assigned using Jinja variables
+yaml_jinja_assign_regex = re.compile(' +([^:]+): *[^ ]*({{ .* }}.*)')
 
 fs_tuple = namedtuple('fs_tuple', ['success', 'needs_update', 'data'])
 
 status_data = namedtuple('status_data', ['text', 'yaml_strs',
                                          'pypi_version', 'reqs',
+# Jinja template informaton
+# Value being set and the setting string
+# tpl(str, str)
+jinja_var = namedtuple('jinja_var', ['value', 'string'])
+
                                          'blob_sha'])
 
 fs_status = namedtuple('fs_status', ['fs', 'status'])

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -56,6 +56,7 @@ IMPORTANT NOTES:
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 # TODO Check special case of feedstocks renamed with 'python-' prefixes
 # TODO Check if already-forked feedstocks have open pulls.
+# TODO Refactor basic patch around find/replace
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -484,7 +484,7 @@ def tick_feedstocks(gh_password=None,
             update.fs.create_pull(title='Ticked version, '
                                   'regenerated if needed. '
                                   '(Double-check reqs!)',
-                                  body='',
+                                  body='(Built using tick_my_feedstocks)',
                                   head='{}:master'.format(gh_user),
                                   base='master')
         except GithubException:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -48,7 +48,7 @@ IMPORTANT NOTES:
   conda-forge tests are lightweight, even if the requirements have changed the
   tests may still pass successfully.
 """
-
+# TODO Finish refactoring meta yaml as a class
 # TODO pass token/user to pygithub for push. (Currently uses system config.)
 # TODO Modify --dry-run flag to list which repos need forks.
 # TODO Modify --dry-run flag to list which forks are dirty.

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -193,7 +193,7 @@ class Feedstock_Meta_Yaml:
         Get current build number.
         :return: `str` -- the extracted build number
         """
-        return str(self._yaml_dict['package']['number'])
+        return str(self._yaml_dict['build']['number'])
 
     def version(self):
         """

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -586,7 +586,7 @@ def tick_feedstocks(gh_password=None,
             update.fs.create_pull(title='Ticked version, '
                                   'regenerated if needed. '
                                   '(Double-check reqs!)',
-                                  body='(Built using tick_my_feedstocks)',
+                                  body='(Made using `tick_my_feedstocks.py`)',
                                   head='{}:master'.format(gh_user),
                                   base='master')
         except GithubException:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -39,6 +39,7 @@ This isn't a replacement for a maintainer, just a support tool.
 # TODO Add support for skipping repos (e.g. fake-factory)
 # TODO verify python 2.7 and 3.4 compatability (should work, but untested.)
 # TODO deeper check of dependencies of new feedstock against conda-forge dependencies?
+# TOD Add dry run mode that checks for packages that need updating and whether or not they can be patched but commits nothing.
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -57,6 +57,7 @@ IMPORTANT NOTES:
 # TODO Test python 3.6 compatability (should work, but untested.)
 # TODO Deeper check of dependency changes in meta.yaml.
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
+# TODO Check special case of feedstocks renamed with 'python-' prefixes
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -84,9 +84,10 @@ pypi_pkg_uri = 'https://pypi.python.org/pypi/{}/json'.format
 
 fs_tuple = namedtuple('fs_tuple', ['success', 'needs_update', 'data'])
 
-status_data_tuple = namedtuple('status_data', ['text', 'yaml_strs',
-                                               'pypi_version', 'reqs',
-                                               'blob_sha'])
+status_data = namedtuple('status_data', ['text', 'yaml_strs',
+                                         'pypi_version', 'reqs',
+                                         'blob_sha'])
+
 
 
 def pypi_org_sha(package_name, version, bundle_type):
@@ -249,11 +250,11 @@ def feedstock_status(feedstock):
 
     return fs_tuple(True,
                     True,
-                    status_data_tuple(text,
-                                      yaml_strs,
-                                      pypi_version,
-                                      reqs - {'python', 'setuptools'},
-                                      meta_yaml.sha))
+                    status_data(text,
+                                yaml_strs,
+                                pypi_version,
+                                reqs - {'python', 'setuptools'},
+                                meta_yaml.sha))
 
 
 def get_user_fork(user, feedstock):

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -237,7 +237,9 @@ class Feedstock_Meta_Yaml:
             # assignment
             build_var = self.yaml_jinja_refs['number'].split()[1]
             mapping = {self.jinja_vars[build_var].string:
-                       '{% set {} = {} %}'.format(build_var, new_number)}
+                       '{{% set {key} = {val} %}}'.format(
+                       key=build_var,
+                       val=new_number)}
         else:
             build_num_regex = re.compile('number: *{}'.format(
                 self._yaml_dict['build']['number']))

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -464,7 +464,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
 
 def main():
     """
-    Parse command-line arguments and tun tick_feedstocks
+    Parse command-line arguments and run tick_feedstocks()
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('--password',

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -2,7 +2,7 @@
 
 # conda execute
 # env:
-#  - python >=2.7
+#  - python >=3.5
 #  - conda-build
 #  - conda-smithy
 #  - beautifulsoup4
@@ -18,14 +18,27 @@
 # run_with: python
 
 """
-TKTKTK
+Usage: python tick_my_feedstocks.py [--password <github_password_or_oauth>] [--user <github_username>]
+NOTE that your oauth token should have these abilities: public_repo, read:org, delete_repo.
+
+This script
+* identifies all of the feedstocks maintained by a user
+* attempts to determine F, the subset of feedstocks that need updating
+* attempts to determine F_i, the subset of F that have no dependencies on other members of F
+* attempts to patch each member of F_i with the new version number and hash
+* attempts to rerender each member of F_i with the installed version of conda-smithy
+* submits a pull request for each member of F_i to the appropriate conda-forge repoository
+
+All feedstocks updated with this script should be double-checked in case build or run dependencies have changed!
+This isn't a replacement for a maintainer, just a support tool.
 """
 
-# TODO strip out rerender.sh if possible
-# TODO debug .create_pull()
+# TODO debug .create_pull() / replace with call to requests
+# TODO pass token/user to pygithub for push. (Currently uses system config., which is an assumption)
 # TODO Add --no-rerender option (stub until .create_pull())
 # TODO Add support for skipping repos (e.g. fake-factory)
-# TODO verify python 2.7 compatability
+# TODO verify python 2.7 and 3.4 compatability (should work, but untested.)
+# TODO deeper check of dependencies of new feedstock against conda-forge dependencies?
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -39,8 +39,9 @@ This isn't a replacement for a maintainer, just a support tool.
 # TODO Test --no-regenerate flag
 # TODO Test --dry-run flag
 # TODO Add support for skipping repos that are deprecated. (e.g. fake-factory)
-# TODO verify python 2.7 and 3.4 compatability (should work, but untested.)
-# TODO deeper check of dependencies of new feedstock against conda-forge dependencies?
+# TODO Test python 2.7 compatability (should work, but untested.)
+# TODO Test python 3.4 compatability (should work, but untested.)
+# TODO deeper check of dependencies of new feedstock against conda-forge dependencies for better patching?
 
 import argparse
 from base64 import b64encode

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -356,8 +356,8 @@ def regenerate_fork(fork):
     commit_msg = 'MNT: Updated the feedstock for conda-smithy version {}.'.format(
         conda_smithy.__version__)
     r.git.add('-A')
-    commit = r.index.commit(commit_msg,
-                            author=Actor(fork.owner.login, fork.owner.email))
+    r.index.commit(commit_msg,
+                   author=Actor(fork.owner.login, fork.owner.email))
     r.git.push()
 
     working_dir.cleanup()
@@ -431,7 +431,7 @@ def tick_feedstocks(gh_password=None, gh_user=None, no_regenerate=False, dry_run
                              })
 
         if not patch.success:
-            # couldn't apply patch
+            # couldn't create
             patch_error_dict[patch.data].append(update.fs.name)
             continue
 


### PR DESCRIPTION
Adds a script, `tick_my_feedstocks.py` that can be run locally to check all of a given user's feedstocks to see if they are current, patch their version numbers and checksums, regenerate feedstocks, and submit pulls.

The script should work with `conda-execute`, but running it currently results in a crash. This *appears* to be an issue with `conda-execute` itself, but this needs some verification.