### PR TITLE
Use conda-forge org URL in feedstocks template

### DIFF
--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -15,7 +15,7 @@
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="https://conda-forge.github.io/css/theme.css" rel="stylesheet">
+    <link href="https://conda-forge.org/css/theme.css" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
@@ -39,27 +39,27 @@
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
                     <i class="fa fa-bars"></i>
                 </button>
-                <a class="navbar-brand page-scroll" href="https://conda-forge.github.io/#page-top">
-                    <i><img src="https://conda-forge.github.io/img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
+                <a class="navbar-brand page-scroll" href="https://conda-forge.org/#page-top">
+                    <i><img src="https://conda-forge.org/img/anvil_white.png" alt="An anvil" style="height: 1em;"></i>  <span class="light">conda-forge</span>
                 </a>
             </div>
 
             <div class="collapse navbar-collapse navbar-right navbar-main-collapse">
                 <ul class="nav navbar-nav">
                     <li>
-                        <a class="page-scroll" href="https://conda-forge.github.io/#about">About</a>
+                        <a class="page-scroll" href="https://conda-forge.org/#about">About</a>
                     </li>
                     <li>
-                        <a href="https://conda-forge.github.io/docs">Docs</a>
+                        <a href="https://conda-forge.org/docs">Docs</a>
                     </li>
                     <li>
-                        <a class="page-scroll" href="https://conda-forge.github.io/#contribute">Contribute</a>
+                        <a class="page-scroll" href="https://conda-forge.org/#contribute">Contribute</a>
                     </li>
                     <li class="active">
-                        <a href="https://conda-forge.github.io/feedstocks">Packages</a>
+                        <a href="https://conda-forge.org/feedstocks">Packages</a>
                     </li>
                     <li>
-                        <a href="https://conda-forge.github.io/status">Status</a>
+                        <a href="https://conda-forge.org/status">Status</a>
                     </li>
 
                 </ul>
@@ -91,15 +91,15 @@
     <footer>
         <div class="container text-center">
             <p>
-            <a href="https://conda-forge.github.io">Home</a> |
-            <a href="https://conda-forge.github.io/index.html#about">About</a> |
-            <a href="https://conda-forge.github.io/index.html#contribute">Contribute</a> |
-            <a href="https://conda-forge.github.io/feedstocks">Feedstocks</a> |
+            <a href="https://conda-forge.org">Home</a> |
+            <a href="https://conda-forge.org/index.html#about">About</a> |
+            <a href="https://conda-forge.org/index.html#contribute">Contribute</a> |
+            <a href="https://conda-forge.org/feedstocks">Feedstocks</a> |
             <a href="https://github.com/conda-forge">conda-forge on GitHub</a>
             </p>
             <br/>
             <p class="small">
-            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><a href="https://conda-forge.github.io">conda-forge.github.io</a> is licensed under a <br /> <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><a href="https://conda-forge.org">conda-forge.org</a> is licensed under a <br /> <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
             </p>
         </div>
     </footer>
@@ -111,7 +111,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 
     <!-- Custom Theme JavaScript -->
-    <script src="https://conda-forge.github.io/js/theme.js"></script>
+    <script src="https://conda-forge.org/js/theme.js"></script>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Replace all instances of conda-forge's GitHub webpage URL with conda-forge's org URL. This seems to help with loading resources like CSS, JavaScript, and images. Not to mention this is a location that we are redirected to anyways by GitHub. So this should avoid rendering issues that sometimes occur because of this redirect.