### PR TITLE
Use pip

### DIFF
--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -72,7 +72,8 @@ Optional: ``bld.bat`` and/or ``build.sh``
 ------------------------------------------
 In many cases, ``bld.bat`` and/or ``build.sh`` files are not required. Pure Python packages almost never need them.
 If the build can be executed with one line, you may put this line in the ``script`` entry of the ``build`` section of
-the ``meta.yaml`` file. (For instance, if a file uses `setuptools`, try ``script: python setup.py install --single-version-externally-managed --record=record.txt``.)
+the ``meta.yaml`` file with: ``script: python -m pip install --no-deps --ignore-installed .``,
+remember to always add ``pip`` to the build requirements.
 
 
 Maintainer Role


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/528

PS: b/c conda-forge drifted away from Python standards and does not ship with ``pip`` by default we need to specify ``pip`` as a build dependency. Ideally we should review that policy and get closer to the Python community and ship ``pip`` by default again.