### PR TITLE
defatuls pin info

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -25,49 +25,52 @@ import conda_smithy.github
 import conda_smithy.feedstocks as feedstocks
 
 
+# The version commented right after the comma is the one available for **Linux** in **defaults**.
+# That version is assumed to be the same in all platforms and the one used to build all packages.
+# The only known incompatibilities at the moment are jpeg 8 vs 9, and icu 54.1 vs 58.*.
 pinned = {
-          'boost': 'boost 1.64.*',
-          'boost-cpp': 'boost-cpp 1.64.*',
-          'bzip2': 'bzip2 1.0.*',
-          'cairo': 'cairo 1.14.*',
-          'ffmpeg': 'ffmpeg 2.8.*',
-          'fontconfig': 'fontconfig 2.12.*',
-          'freetype': 'freetype 2.7|2.7.*',
-          'geos': 'geos 3.5.1',
-          'giflib': 'giflib 5.1.*',
-          'glib': 'glib 2.51.*',
-          'gmp': 'gmp >=5.0.1,<7',
-          'harfbuzz': 'harfbuzz 1.3.*',
-          'hdf5': 'hdf5 1.8.17|1.8.17.*',
-          'icu': 'icu 58.*',
-          'jpeg': 'jpeg 9*',
-          'libblitz': 'libblitz 0.10|0.10.*',
-          'libevent': 'libevent 2.0.*',
-          'libmatio': 'libmatio 1.5.*',
-          'libnetcdf': 'libnetcdf 4.4.*',
-          'libpng': 'libpng >=1.6.28,<1.7',
-          'libsvm': 'libsvm 3.21|3.21.*',
-          'libtiff': 'libtiff 4.0.*',
-          'libxml2': 'libxml2 2.9.*',
-          'metis': 'metis 5.1.*',
-          'mpfr': 'mpfr 3.*',
-          'ncurses': 'ncurses 5.9*',
-          'netcdf-cxx4': 'netcdf-cxx4 4.3.*',
-          'netcdf-fortran': 'netcdf-fortran 4.4.*',
-          'openblas': 'openblas 0.2.19|0.2.19.*',
-          'openssl': 'openssl 1.0.*',
-          'pango': 'pango 1.40.*',
-          'pixman': 'pixman 0.34.*',
-          'proj4': 'proj4 4.9.3',
-          'pyqt': 'pyqt 5.6.*',
-          'qt': 'qt 5.6.*',
-          'readline': 'readline 6.2*',
-          'sox': 'sox 14.4.2',
-          'sqlite': 'sqlite 3.13.*',
-          'tk': 'tk 8.5.*',
-          'vlfeat': 'vlfeat 0.9.20',
-          'xz': 'xz 5.2.*',
-          'zlib': 'zlib 1.2.*',
+          'boost': 'boost 1.64.*',  # 1.61.0
+          'boost-cpp': 'boost-cpp 1.64.*',  # NA
+          'bzip2': 'bzip2 1.0.*',  # 1.0.6
+          'cairo': 'cairo 1.14.*',  # 1.12.18
+          'ffmpeg': 'ffmpeg 2.8.*',  # NA
+          'fontconfig': 'fontconfig 2.12.*',  # 2.12.1
+          'freetype': 'freetype 2.7|2.7.*',  # 2.5.5
+          'geos': 'geos 3.5.1',  # 3.5.0
+          'giflib': 'giflib 5.1.*',  # NA
+          'glib': 'glib 2.51.*',  # 2.50.2
+          'gmp': 'gmp >=5.0.1,<7', # 6.1.0
+          'harfbuzz': 'harfbuzz 1.3.*',  # 0.9.39
+          'hdf5': 'hdf5 1.8.17|1.8.17.*',  # 1.8.17
+          'icu': 'icu 58.*',  # 54.1
+          'jpeg': 'jpeg 9*',  # 9b (but defaults is probably using 8d)
+          'libblitz': 'libblitz 0.10|0.10.*',  # NA
+          'libevent': 'libevent 2.0.*',  # 2.0.22
+          'libmatio': 'libmatio 1.5.*',  # NA
+          'libnetcdf': 'libnetcdf 4.4.*',  # 4.4.1
+          'libpng': 'libpng >=1.6.28,<1.7',  # 1.6.27
+          'libsvm': 'libsvm 3.21|3.21.*',  # NA
+          'libtiff': 'libtiff 4.0.*',  # 4.0.6
+          'libxml2': 'libxml2 2.9.*',  # 2.9.4
+          'metis': 'metis 5.1.*',  # NA
+          'mpfr': 'mpfr 3.*',  # 3.1.5
+          'ncurses': 'ncurses 5.9*',  # 5.9
+          'netcdf-cxx4': 'netcdf-cxx4 4.3.*',  # NA
+          'netcdf-fortran': 'netcdf-fortran 4.4.*',  #
+          'openblas': 'openblas 0.2.19|0.2.19.*',  # 0.2.19
+          'openssl': 'openssl 1.0.*',  # 1.0.2k
+          'pango': 'pango 1.40.*',  # 1.40.3
+          'pixman': 'pixman 0.34.*',  # 0.34.0
+          'proj4': 'proj4 4.9.3',  # 4.9.2
+          'pyqt': 'pyqt 5.6.*',  # 5.6.0
+          'qt': 'qt 5.6.*',  # 5.6.2
+          'readline': 'readline 6.2*',  # 6.2
+          'sox': 'sox 14.4.2',  # NA
+          'sqlite': 'sqlite 3.13.*',  # 3.13.0
+          'tk': 'tk 8.5.*',  # 8.5.18
+          'vlfeat': 'vlfeat 0.9.20',  # NA
+          'xz': 'xz 5.2.*',  # 5.2.2
+          'zlib': 'zlib 1.2.*',  # 1.2.8
         }
 
 parser = argparse.ArgumentParser(description='Propose a feedstock update.')


### PR DESCRIPTION
@jjhelmus, @msarahan and @mingwandroid as promised today in the meeting here is an attempt to document what is used in `defaults` to help us improve compatibility between `conda-forge` and `defaults`.

The version commented right after the comma is the one available for **Linux** in `defaults`. I assumed that is the same available for all platforms (which is not always the case) and the one used for package pinning (which is also not true because `jpeg 9b` is available on `defaults` but the pinning is probably still using `jpeg 8d` there).

The only known incompatibilities that causes headaches are `jpeg` 8 vs 9 and `icu` 54.1 vc 58.*. `libpng` and `libtiff` seems OK for a while now.

PS: note that this PR does not make any functional change to the pinning script. This extra info is only to guide us towards better compatibility. When updating a pin please double check with `defaults`!