### PR TITLE
Added a CNAME again.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+conda-forge.org


### PR DESCRIPTION
See c0cb163f5961b527d74a48fd26d4c9f306d8a947 for previous attempt.

I've double checked the cloudflare settings as per https://blog.cloudflare.com/secure-and-fast-github-pages-with-cloudflare/.
I've verified that conda-forge.github.io will continue to function as a redirected domain (as per matplotlib.github.io): https://github.com/matplotlib/matplotlib.github.com/blob/master/CNAME

This *may* result in some downtime on conda-forge.github.io, but there isn't a lot we can do about it. We'll definitely be in a better position to move things around once we are pointing at the cloudflare domain (including subdomains).