### PR TITLE
update_docs: remove outdated files from docs/

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -12,12 +12,22 @@ if [ -n "$GH_TOKEN" ]; then
     # Generate html requires a GitHub token in order to query the available feedstocks.
     conda install conda-smithy --yes --quiet -c conda-forge
     conda install sphinx --yes --quiet -c conda-forge
+
+    # build docs into docs/; preserve old README file
+    mv docs/README docs-README
+    rm -rf docs/
+
     cd src
     make html
-    cp -r _build/html/* ../docs
+    mv _build/html ../docs
     rm -rf _build
+
+    cd ..
+    mv docs-README docs/README
+
     git diff
-    # Only build the docs for commits on master.
+
+    # Only commit the docs for commits on master.
     if (( "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" )); then
         git add -A :/
         git commit -m "Re-ran make.py. [ci skip]" || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignore doc build
 src/_build/
+# Ignore sphinx .buildinfo metadata
+docs/.buildinfo


### PR DESCRIPTION
The `docs/` dir contains some outdated files: old versions of jquery in `docs/_static`, and `docs/_sources` has old `guidelines.txt`/`index.txt` files (instead of the current ones like `guidelines.rst.txt`). This is because `update_docs` currently doesn't delete old files from `docs`, just builds the new ones on top of it.

This PR changes the `update_docs` script so that it removes the old content first. The one hacky thing it does is to keep the `README` file around; there's probably a better way to do that....