### PR TITLE
Add an onerror handler to shutil.rmtree calls in tick_my_feedstocks.py

### DIFF
--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -97,6 +97,7 @@ from pkg_resources import parse_version
 import re
 import requests
 import shutil
+import stat
 import tempfile
 from tqdm import tqdm
 import yaml
@@ -542,7 +543,7 @@ def regenerate_fork(fork):
     if not r.is_dirty():
         # No changes made during regeneration.
         # Clean up and return
-        shutil.rmtree(working_dir)
+        shutil.rmtree(working_dir, onerror=remove_readonly)
         return False
 
     commit_msg = \
@@ -553,8 +554,13 @@ def regenerate_fork(fork):
                    author=Actor(fork.owner.login, fork.owner.email))
     r.git.push()
 
-    shutil.rmtree(working_dir)
+    shutil.rmtree(working_dir, onerror=remove_readonly)
     return True
+
+
+def remove_readonly(func, path, excinfo):
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 
 def tick_feedstocks(gh_password=None,


### PR DESCRIPTION
Should avoid errors such as
`PermissionError: [WinError 5] Access is denied: 'C:\\Users\\akelman\\AppData\\Local\\Temp\\tmpu3fwwzf4\\botocore-feedstock\\.git\\objects\\pack\\pack-75b2092341bff03adcd15b32b752762b5801440f.idx'`