### PR TITLE
libgdal pinning

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -55,6 +55,7 @@ pinned = {
           'krb5': 'krb5 1.14.*',  # 1.13.2
           'libblitz': 'libblitz 0.10|0.10.*',  # NA
           'libevent': 'libevent 2.0.22',  # 2.0.22
+          'libgdal': 'libgdal 2.1.*',  # 2.1.0
           'libmatio': 'libmatio 1.5.*',  # NA
           'libnetcdf': 'libnetcdf 4.4.*',  # 4.4.1
           'libpng': 'libpng >=1.6.28,<1.7',  # 1.6.27


### PR DESCRIPTION
Very few project use `gdal 1.x` and we are packaging both `gdal 2.2.x` and `2.1.x`. However, until `fiona` is compatible with `gdal 2.2.x`, we should be pinning to `2.1.x` to ensure consistency unless `gdal 2.2.x` is a hard dependency for the package. 