### PR TITLE
Update pin to hdf5 1.8.18

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -41,7 +41,7 @@ pinned = {
           'glib': 'glib 2.51.*',  # 2.50.2
           'gmp': 'gmp >=5.0.1,<7', # 6.1.0
           'harfbuzz': 'harfbuzz 1.3.*',  # 0.9.39
-          'hdf5': 'hdf5 1.8.17|1.8.17.*',  # 1.8.17
+          'hdf5': 'hdf5 1.8.18|1.8.18.*',  # 1.8.17
           'icu': 'icu 58.*',  # 54.1
           'jpeg': 'jpeg 9*',  # 9b (but defaults is probably using 8d)
           'libblitz': 'libblitz 0.10|0.10.*',  # NA


### PR DESCRIPTION
Update ```hdf5``` to 1.8.18 to resolve some CVEs announced back in November.

See https://github.com/conda-forge/hdf5-feedstock/issues/71 for more info.