### PR TITLE
Update libpng pinning

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -61,7 +61,7 @@ pinned = {
           'libgdal': 'libgdal 2.1.*',  # 2.1.0
           'libmatio': 'libmatio 1.5.*',  # NA
           'libnetcdf': 'libnetcdf 4.4.*',  # 4.4.1
-          'libpng': 'libpng >=1.6.28,<1.7',  # 1.6.27
+          'libpng': 'libpng >=1.6.22,<1.6.31',  # 1.6.27
           'libssh2': 'libssh2 1.8.*',  # 1.8.0
           'libsvm': 'libsvm 3.21|3.21.*',  # NA
           'libtiff': 'libtiff >=4.0.3,<4.0.8',  # 4.0.6


### PR DESCRIPTION
Appears that libpng is stable beginning with 1.6.22, but ends up breaking ABI in version 1.6.31 from this year. So adjust the lower and upper bounds of the pinning to match this.

ref: https://abi-laboratory.pro/tracker/timeline/libpng/

cc @conda-forge/core @conda-forge/libpng