### PR TITLE
Use absolute link in feedstocks template for anvil

### DIFF
--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -40,7 +40,7 @@
                     <i class="fa fa-bars"></i>
                 </button>
                 <a class="navbar-brand page-scroll" href="https://conda-forge.github.io/#page-top">
-                    <i><img src="img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
+                    <i><img src="https://conda-forge.github.io/img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
                 </a>
             </div>
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/conda-forge.github.io/pull/467 )

Fix one more link to be absolute instead of relative in the feedstocks template as it was missed before. Namely fix the link to the anvil image to be absolute instead of relative. Should ensure the anvil image gets loaded properly even if it is being referenced from a location outside the webpage repo.