### PR TITLE
Unpin conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,6 @@ install:
     - conda config --set show_channel_urls true
     - conda config --set auto_update_conda false
 
-    # Temporarily pin conda for conda-execute compatibility.
-    # Please see the linked issue for details.
-    #
-    # xref: https://github.com/pelson/conda-execute/issues/41
-    #
-    - conda install --yes --quiet -c conda-forge conda=4.2.13
-
     # Now do the things we need to do to install it.
     - conda install conda-execute --yes --quiet -c conda-forge
 


### PR DESCRIPTION
Reverts commit ( https://github.com/conda-forge/conda-forge.github.io/commit/f28297fb22ac055d777ee319fd6f1ab5f517c9aa ) from PR ( https://github.com/conda-forge/conda-forge.github.io/pull/400 ).

With the recent `conda-execute` release ( [v0.8.1]( https://github.com/pelson/conda-execute/releases/tag/v0.8.1 ) ) out, this pinning is no longer necessary as `conda` 4.3 support is now present. So this pinning to `conda` 4.2.13 can be dropped.