### PR TITLE
pin xerces-c

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -96,6 +96,7 @@ pinned = {
           'sundials': 'sundials 2.7.*',  # NA
           'tk': 'tk 8.5.*',  # 8.5.18
           'vlfeat': 'vlfeat 0.9.20',  # NA
+          'xerces-c': 'xerces-c 3.2.0'  # 3.2.0
           'xz': 'xz 5.2.*',  # 5.2.2
           'zeromq': 'zeromq 4.2.*', # 4.2.*
           'zlib': 'zlib 1.2.11',  # zlib run_exports min is latest build 1.2.11


### PR DESCRIPTION
See https://abi-laboratory.pro/tracker/timeline/xerces-c/ and https://github.com/conda-forge/xerces-c-feedstock/pull/8

Now that `defaults` is using `conda-build 3` they are constantly updating their packages and that exposed a big flaw in the channel preference feature "it does not work :wink:" basically conda gets the latest version of anything unpinned and breaks stuff that is outdated in `conda-forge`.