### PR TITLE
move the conda_smithy imports in tick_my_feedstocks.py

### DIFF
--- a/scripts/tick_my_feedstocks.py
+++ b/scripts/tick_my_feedstocks.py
@@ -83,8 +83,6 @@ import argparse
 from base64 import b64encode
 from collections import defaultdict
 from collections import namedtuple
-import conda_smithy
-import conda_smithy.configure_feedstock
 from git import Actor
 from git import Repo
 from github import Github
@@ -531,6 +529,9 @@ def regenerate_fork(fork):
     :param github.Repository.Repository fork: fork of conda-forge feedstock
     :return: `bool` -- True if regenerated, false otherwise
     """
+    import conda_smithy
+    import conda_smithy.configure_feedstock
+
     # Would need me to pass gh_user, gh_password
     # subprocess.run(["./renderer.sh", gh_user, gh_password, fork.name])
 


### PR DESCRIPTION
follow-up to #523, this makes conda-smithy optional when using `--no-regenerate`
(conda-smithy can only be installed in the root environment, which you might want to avoid messing with)