### PR TITLE
pin poppler

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -61,6 +61,7 @@ pinned = {
           'libblitz': 'libblitz 0.10|0.10.*',  # NA
           'libevent': 'libevent 2.0.22',  # 2.0.22
           'libgdal': 'libgdal 2.1.*',  # 2.1.0
+          'libiconv' :'libiconv 1.15',  # 1.15
           'libmatio': 'libmatio 1.5.*',  # NA
           'libnetcdf': 'libnetcdf 4.4.*',  # 4.4.1
           'libpng': 'libpng >=1.6.22,<1.6.31',  # 1.6.27

--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -82,6 +82,7 @@ pinned = {
           'openssl': 'openssl 1.0.*',  # 1.0.2k
           'pango': 'pango 1.40.*',  # 1.40.3
           'pixman': 'pixman 0.34.*',  # 0.34.0
+          'poppler': 'poppler 0.61.*'  # 0.60.1
           'proj4': 'proj4 4.9.3',  # 4.9.2
           'protobuf': 'protobuf 3.4.*',  # 3.4.0
           'pyqt': 'pyqt 5.6.*',  # 5.6.0


### PR DESCRIPTION
Defaults added `poppler 0.60.1` and we never had that pinned b/c `conda-forge` was the only source. Now we have to b/c it is breaking packages that links to `poppler`.

Same story with `libiconv`/