### PR TITLE
pin zeromq to 4.2.1

### DIFF
--- a/scripts/pin_the_slow_way.py
+++ b/scripts/pin_the_slow_way.py
@@ -125,7 +125,7 @@ pinned = {
           'vlfeat': 'vlfeat 0.9.20',  # NA
           'xerces-c': 'xerces-c 3.2.0',  # 3.2.0
           'xz': 'xz 5.2.*',  # 5.2.2
-          'zeromq': 'zeromq 4.2.*', # 4.2.*
+          'zeromq': 'zeromq 4.2.1', # should be 4.2.*, but ABI is incorrectly tagged
           'zlib': 'zlib 1.2.11',  # zlib run_exports min is latest build 1.2.11
         }
 


### PR DESCRIPTION
An ABI-specifying bug in the zeromq recipe means we need to pin zeromq to the patch level until a fix is issued.

See related discussion in https://github.com/conda-forge/pyzmq-feedstock/pull/25 and https://github.com/conda-forge/zeromq-feedstock/issues/25