### PR TITLE
Latest changes from  @pmlandwehr/tick-my-feedstocks:develop

### DIFF
--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -146,8 +146,8 @@ def parse_feedstock_file(feedstock_fpath):
     """
     from itertools import chain
 
-    if not isinstance(feedstock_fpath, str) and \
-            os.path.exists(feedstock_fpath):
+    if not (isinstance(feedstock_fpath, str) and
+            os.path.exists(feedstock_fpath)):
         return list()
 
     try:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -2,16 +2,15 @@
 
 # conda execute
 # env:
-#  - python ==3.5
-#  - conda-build
-#  - conda-smithy
+#  - python >=2.7
+#  - setuptools
 #  - beautifulsoup4
+#  - conda-smithy
 #  - gitpython
 #  - jinja2
-#  - pygithub >=1.29
+#  - pygithub >=1.29,<2
 #  - pyyaml
 #  - requests
-#  - setuptools
 #  - tqdm
 # channels:
 #  - conda-forge

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -474,20 +474,39 @@ def even_feedstock_fork(user, feedstock):
     try:
         fork = user.create_fork(feedstock)
     except UnknownObjectException:
-        raise UnknownObjectException('Issue with GitHub API when forking')
-    except GithubException:
-        raise GithubException('Issue with GitHub API when forking')
+        raise ValueError('Got 404 when creating fork')
+    try:
+        comparison = fork.compare(base='{}:master'.format(user.login),
+                                  head='conda-forge:master')
+    except UnknownObjectException:
+        raise ValueError('Got 404 when comparing forks, left new fork')
 
-    comparison = fork.compare(base='{}:master'.format(user.login),
-                              head='conda-forge:master')
+        # TODO Solve the mystery of why github times are misbehaving
+        #  and then check if a fork was just created and can be purged.
+        # from datetime import datetime
+        # seconds_since_creation = (
+        #     datetime.now() - fork.created_at).total_seconds()
+        # print('seconds_since_creation = {}'.format(seconds_since_creation))
+        # if seconds_since_creation > 10:
+        #     # Assume fork is old, so don't clean it up
+        #     raise ValueError('Got 404 when comparing forks, left fork')
+        #
+        # try:
+        #     fork.delete()
+        # except UnknownObjectException:
+        #     raise ValueError(
+        #         "Got 404 when comparing forks, couldn't clean up")
+        #
+        # raise ValueError(
+        #     'Got 404 when comparing forks, cleaned up fork')
 
     if comparison.behind_by > 0:
         # head is *behind* the base
         # conda-forge is behind the fork
         # leave everything alone - don't want a mess.
-        return None
+        raise ValueError('local fork is ahead of conda-forge')
 
-    elif comparison.ahead_by > 0:
+    if comparison.ahead_by > 0:
         # head is *ahead* of base
         # conda-forge is ahead of the fork
         # delete fork and clone from scratch
@@ -496,14 +515,12 @@ def even_feedstock_fork(user, feedstock):
         except GithubException:
             # couldn't delete feedstock
             # give up, don't want a mess.
-            raise GithubException("Couldn't delete outdated fork")
+            raise ValueError("Couldn't delete outdated fork")
 
         try:
             fork = user.create_fork(feedstock)
         except UnknownObjectException:
-            raise UnknownObjectException('Issue with GitHub API when forking')
-        except GithubException:
-            raise GithubException('Issue with GitHub API when forking')
+            raise ValueError('Got 404 when re-creating fork')
 
     return fork
 
@@ -605,8 +622,9 @@ def tick_feedstocks(gh_password=None,
                 repo.full_name
                 feedstocks.append(repo)
             except UnknownObjectException:
-                # couldn't get repo, so ignore it
-                continue
+                # couldn't get repo, so error out
+                raise ValueError(
+                    "Couldn't retrieve repository: {}".format(name))
 
     else:
         # If we have no specific targets
@@ -632,6 +650,7 @@ def tick_feedstocks(gh_password=None,
     successful_forks = list()
     successful_updates = list()
     patch_error_dict = defaultdict(list)
+    fork_error_dict = defaultdict(list)
     error_dict = defaultdict(list)
     for update in tqdm(indep_updates, desc='Updating feedstocks'):
 
@@ -667,12 +686,12 @@ def tick_feedstocks(gh_password=None,
         # make fork
         try:
             fork = even_feedstock_fork(user, update.fs)
-        except (UnknownObjectException, GithubException) as e:
-            # TODO this should be a better error catch
-            fork = None
+        except ValueError as e:
+            fork_error_dict[e.args[0]].append(update.fs.name)
+            continue
 
         if fork is None:
-            error_dict["Couldn't fork"].append(update.fs.name)
+            fork_error_dict["Unspecified failure"].append(update.fs.name)
             continue
 
         # patch fork
@@ -714,26 +733,31 @@ def tick_feedstocks(gh_password=None,
 
         pull_count += 1
 
-    print('{} feedstocks skipped.'.format(skip_count))
-    print('{} feedstocks checked.'.format(len(feedstocks)))
-    print('  {} were out-of-date.'.format(len(can_be_updated)))
-    print('  {} were independent of other out-of-date feedstocks'.format(
-        len(indep_updates)))
-    print('  {} had pulls submitted.'.format(pull_count))
+    print('{} feedstock(s) skipped.'.format(skip_count))
+    print('{} feedstock(s) checked.'.format(len(feedstocks)))
+    print('  {} feedstock(s) '
+          'were out-of-date.'.format(len(can_be_updated)))
+    print('  {} feedstock(s) '
+          'were independent of other out-of-date feedstocks'.format(
+              len(indep_updates)))
+    print('  {} feedstock(s) '
+          'had pulls submitted.'.format(pull_count))
     print('-----')
 
     for msg, cur_dict in [("Couldn't check status", status_error_dict),
-                          ("Couldn't create patch", patch_error_dict)]:
-        if len(cur_dict) > 0:
-            print('{}:'.format(msg))
-            for error_msg in cur_dict:
-                print('  {} ({}):'.format(error_msg,
-                                          len(cur_dict[error_msg])))
-                for name in cur_dict[error_msg]:
-                    print('    {}'.format(name))
+                          ("Couldn't create patch", patch_error_dict),
+                          ("Error when forking", fork_error_dict)]:
+        if len(cur_dict) < 1:
+            continue
 
-    for error_msg in ["Couldn't fork",
-                      "Couldn't apply patch",
+        print('{}:'.format(msg))
+        for error_msg in cur_dict:
+            print('  {} ({}):'.format(error_msg,
+                                      len(cur_dict[error_msg])))
+            for name in cur_dict[error_msg]:
+                print('    {}'.format(name))
+
+    for error_msg in ["Couldn't apply patch",
                       "Couldn't create pull"]:
         if error_msg not in error_dict:
             continue

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -69,18 +69,14 @@ IMPORTANT NOTES:
 # TODO Modify --dry-run flag to list which repos need forks.
 # TODO Modify --dry-run flag to list which forks are dirty.
 # TODO Modify --dry-run to also cover regeneration
-# TODO Add support for skipping repos that are deprecated. (e.g. fake-factory)
 # TODO skip upgrading from a stable release to a dev release (e.g. ghost.py)
-# TODO Test python 2.7 compatability (should work, but untested.)
-# TODO Test python 3.4 compatability (should work, but untested.)
-# TODO Test python 3.5 compatability (worked, but un-retested.)
-# TODO Test python 3.6 compatability (worked, but un-retested.)
+#  (This is useful but not critical, since we can provide skip lists)
 # TODO Deeper check of dependency changes in meta.yaml.
 # TODO Check installed conda-smithy against current feedstock conda-smithy.
 # TODO Check if already-forked feedstocks have open pulls.
 # TODO maintainer_can_modify flag when submitting pull
-#   Note that this isn't supported by pygithub yet, so would require
-#   switching back to requests
+#  Note that this isn't supported by pygithub yet, so would require
+#  switching back to requests
 # TODO Suppress regeneration text output
 # TODO improve the tqdm progress bar during regeneration.
 
@@ -270,7 +266,8 @@ class Feedstock_Meta_Yaml:
         """
         Reset the build number
         :param int|str new_number: New build number
-        :return: `bool` -- True if replacement successful or unneeded, False if failed
+        :return: `bool` -- True if replacement successful or unneeded, False if
+        failed
         """
         if str(new_number) == self._yaml_dict['build']['number']:
             # Nothing to do
@@ -347,7 +344,8 @@ def pypi_org_sha(package_name, version):
     Scrape pypi.org for SHA256 of the source bundle
     :param str package_name: Name of package (PROPER case)
     :param str version: version for which to get sha
-    :return: `str,str|None,None` -- bundle type,SHA for source, None,None if can't be found
+    :return: `str,str|None,None` -- bundle type,SHA for source, None,None if
+    can't be found
     """
     import warnings
     from bs4 import BeautifulSoup
@@ -403,8 +401,10 @@ def user_feedstocks(user, limit=-1, skips=None):
     """
     :param github.AuthenticatedUser.AutheticatedUser user:
     :param  int limit: If greater than -1, max number of feedstocks to return
-    :param list|set skips: an iterable of the names of feedstocks that should be skipped
-    :return: `tpl(int,list)` -- count of skipped feedstocks, list of conda-forge feedstocks the user maintains
+    :param list|set skips: an iterable of the names of feedstocks that should
+    be skipped
+    :return: `tpl(int,list)` -- count of skipped feedstocks, list of
+    conda-forge feedstocks the user maintains
     """
     if skips is None:
         skips = set()
@@ -438,16 +438,17 @@ def user_feedstocks(user, limit=-1, skips=None):
 
 def feedstock_status(feedstock):
     """
-    Return whether a feedstock is out of date and any information needed to update it.
+    Return whether a feedstock is out of date and any information needed to
+    update it.
     :param github.Repository.Repository feedstock:
-    :return: `tpl(bool,bool,None|status_data)` -- bools indicating success and either None or a status_data tuple
+    :return: `tpl(bool,bool,None|status_data)` -- bools indicating success and
+    either None or a status_data tuple
     """
     fs_contents = feedstock.get_contents('recipe/meta.yaml')
     try:
         meta_yaml = Feedstock_Meta_Yaml(
             fs_contents.decoded_content.decode('utf-8'))
     except (UndefinedError, KeyError) as e:
-        # TODO fix this to use the passed error message
         return result_tuple(False, e.args[0])
 
     pypi_version = pypi_version_str(meta_yaml.pypi_package)
@@ -469,7 +470,8 @@ def even_feedstock_fork(user, feedstock):
     If the user has a fork that's ahead of the feedstock, do nothing
     :param github.AuthenticatedUser.AuthenticatedUser user: GitHub user
     :param github.Repository.Repository feedstock: conda-forge feedstock
-    :return: `None|github.Repository.Repository` -- None if no fork, else the repository
+    :return: `None|github.Repository.Repository` -- None if no fork, else the
+    repository
     """
     try:
         fork = user.create_fork(feedstock)

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -776,7 +776,7 @@ def main():
     parser.add_argument('--target-feedstocks',
                         default=None,
                         dest='target_feedstocks',
-                        nargs='*'
+                        nargs='*',
                         help='List of feedstocks to update')
     parser.add_argument('--limit-feedstocks',
                         type=int,
@@ -787,10 +787,11 @@ def main():
                         type=int,
                         default=-1,
                         dest='limit_outdated',
-                        help='Maximum number of outdated feedstocks to try and patch')
+                        help='Maximum number of outdated feedstocks to try '
+                        'and patch')
     parser.add_argument('--skip-feedstocks-file',
                         default=None,
-                        dest='skipfile,'
+                        dest='skipfile',
                         help='File listing feedstocks to skip')
     parser.add_argument('--skip-feedstocks',
                         default=None,

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -704,7 +704,8 @@ def tick_feedstocks(gh_password=None,
             update.fs.create_pull(title='Ticked version, '
                                   'regenerated if needed. '
                                   '(Double-check reqs!)',
-                                  body='(Made using `tick_my_feedstocks.py`)',
+                                  body='Made using `tick_my_feedstocks.py`!\n'
+                                  '- [ ] **I have vetted this recipe**',
                                   head='{}:master'.format(gh_user),
                                   base='master')
         except GithubException:

--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -287,17 +287,15 @@ class Feedstock_Meta_Yaml:
         else:
             build_num_regex = re.compile('number: *{}'.format(
                 self._yaml_dict['build']['number']))
-            matches = re.findall(build_num_regex, self.text)
-            if len(matches) > 1:
+            matches = re.findall(build_num_regex, self._text)
+            if len(matches) != 1:
                 # Multiple number lines
+                # or no number lines
                 # So give up
                 return False
 
-            build_num_str = matches[0].string[matches[0].start():
-                                              matches[0].end()]
-            mapping = {build_num_str:
-                       'number: {}'.format(
-                           self._yaml_dict['build']['number'])}
+            mapping = {matches[0]:
+                       'number: {}'.format(new_number)}
 
         self.find_replace_update(mapping)
         return True


### PR DESCRIPTION
Seems worth updating this to match [`baf91ba`](https://github.com/pmlandwehr/tick-my-feedstocks/commit/baf91ba3b549242139347c8d905a7763595e6d72) on my local `develop` branch. Notable changes include:
* more arguments for filtering the different feedstocks you're working with (primarily useful for testing)
* suppress printing warnings from beautifulsoup about not specifying an HTML parser. (I've laid off on the `lxml` requirement because this seemed to have some complications; `lxml` would be installed via conda execute but then fail to be found by the program.
* fix issue with renamed feedstock directories caused by using temporary directories instead of named directories.
* better doc strings, updated TODOS
* catching some additional exceptions, though they could be handled better.

Still pinning dependency to `py35`, though I think `py>=34` is all that's required.