### PR TITLE
Recommend `pip` instead of `python -m pip`, fix minor error

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -186,7 +186,7 @@ while adding ``pip`` to the build requirements:
         - pip
 
 These options should be used to ensure a clean installation of the package without its
-dependencies and without ``egg-info`` directories, which do not interact well with conda.
+dependencies, which do not interact well with conda.
 
 
 Downloading extra sources and data files

--- a/src/meta.rst
+++ b/src/meta.rst
@@ -174,7 +174,7 @@ Normally packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: python -m pip install --no-deps --ignore-installed .
+      script: pip install --no-deps --ignore-installed .
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the build requirements:

--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -75,7 +75,7 @@ Optional: ``bld.bat`` and/or ``build.sh``
 ------------------------------------------
 In many cases, ``bld.bat`` and/or ``build.sh`` files are not required. Pure Python packages almost never need them.
 If the build can be executed with one line, you may put this line in the ``script`` entry of the ``build`` section of
-the ``meta.yaml`` file with: ``script: python -m pip install --no-deps --ignore-installed .``,
+the ``meta.yaml`` file with: ``script: pip install --no-deps --ignore-installed .``,
 remember to always add ``pip`` to the build requirements.
 
 


### PR DESCRIPTION
There should be no advantage in using `python -m pip` over `pip`, so we should use the latter. Even under Windows we always have a `pip.exe` available, so really no reason not to use it.

Additionally, the docs say a `pip install --no-deps --ignore-installed .` invocation would not create `egg-info` dirs, which is not true, so I removed that part of the sentence.