### PR TITLE
Add operational meeting minutes for 2016-11-17 [ci skip]

### DIFF
--- a/minutes/2016-11-17.md
+++ b/minutes/2016-11-17.md
@@ -1,0 +1,21 @@
+## 2016-11-17: Operational catchup
+
+Time: 20:00 (UTC)
+
+Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)
+
+**Attendees**
+
+*   Phil Elson
+*   [Filipe Fernandes](https://twitter.com/ocefpaf)
+*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+*   Ray Donnelly
+*   [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+
+**Notes**
+
+*
+
+**Agenda**
+
+*   Any operational issues that need to be addressed over the next few days/weeks/months


### PR DESCRIPTION
This is a markdown converted copy of the meeting minutes from the operational meeting on 2016-11-17 for archival. Please let me know if there need to be any changes. Will merge in 24hrs if there are no changes.

In attendance: @pelson @ocefpaf @jakirkham @mingwandroid @msarahan

Note: Admittedly this is quite old. Trying to get everything exported from Hackpad to here before we convert to Dropbox Paper in case things get lost in the conversion. Also this was an operational meeting with relatively little written. Still exporting it to make sure I got everything.