### PR TITLE
pin snappy

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -75,6 +75,7 @@ pinned = {
           'pyqt': 'pyqt 5.6.*',  # 5.6.0
           'qt': 'qt 5.6.*',  # 5.6.2
           'readline': 'readline 6.2*',  # 6.2
+          'snappy': 'snappy 1.1.6',  # 1.1.6
           'sox': 'sox 14.4.2',  # NA
           'sqlite': 'sqlite 3.13.*',  # 3.13.0
           'tk': 'tk 8.5.*',  # 8.5.18


### PR DESCRIPTION
Pins to current most recent version in conda-forge, 1.1.4.

1.1.6 has a pending PR: https://github.com/conda-forge/snappy-feedstock/pull/11. It apparently has a slight ABI incompatibility, per [the tracker](https://abi-laboratory.pro/tracker/timeline/snappy/). (1.1.5 was broken in between.)

cc @conda-forge/snappy 