### PR TITLE
Switch email to @conda-forge-coordinator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
     - git config --global user.name "Travis-CI on github.com/conda-forge/conda-forge.github.io"
-    - git config --global user.email pelson.pub+conda-forge@gmail.com
+    - git config --global user.email conda.forge.coordinator@gmail.com
     - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token
 
     # Now do the things we need to do to install it.


### PR DESCRIPTION
This is a follow-up to PR ( https://github.com/conda-forge/conda-forge.github.io/pull/341 ).

Instead of using the email associated with @conda-forge-admin , switch to using the email associated with @conda-forge-coordinator . It's possible that using the former bot's email (even though its GitHub token is not being used) is somehow causing rate limiting to occur for @conda-forge-admin . So this should eliminate that potential issue.

cc @isuruf