### PR TITLE
update snappy pin

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -80,7 +80,7 @@ pinned = {
           'pyqt': 'pyqt 5.6.*',  # 5.6.0
           'qt': 'qt 5.6.*',  # 5.6.2
           'readline': 'readline 6.2*',  # 6.2
-          'snappy': 'snappy 1.1.6',  # 1.1.6
+          'snappy': 'snappy 1.1.6|1.1.7',  # 1.1.6
           'sox': 'sox 14.4.2',  # NA
           'sqlite': 'sqlite 3.13.*',  # 3.13.0
           'tk': 'tk 8.5.*',  # 8.5.18


### PR DESCRIPTION
Update the snappy pin (just added today in #412...) to `1.1.6|1.1.7`: their ABI is [totally compatible](https://abi-laboratory.pro/tracker/timeline/snappy/), and though we don't have 1.1.7 in conda-forge yet we will soon: https://github.com/conda-forge/snappy-feedstock/pull/14.