### PR TITLE
Pin conda to 4.3.22 scripts

### DIFF
--- a/scripts/generate_html.py
+++ b/scripts/generate_html.py
@@ -3,6 +3,7 @@
 # conda execute
 # env:
 #  - python
+#  - conda 4.3.22
 #  - conda-smithy
 # channels:
 #  - conda-forge

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -4,6 +4,7 @@
 # env:
 #  - git
 #  - python
+#  - conda 4.3.22
 #  - conda-smithy
 #  - gitpython
 # channels:

--- a/scripts/update_teams.py
+++ b/scripts/update_teams.py
@@ -3,6 +3,7 @@
 # conda execute
 # env:
 #  - python 2.7.*
+#  - conda 4.3.22
 #  - conda-smithy
 #  - pygithub 1.*
 #  - six


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/425

Currently `conda-build-all` and `conda-smithy` do not work well with `conda` 4.3.23. So to workaround this issue, we pin `conda` to 4.3.22 in all of the CI-based update scripts, which we know to be affected.

cc @isuruf