### PR TITLE
Pin conda 4.2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
     # Re-use the packages in the cache, and download any new ones into that location.
     - rm -rf ${CONDA_INSTALL_LOCN}/pkgs && ln -s ${HOME}/cache/pkgs ${CONDA_INSTALL_LOCN}/pkgs
 
+    # Configure Bot account.
     - git config --global user.name "Travis-CI on github.com/conda-forge/conda-forge.github.io"
     - git config --global user.email conda.forge.coordinator@gmail.com
     - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
 
     # Configure conda.
     - conda config --set show_channel_urls true
+    - conda config --set auto_update_conda false
 
     # Now do the things we need to do to install it.
     - conda install conda-execute --yes --quiet -c conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ install:
     - git config --global user.email conda.forge.coordinator@gmail.com
     - mkdir -p ~/.conda-smithy && echo $GH_TOKEN > ~/.conda-smithy/github.token
 
+    # Configure conda.
+    - conda config --set show_channel_urls true
+
     # Now do the things we need to do to install it.
     - conda install conda-execute --yes --quiet -c conda-forge
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ install:
     - conda config --set show_channel_urls true
     - conda config --set auto_update_conda false
 
+    # Temporarily pin conda for conda-execute compatibility.
+    # Please see the linked issue for details.
+    #
+    # xref: https://github.com/pelson/conda-execute/issues/41
+    #
+    - conda install --yes --quiet -c conda-forge conda=4.2.13
+
     # Now do the things we need to do to install it.
     - conda install conda-execute --yes --quiet -c conda-forge
 


### PR DESCRIPTION
Currently `conda-execute` is not compatible with `conda` 4.3. So unfortunately we need to pin `conda` to a version `conda-execute` will work with. The last known working version was `conda` 4.2.13. So we pin that here. More details about this incompatibility can be found in issue ( https://github.com/pelson/conda-execute/issues/41 ).