### PR TITLE
Add general meeting minutes for 2016-09-23 [ci skip]

### DIFF
--- a/minutes/2016-09-23.md
+++ b/minutes/2016-09-23.md
@@ -1,0 +1,105 @@
+## 2016-09-23 (postponed from 16th): General Discussion
+
+Time: 14:00 UTC (<s>Doodle poll for time preferences: </s>[](http://doodle.com/poll/qeubq3sn6rk66hz5))<s>[http://doodle.com/poll/qeubq3sn6rk66hz5](http://doodle.com/poll/qeubq3sn6rk66hz5))</s>
+
+Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)
+
+**Attendees**
+
+*   Jonathan, Phil, John, Filipe,  Eric, Sylvain
+*   **Apologies**
+*   Michael (re 16th): wife's water broke. Probably not going to make this one. 
+
+**Standing Items**
+
+*   How many repos? ~1200
+*   How many contributors? ~230
+
+**Notes**
+
+*   Recipe license to include in feedstock?
+
+        *   Where to include?  In recipe? Should not be license for the package but rather for the **recipe.**
+    *   Not many
+    *   Deal with on-case-by case basis as extra commit on feedstock.
+
+*   Moving to conda build 2.0 requires rebuilding ~35 packages.
+
+        *   Rebuilding should be done before moving all feedstocks to new version
+    *   Not backwards incompatible.  Mixing short and long prefix will results in short prefixes.
+    *   Filipe has done this with his own build system, maybe some issues on Windows.
+
+    *   This is the issue our Windows tech is seeing [conda/conda build#1383](https://github.com/conda/conda-build/pull/1383)
+
+    *   Conclusion: start rebuilding packages that use short binary prefix, then flip switch on all recipes.
+
+*   Phil will be in Oz for next 6 months (Melbourne: UTC +10)
+*   Next meeting schedule with doodle
+*   Sylvain -- mixing VC runtimes
+
+        *   Recommend that these be placed in a different channel
+    *   Python 2.7 with VC 14/2015 should be considered a new version.
+    *   Proposal is to build extensions with VC 14 not Python itself
+    *   [conda forge/feather format feedstock#7](https://github.com/conda-forge/feather-format-feedstock/pull/7)
+    *   [conda forge/feather format feedstock#6](https://github.com/conda-forge/feather-format-feedstock/pull/6)
+    *   CFEP -- with types of errors we can see
+
+*   conda-smithy release -- Maybe Monday?
+*   Do not know why rerendering is happening slowly
+
+        *   Rerendering happens on Heroku, max 5 PR but can up limit
+
+*   CFEP -- if you have not looked at them CFEP 01 do so soon:
+
+        *   [conda forge/conda forge enhancement proposals#1](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/1)
+    *   Can CFEPs change after the fact
+    *   What is consensus?  BDFL, vote, vetos (like NumPy?), other?
+
+                *   majority of  core member -- at meetings
+
+        *   Formal Government document, which includes how consensus is reached. -- or should this be seperate
+    *   Start repo with 
+
+*   Have a look at 
+
+        *   [conda forge/conda forge enhancement proposals#3](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3)
+    *   Labels for Python 3.6 -- Jonathan will add comment
+    *   Offer ability to build against Python 3.6?
+
+**Agenda**
+
+*   Recipe licenses, see [conda forge/conda smithy#230](https://github.com/conda-forge/conda-smithy/pull/230) and [conda forge/conda smithy#229](https://github.com/conda-forge/conda-smithy/issues/229)
+*   Moving to conda build 2.0
+
+*   Meeting time roadblock Oct-May ;)
+*   Next meeting: 2016-09-30 @ 14:00 UTC
+*   CUDA/cuDNN update -- delay until Michael is back
+*   Dev releases: Where do they happen? [conda forge/conda forge enhancement proposals#3](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3)
+*   CFEPs - [conda forge/conda forge enhancement proposals#1](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/1)
+
+*   Binary data in recipes
+*   conda-forge installer (our own Miniconda)
+
+        *   Name? - [conda forge/conda forge anvil#1](https://github.com/conda-forge/conda-forge-anvil/issues/1)
+    *   Included channels? - [conda forge/conda forge anvil#5](https://github.com/conda-forge/conda-forge-anvil/issues/5)
+    *   Included packages? - [conda forge/conda forge anvil#8](https://github.com/conda-forge/conda-forge-anvil/issues/8)
+    *   Versioning? - [conda forge/conda forge anvil#9](https://github.com/conda-forge/conda-forge-anvil/issues/9)
+
+*   [Staged Releases](https://conda-forge.hackpad.com/DZNKZdgiMbF)
+*   Smoothly handling CI registration failures during conversion - [conda forge/staged recipes#1466](https://github.com/conda-forge/staged-recipes/pull/1466)
+*   Handling broken packages
+
+        *   Whether to delete or not
+
+                *   Relabeling instead - [conda forge/conda forge.github.io#181](https://github.com/conda-forge/conda-forge.github.io/issues/181)
+        *   Deletion controversy - [conda forge/conda forge.github.io#220](https://github.com/conda-forge/conda-forge.github.io/issues/220)
+        *   Retention Policy CFEP? - [conda forge/conda forge.github.io#220](https://github.com/conda-forge/conda-forge.github.io/issues/220)#issuecomment-245478336
+
+        *   Hot fixing - [conda forge/conda forge.github.io#170](https://github.com/conda-forge/conda-forge.github.io/pull/170)
+
+*   Mention [conda forge upload service](https://conda-forge.hackpad.com/N5evEX7bZAf) idea
+*   Build infrastructure status - [conda/build_infrastructure#1](https://github.com/conda/build_infrastructure/issues/1)
+*   Team update web service - [conda forge/conda forge webservices#63](https://github.com/conda-forge/conda-forge-webservices/issues/63)
+*   Windows BLAS Solutions
+
+*   Modern C++ , MSVC and Python < 3.5 


### PR DESCRIPTION
This is a markdown converted copy of the meeting minutes from the general meeting on 2016-09-23 for archival. Please let me know if there need to be any changes. Will merge in 24hrs if there are no changes.

In attendance: @jjhelmus @pelson @jakirkham @ocefpaf @ericdill @SylvainCorlay

Note: Admittedly this is quite old. Trying to get everything exported from Hackpad to here before we convert to Dropbox Paper in case things get lost in the conversion.