### PR TITLE
Fix backticks for reStructuredText

### DIFF
--- a/src/buildwin.rst
+++ b/src/buildwin.rst
@@ -50,7 +50,7 @@ Rule of thumb:
 * if it is a shared library that is tied to a Python API (e.g. Boost Python), you need BOTH, and the features block;
 * if it is a library that has compiled content, but is used only from Python, you need Python in both build and runtime requirements, but you do NOT need the features block.
 
-\* Note that, because PY35 and PY36 use the same `vc` the user can skip py36 (or py35) in the first case above because the `vc14` package created will work on both versions.
+\* Note that, because PY35 and PY36 use the same ``vc`` the user can skip py36 (or py35) in the first case above because the ``vc14`` package created will work on both versions.
 
 To provide features add the following lines to the build section:
 

--- a/src/conda-forge_gotchas.rst
+++ b/src/conda-forge_gotchas.rst
@@ -14,7 +14,7 @@ see an error like (OS X example):
       Referenced from: .../site-packages/rpy2/rinterface/_rinterface.so
       Reason: image not found
 
-That happens because either the correct version of `icu`,
+That happens because either the correct version of ``icu``,
 or any other package in the error,
 is not present or the package is missing altogether.
 
@@ -23,8 +23,8 @@ Once can confirm by issuing the command ``conda list`` and searching for the pac
 Why that happens?
 '''''''''''''''''
 
-The `conda-forge` and `defaults` are not 100% compatible.
-In the example above it is known that `defaults` uses `icu 54.*` while `conda-forge` relies on `icu 56.*`,
+The ``conda-forge`` and ``defaults`` are not 100% compatible.
+In the example above it is known that ``defaults`` uses ``icu 54.*`` while ``conda-forge`` relies on ``icu 56.*``,
 that mismatch can lead to errors when the install environment is mixing packages from multiple channels.
 
 Note: All of conda-forge software pinning can be found at: https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies
@@ -32,12 +32,12 @@ Note: All of conda-forge software pinning can be found at: https://github.com/co
 How to fix it?
 ''''''''''''''
 
-Newer `conda` versions introduced a channel priority feature.
+Newer ``conda`` versions introduced a channel priority feature.
 See https://conda.io/docs/channels.html for more information.
 
-One possible solution is to add the `conda-forge` channel on top of `defaults` in your `condarc` file when using `conda-forge` packages.
-This will ensuring that all the dependencies will come from the `conda-forge` channel.
-Here is how a `.condarc` file would look like:
+One possible solution is to add the ``conda-forge`` channel on top of ``defaults`` in your ``condarc`` file when using ``conda-forge`` packages.
+This will ensuring that all the dependencies will come from the ``conda-forge`` channel.
+Here is how a ``.condarc`` file would look like:
 
 .. code-block:: shell
 
@@ -63,11 +63,11 @@ All maintainers are given push access to the feedstocks that they maintain. This
 
    This means if you push a version update to a branch and then create a PR, conda packages will be published to anaconda.org before the PR is merged.
 
-For these reasons maintainers are asked to fork the feedstock, push to a branch in the fork and then open a PR to the `conda-forge` repo.
+For these reasons maintainers are asked to fork the feedstock, push to a branch in the fork and then open a PR to the ``conda-forge`` repo.
 
 Branches in the main repo are used for,
 
 1. Maintaining a LTS branch of a package.
 
-   For eg. `master` branch of `python-feedstock` builds `3.6.x`, while `3.5` branch builds `3.5.x` versions of python.
+   For eg. ``master`` branch of ``python-feedstock`` builds ``3.6.x``, while ``3.5`` branch builds ``3.5.x`` versions of python.
 

--- a/src/meta.rst
+++ b/src/meta.rst
@@ -73,7 +73,7 @@ A full description of selectors is
 
 Using the Compilation ``toolchain``
 -----------------------------------
-Packages that need to compile code should add the `toolchain` package as a build dependency. This helps set up environment variables to instruct the compilers to do the right thing (e.g. building against the right version of the MacOS SDK).
+Packages that need to compile code should add the ``toolchain`` package as a build dependency. This helps set up environment variables to instruct the compilers to do the right thing (e.g. building against the right version of the MacOS SDK).
 
 
 Building Against NumPy

--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -29,8 +29,8 @@ Step-by-step instructions
 1. Fork the `example recipes <https://github.com/conda-forge/staged-recipes/tree/master/recipes>`_
 2. Within your forked copy, generate a new folder in the recipes subdirectory and copy `meta.yml <https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml>`_ from the example directory. Please leave the example directory unchanged!
 3. Edit the copied recipe (meta.yml) as you need it
-4. Generate the sha-256 key like described in the example recipe using the `openssl` tool. As an alternative you can also go to the package description on `PyPi <https://pypi.org>`_ where you can directly copy the sha-256 key from.
-5. Ensure to fill in the `tests` section. Simple tests would just import your modulei and are described in the example.
+4. Generate the sha-256 key like described in the example recipe using the ``openssl`` tool. As an alternative you can also go to the package description on `PyPi <https://pypi.org>`_ where you can directly copy the sha-256 key from.
+5. Ensure to fill in the ``tests`` section. Simple tests would just import your modulei and are described in the example.
 6. Remove all comments in the `meta.yml <https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml>`_
 
 
@@ -47,7 +47,7 @@ Checklist
 What happens after the PR to staged-recipes is merged
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* After the PR is merged, travis-ci will create a new git repo automatically. For example, the recipe for a package named `pydstool` will be moved to a new repository `https://github.com/conda-forge/pydstool-feedstock <https://github.com/conda-forge/pydstool-feedstock>`_.
+* After the PR is merged, travis-ci will create a new git repo automatically. For example, the recipe for a package named ``pydstool`` will be moved to a new repository `https://github.com/conda-forge/pydstool-feedstock <https://github.com/conda-forge/pydstool-feedstock>`_.
 * CI services (travis-ci, circleci, appveyor) will be enabled automatically and a build will be triggered automatically which will build the conda package and upload to `https://anaconda.org/conda-forge <https://anaconda.org/conda-forge>`_
 * If this is your first contribution, you will be added to the conda-forge `team <https://github.com/orgs/conda-forge/teams/all-members>`_ and given access to the CI services so that you can stop and restart builds. You will also be given commit rights to the new git repository.
 * If you want to make a change to the recipe, send a PR to the git repository from a fork. Branches of the main repository are used for maintaining different versions only.

--- a/src/webservice.rst
+++ b/src/webservice.rst
@@ -14,13 +14,13 @@ The webservice also listens to issue and PR comments so that you can ask for the
 -----------------------------------
 
 Entering the above phrase in a PR of a feedstock will rerender the feedstock and push the changes to your PR.
-Make sure to tick the `Allow edits from maintainers.` button locate at the bottom of the right side bar of the PR.
+Make sure to tick the ``Allow edits from maintainers.`` button locate at the bottom of the right side bar of the PR.
 
 
 @conda-forge-admin, please add noarch: python
 ---------------------------------------------
 
-Entering the above phrase in a PR of a feedstock will add `noarch: python` to the build and rerender the feedstock
+Entering the above phrase in a PR of a feedstock will add ``noarch: python`` to the build and rerender the feedstock
 for you.
 
 
@@ -34,7 +34,7 @@ Entering the above phrase in a PR of a feedstock will lint the PR again.
 ----------------------------------------
 
 Entering the above phrase in an issue of a feedstock will update the Circle-CI SSH deploy key. This will fix the
-`permission denied (public key)` issue in Circle-CI checkout phase
+``permission denied (public key)`` issue in Circle-CI checkout phase
 
 
 @conda-forge-admin, please update team


### PR DESCRIPTION
Make sure code sections use two backticks instead of one (as was the case in some instances).