### PR TITLE
pin zlib 1.2.11

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -92,7 +92,7 @@ pinned = {
           'tk': 'tk 8.5.*',  # 8.5.18
           'vlfeat': 'vlfeat 0.9.20',  # NA
           'xz': 'xz 5.2.*',  # 5.2.2
-          'zlib': 'zlib 1.2.8',  # 1.2.8
+          'zlib': 'zlib 1.2.11',  # zlib run_exports min is latest build 1.2.11
         }
 
 parser = argparse.ArgumentParser(description='Propose a feedstock update.')


### PR DESCRIPTION
@jjhelmus or @msarahan do you know if `defaults` moved to `zlib 1.2.11`? Latest curl seemed to be pinned to it.