### PR TITLE
Force latest git with feedstock updates

### DIFF
--- a/.ci_scripts/update_feedstocks_repo
+++ b/.ci_scripts/update_feedstocks_repo
@@ -5,7 +5,7 @@
 set -e
 
 if [ -n "$GH_TOKEN" ]; then
-    conda install --yes --quiet conda-smithy git gitpython pygithub six conda-build -c conda-forge
+    conda install --yes --quiet conda-smithy git=2.14.2 gitpython pygithub six conda-build -c conda-forge
     git clone https://${GH_TOKEN}@github.com/conda-forge/feedstocks.git feedstocks_repo
     python scripts/update_feedstocks_submodules.py ./feedstocks_repo
     cd ./feedstocks_repo

--- a/scripts/update_feedstocks_submodules.py
+++ b/scripts/update_feedstocks_submodules.py
@@ -2,7 +2,7 @@
 
 # conda execute
 # env:
-#  - git
+#  - git 2.14.2
 #  - python
 #  - conda-smithy
 #  - gitpython


### PR DESCRIPTION
Seems that recently `conda` has been picking an older version of `git` ( maybe to have a newer version of `zlib` :/ ). That is the only notable change between the feedstocks' script failing and working. So try forcing the newer `git`.

Passing: https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/281593290#L522
Failing: https://travis-ci.org/conda-forge/conda-forge.github.io/jobs/279785043#L522