### PR TITLE
highlight linked-to headers

### DIFF
--- a/src/_static/custom.css
+++ b/src/_static/custom.css
@@ -1,0 +1,3 @@
+:target > h1, :target > h2, :target > h3, :target > h4, :target > h5, :target > h6 {
+    background-color: #ffc;
+}


### PR DESCRIPTION
Currently when you link to a specific header in the docs, it just scrolls there; this is pretty bad for ones near the bottom of the page, like the maintainer role link. This highlights the header file as well (in a pale yellow; maybe there's a better color to use, idk).