### PR TITLE
Add instructions for R recipes to docs.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+## Contributing
+
+To edit the documentation pages displayed at
+[conda-forge.org/docs/][conda-forge-docs], please edit the source
+[reStructuredText][] files in `src/`.
+
+[conda-forge-docs]: https://conda-forge.org/docs/
+[reStructuredText]: http://docutils.sourceforge.net/rst.html

--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -6,13 +6,16 @@ this documentation.
 
 Getting Started
 ------------------------------
-There are two ways to get started:
+There are multiple ways to get started:
 
 a. If it is a python package you can generate a skeleton as a starting point with
    ``conda skeleton pypi your_package_name``. You do *not* have to use skeleton, and the
    recipes produced by skeleton will need to be edited.
 b. Look at one of `these examples <https://github.com/conda-forge/staged-recipes/tree/master/recipes>`_
    in this repository and modify it as necessary.
+c. If it is an R package from `CRAN <https://cran.r-project.org/>`_, please
+   start by using the `conda-forge helper script for R recipes <https://github.com/bgruening/conda_r_skeleton_helper>`_.
+   Then if necessary you can make manual edits to the recipe.
 
 Your final recipe should have no comments and follow the order in the example.
 


### PR DESCRIPTION
To expedite the review process for contributors and reviewers of R recipes, I have added a note in the documentation pointing to the [helper script](https://github.com/bgruening/conda_r_skeleton_helper) used by the conda-forge R maintainers to format R recipes.

In the long-term we plan to improve the infrastructure for creating R recipes, but we get new R recipe submissions to staged-recipes almost daily, so we need a short-term solution.

cc:  @bgruening  @bsennblad @jvegasbsc

xref: https://github.com/conda-forge/staged-recipes/pull/5029#issuecomment-366628059