### PR TITLE
pin lzo

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -62,6 +62,7 @@ pinned = {
           'libsvm': 'libsvm 3.21|3.21.*',  # NA
           'libtiff': 'libtiff >=4.0.3,<4.0.8',  # 4.0.6
           'libxml2': 'libxml2 2.9.*',  # 2.9.4
+          'lzo': 'lzo 2.*',  # 2.06
           'metis': 'metis 5.1.*',  # NA
           'mpfr': 'mpfr 3.1.*',  # 3.1.5
           'ncurses': 'ncurses 5.9',  # 5.9


### PR DESCRIPTION
I don't know about binary compatibility on this one, since it's not on the tracker. There's actually a 2.10 release, though the PR for it (https://github.com/conda-forge/lzo-feedstock/pull/2) hit some build error that nobody ever debugged apparently. 2.09 is presumably fine for now.

cc @conda-forge/lzo 