### PR TITLE
improve example bld.bat script a bit

### DIFF
--- a/src/buildwin.rst
+++ b/src/buildwin.rst
@@ -20,7 +20,11 @@ build for such projects.
     cd build
 
     :: Configure using the CMakeFiles
-    %LIBRARY_BIN%\cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" -DCMAKE_BUILD_TYPE:STRING=Release ..
+    cmake -G "NMake Makefiles" ^
+          -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+          -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+          -DCMAKE_BUILD_TYPE:STRING=Release ^
+          ..
     if errorlevel 1 exit 1
 
     :: Build!


### PR DESCRIPTION
Add `CMAKE_PREFIX_PATH`, get rid of unnecessary explicit path for cmake, and demonstrate the weird line-continuation character in batch scripts for increased readability.