### PR TITLE
Use absolute links in feedstocks template

### DIFF
--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -15,7 +15,7 @@
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="css/theme.css" rel="stylesheet">
+    <link href="https://conda-forge.github.io/css/theme.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
@@ -39,7 +39,7 @@
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
                     <i class="fa fa-bars"></i>
                 </button>
-                <a class="navbar-brand page-scroll" href="./#page-top">
+                <a class="navbar-brand page-scroll" href="https://conda-forge.github.io/#page-top">
                     <i><img src="img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
                 </a>
             </div>
@@ -47,19 +47,19 @@
             <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
                 <ul class="nav navbar-nav">
                     <li>
-                        <a class="page-scroll" href="./#about">About</a>
+                        <a class="page-scroll" href="https://conda-forge.github.io/#about">About</a>
                     </li>
                     <li>
-                        <a href="docs">Docs</a>
+                        <a href="https://conda-forge.github.io/docs">Docs</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="./#contribute">Contribute</a>
+                        <a class="page-scroll" href="https://conda-forge.github.io/#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="feedstocks">Packages</a>
+                        <a href="https://conda-forge.github.io/feedstocks">Packages</a>
                     </li>
                     <li>
-                        <a href="./status">Status</a>
+                        <a href="https://conda-forge.github.io/status">Status</a>
                     </li>
 
                 </ul>
@@ -92,9 +92,9 @@
         <div class="container text-center">
             <p>
             <a href="https://conda-forge.github.io">Home</a> |
-            <a href="index.html#about">About</a> |
-            <a href="index.html#contribute">Contribute</a> |
-            <a href="feedstocks">Feedstocks</a> |
+            <a href="https://conda-forge.github.io/index.html#about">About</a> |
+            <a href="https://conda-forge.github.io/index.html#contribute">Contribute</a> |
+            <a href="https://conda-forge.github.io/feedstocks">Feedstocks</a> |
             <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
             </p>
             <br/>
@@ -111,7 +111,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="js/theme.js"></script>
+    <script src="https://conda-forge.github.io/js/theme.js"></script>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
To make sure that everything links properly from the feedstocks listing, even if it is not next to the relevant resources, change all of the URLs in the feedstocks template to be absolute. This way they are guaranteed to point back to right places.