### PR TITLE
new location for run_docker_build on staged-recipes

### DIFF
--- a/src/testing.rst
+++ b/src/testing.rst
@@ -42,12 +42,12 @@ feedstock directory and run, the ``ci_support/run_docker_build.sh`` script.
 Run Docker Tests Locally for Staged Recipes
 --------------------------------------------
 If you want to run the docker tests for the staged-recipes repository locally, go to
-the root repository directory and run, the ``scripts/run_docker_build.sh`` script.
+the root repository directory and run the ``.circleci/run_docker_build.sh`` script.
 
 .. code-block:: sh
 
     $ cd staged-recipes
-    $ ./scripts/run_docker_build.sh
+    $ ./.circleci/run_docker_build.sh
 
 
 


### PR DESCRIPTION
Fix the location of `run_docker_build.sh` on staged-recipes, now that it's moved.

https://github.com/conda-forge/staged-recipes/issues/4799