### PR TITLE
Add general meeting minutes for 2016-11-24 [ci skip]

### DIFF
--- a/minutes/2016-11-24.md
+++ b/minutes/2016-11-24.md
@@ -1,0 +1,67 @@
+## 2016-11-24: General Discussion
+
+Time: 20:00 (UTC)
+
+Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)
+
+**Attendees**
+
+*   Filipe
+*   Mike
+*   Phil
+
+**Standing Items**
+
+*   How many repos? ~1400
+*   How many contributors? ~300
+*   CFEP status
+
+**Notes**
+
+*   Action: Phil to take a look at [conda forge/conda forge.github.io#256](https://github.com/conda-forge/conda-forge.github.io/pull/256)
+*   Filipe will ask Carlos whether he is prepared to build qt 
+*   Binary data (repacking)
+
+        *   Currently done with "low hanging fruit" or difficult packages
+    *   CFEP would be helpful to give clear guidance
+    *   What does it take to merge repackaging stuff?  At what point does it become painful enough to allow repackaging?  
+    *   MSYS2 - [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS) to ask Ray about build infrastructure for MSYS2 and perhaps unification with conda/conda-forge
+    *   Git  for windows as example to avoid (Large agglomeration of individual  projects - prefer to build individual projects).  If MSYS2 were not  available, this would be an OK candidate for repackaging, because it is  such a huge pain.  Because MSYS2 is available, we should avoid  repackaging git for windows.
+
+*   conda-build 2
+
+        *   bldpkg_path also takes a config argument. See [](https://circleci.com/gh/conda-forge/texinfo-feedstock/24)[https://circleci.com/gh/conda-forge/texinfo-feedstock/24](https://circleci.com/gh/conda-forge/texinfo-feedstock/24)
+
+    *   There is very little that needs to be done. See [conda forge/conda forge build setup feedstock#38](https://github.com/conda-forge/conda-forge-build-setup-feedstock/issues/38)#issuecomment-262931757
+    *   (It is a matter of merging PRs now :-) 
+
+    *   can we just disable symlinks for environments when building to fix the CMAKE issue? Phil: I believe so. MS +1
+
+                *   [](http://conda.pydata.org/docs/config.html#disallow-soft-linking-allow-softlinks)[http://conda.pydata.org/docs/config.html#disallow-soft-linking-allow-softlinks](http://conda.pydata.org/docs/config.html#disallow-soft-linking-allow-softlinks)
+
+        *   ACTION: Let's get rid of softlinks when using conda-build
+
+*   Handling broken packages
+
+        *   Hotfix  capability: we will never have control of the channel index, so we must  rebuild or modify existing packages. MS: There should be a preference  for rebuild vs modify. CFEP (policy) would be helpful.
+    *   Generally,  moving broken packages to a "broken" channel is preferable to deleting  them. We can consider purging these after a period of time.
+
+**Agenda**
+
+*   <s>Binary data in recipes </s>Repackaging existing executables
+*   conda-forge installer (our own Miniconda)
+
+*   [Staged Releases](https://conda-forge.hackpad.com/DZNKZdgiMbF)
+*   Smoothly handling CI registration failures during conversion - [conda forge/staged recipes#1466](https://github.com/conda-forge/staged-recipes/pull/1466)
+*   Handling broken packages
+
+*   Mention [conda forge upload service](https://conda-forge.hackpad.com/N5evEX7bZAf) idea
+*   Build infrastructure status - [conda/build_infrastructure#1](https://github.com/conda/build_infrastructure/issues/1)
+*   Team update web service - [conda forge/conda forge webservices#63](https://github.com/conda-forge/conda-forge-webservices/issues/63)
+*   Windows BLAS Solutions
+
+*   Build/Upload Qt
+*   Move to conda-build 2!
+*   conda-forge.org
+
+*   pycon 2017


### PR DESCRIPTION
This is a markdown converted copy of the meeting minutes from the general meeting on 2016-11-24 for archival. Please let me know if there need to be any changes. Will merge in 24hrs if there are no changes.

In attendance: @ocefpaf @msarahan @pelson

Note: Admittedly this is quite old. Trying to get everything exported from Hackpad to here before we convert to Dropbox Paper in case things get lost in the conversion.