### PR TITLE
Doc BLAS

### DIFF
--- a/src/blas.rst
+++ b/src/blas.rst
@@ -1,0 +1,68 @@
+BLAS & Numpy & Friends
+======================
+
+-  BLAS metapackage
+
+   -  Version will have two values X.Y
+
+      -  X represents changes to the metapackage.
+      -  Y represents priority of BLAS (if we change priorities BLASes X
+         must be bumped, if we want to prioritize something new over
+         OpenBLAS we do not need to change X)
+
+         -  1 is OpenBLAS
+         -  0 is None (no BLAS whatsoever)
+
+   -  needs to have version stay the same across all variants.
+   -  build number cannot be touched (it won't be in the string anyways)
+   -  no pinning of BLAS inside the metapackages (dependencies can pin
+      this)
+   -  to preserve a BLAS in an environment it is recommend to add
+      ``pinned`` to ``conda-meta`` and specify down to the build string
+      what is the expected BLAS
+   -  To install a specific variant, ``conda install blas=1.0=none`` /
+      ``conda install blas=1.0=openblas``. It is hoped the syntax will be
+      improved in conda.
+
+      -  In the future, with some fixes to ``conda`` will allow for syntax
+         like ``conda install blas=*=openblas``. We should keep an eye on
+         this. (maybe even ``conda install blas:openblas``)
+
+   -  There will be two variants initially:
+
+      -  openblas
+      -  noblas - no BLAS optimisations (e.g. for reasons of smaller
+         installations)
+
+-  Numpy package
+
+   -  "version + build number" must always be greater than or equal to that
+      in defaults. If not, defaults "numpy" will be chosen, complete with
+      mkl
+
+      -  to make this simple we can pick a high build number so this is
+         prioritized 100 and then bump from there
+
+         -  Should make the build number ranges tied to BLAS X version above.
+         -  Build number should start at ``(X+1)*100``.
+
+            -  Means OpenBLAS starts at 200.
+            -  No BLAS starts at 100.
+
+         -  Unfortunately the 1.11.0 release breaks this rule so we will have
+            No BLAS at 101.
+
+      -  if defaults gains a newer version and build without conda-forge
+         updating, users will be prompted to upgrade to the defaults numpy.
+         Even if a user does this, as soon as an equivalent build is
+         available on conda-forge, they will be prompted to update to their
+         previous variant
+
+   -  will track the blas\_{{ variant }} feature enabled by the BLAS
+      metapackage
+   -  will pin the specific blas package versions (e.g. openblas .)
+
+-  SciPy, scikit-learn, etc. package
+
+   -  Same thing as NumPy
+   -  Add x.x for numpy dependency

--- a/src/blas.rst
+++ b/src/blas.rst
@@ -65,4 +65,4 @@ BLAS & Numpy & Friends
 -  SciPy, scikit-learn, etc. package
 
    -  Same thing as NumPy
-   -  Add x.x for numpy dependency
+   -  Add numpy dependency as if linking occurs

--- a/src/index.rst
+++ b/src/index.rst
@@ -14,6 +14,7 @@ Contents:
    guidelines
    recipe
    meta
+   blas
    buildwin
    testing
    ciservices


### PR DESCRIPTION
Exports the [BLAS Guidelines]( https://paper.dropbox.com/doc/BLAS-Numpy-Friends-rUDMIWo9NXQzKMP3f3gK7 ) from the [Hackpad]( https://conda-forge.hackpad.com/BLAS-Numpy-Friends-86De62hoNdT ) (now Dropbox Paper) document and adds them to the docs. Should help make things a little clearer and straightforward on this subject.