### PR TITLE
Added link to recipe docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
                       <li><i class="mega-octicon fa-3x octicon-pencil"></i>
                           Add a new conda recipe in the "recipes" directory.
                           There is an example of a well written recipe there.
-                          Further guidance on writing good recipes.
+                          <a href="docs/recipe.html">Further guidance on writing good recipes</a>.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-pull-request"></i>
                           Propose the change as a pull request.


### PR DESCRIPTION
The sentence makes no sense without a link or another verb. Added a link to docs on how to create a recipe.