### PR TITLE
doc fix: pip does not avoid/delete egg-info dirs

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -186,7 +186,7 @@ while adding ``pip`` to the build requirements:
         - pip
 
 These options should be used to ensure a clean installation of the package without its
-dependencies and without ``egg-info`` directories, which do not interact well with conda.
+dependencies, which do not interact well with conda.
 
 
 Downloading extra sources and data files


### PR DESCRIPTION
Very minor doc fix. Separated from https://github.com/conda-forge/conda-forge.github.io/pull/551 since that PR is a bit controversial.
Relevant comments:
https://github.com/conda-forge/conda-forge.github.io/pull/551#issue-179089383
https://github.com/conda-forge/conda-forge.github.io/pull/551#discussion_r178813938
https://github.com/conda-forge/conda-forge.github.io/pull/551#issuecomment-378269975
https://github.com/conda-forge/conda-forge.github.io/pull/551#issuecomment-378272118
https://github.com/conda-forge/conda-forge.github.io/pull/551#issuecomment-378274057