### PR TITLE
Update ncurses pin to 6.0

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -70,7 +70,7 @@ pinned = {
           'lzo': 'lzo 2.*',  # 2.06
           'metis': 'metis 5.1.*',  # NA
           'mpfr': 'mpfr 3.1.*',  # 3.1.5
-          'ncurses': 'ncurses 5.9',  # 5.9
+          'ncurses': 'ncurses 6.0',  # 6.0
           'netcdf-cxx4': 'netcdf-cxx4 4.3.*',  # NA
           'netcdf-fortran': 'netcdf-fortran 4.4.*',  #
           'nettle': 'nettle 3.3|3.3.*',  # NA


### PR DESCRIPTION
Anaconda 5.0.0 depends on `libedit` 3.1 which depend on `ncurses` 6.0