### PR TITLE
Add general meeting minutes for 2017-01-06 [ci skip]

### DIFF
--- a/minutes/2017-01-06.md
+++ b/minutes/2017-01-06.md
@@ -1,0 +1,65 @@
+## 2017-01-06: General Discussion
+
+Time: 20:00 (UTC)
+
+Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)
+
+**Attendees**
+
+*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+*   Ray Donnelly
+*   Filipe Fernandes
+*   [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+*   [Peter Williams](https://conda-forge.hackpad.com/ep/profile/Gxz5eDxqYrB)
+*   [Eric Dill](https://conda-forge.hackpad.com/ep/profile/yJqDqpPqJyz)
+
+**Standing Items**
+
+*   How many repos? ~1400
+*   How many contributors? ~300
+*   CFEP status
+
+**Notes**
+
+*   Options for packaging X.org libraries.
+
+        *   Bundle them together [PR#2068](https://github.com/conda-forge/staged-recipes/pull/2068).
+    *   Use build customization to do one build and split out multiple packages.
+
+*   Drop numpy 1.10 but leave Python 3.4 for a while longer.
+*   John will build Qt 4 on OS X.
+*   Ray will build Qt 5 with jpeg 9* soon on defaults and our problem will go away.
+*   conda-build 2
+
+        *   do not wait for the remaining packages that needs long prefix
+    *   merge [conda forge/conda forge build setup feedstock#40](https://github.com/conda-forge/conda-forge-build-setup-feedstock/issues/40)
+    *   investigate why pestc is not uploading
+
+*   Move MACOSX_DEPLOYMENT_TARGET variable to conda-build-setup and modify the CFEP to reflect that.
+
+**Agenda**
+
+*   pkgw would like to discuss bundling X.org client libraries in the conda-forge stack, as per [PR#2068](https://github.com/conda-forge/staged-recipes/pull/2068). The PR has everything bundled into a giant tarball for simplicity; gqmelo posted [a set of recipes](https://github.com/ESSS/xorg-recipes) that splits each library out.
+
+*   Defaults  channel libpng and jpeg updates: scheduled for 1Q 2017.  Continuum  requests closer collaboration on future api/abi incompatible updates to  core libraries.
+
+*   One pinning scheme for both defaults and conda-forge?
+*   That would be ideal.  Hopefully we can head that way.
+
+*   Drop  Python 3.4. Now that conda-forge have Qt 4+jpeg9* on Windows the Python  3.5+Windows users can migrate from Python 3.4 to 3.5.
+
+*   Do MinGW compile things that play well with Python 3.5/MSVC 2015 yet? AFAICT this is still an [issue](http://bugs.python.org/issue4709).
+
+*   Drop numpy 110
+*   Upload of Qt 4 for OS X
+
+*   Have a VM I'm willing to use to do this. Details [here](https://github.com/boxcutter/macos).
+
+*   Build and upload of Qt 5+jpeg 9* for all platforms
+*   PyCon  2017. Just submitted a place holder talk as we lost the tutorial  deadline and the talk deadline is today. Anyone interested in  participating please get in touch.
+
+*   Re-rendering channel improvements. ( [conda forge/conda smithy#401](https://github.com/conda-forge/conda-smithy/pull/401) )
+
+*   conda-build 2 ( [conda forge/conda forge build setup feedstock#40](https://github.com/conda-forge/conda-forge-build-setup-feedstock/issues/40) )
+*   Travis CI image change. ( [conda forge/conda forge enhancement proposals#6](https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6) )
+*   conda-smithy and conda 4.2 ( [conda forge/conda smithy#394](https://github.com/conda-forge/conda-smithy/pull/394) )


### PR DESCRIPTION
This is a markdown converted copy of the meeting minutes from the general meeting on 2017-01-06 for archival. Please let me know if there need to be any changes. Will merge in 24hrs if there are no changes.

In attendance: @jakirkham @mingwandroid @ocefpaf @msarahan @pkgw @ericdill

Note: Admittedly this is quite old. Trying to get everything exported from Hackpad to here before we convert to Dropbox Paper in case things get lost in the conversion.