### PR TITLE
Update Docker tests for conda-smithy 3+

### DIFF
--- a/src/testing.rst
+++ b/src/testing.rst
@@ -31,12 +31,13 @@ On Windows, use the ``exist`` command. See below for an example.
 Run Docker Tests Locally for Feedstock
 --------------------------------------
 If you want to run the docker tests for a feedstock locally, go to the root
-feedstock directory and run, the ``ci_support/run_docker_build.sh`` script.
+feedstock directory and run, the ``.circleci/run_docker_build.sh`` script
+(or ``ci_support/run_docker_build.sh`` in older feedstocks).
 
 .. code-block:: sh
 
     $ cd my-feedstock
-    $ ./ci_support/run_docker_build.sh
+    $ ./.circleci/run_docker_build.sh
 
 
 Run Docker Tests Locally for Staged Recipes

--- a/src/testing.rst
+++ b/src/testing.rst
@@ -42,8 +42,9 @@ feedstock directory and run, the ``.circleci/run_docker_build.sh`` script
 
 Run Docker Tests Locally for Staged Recipes
 --------------------------------------------
-If you want to run the docker tests for the staged-recipes repository locally, go to
-the root repository directory and run the ``.circleci/run_docker_build.sh`` script.
+If you want to run the docker tests for the staged-recipes repository locally,
+go to the root repository directory and run the
+``.circleci/run_docker_build.sh`` script.
 
 .. code-block:: sh
 

--- a/src/testing.rst
+++ b/src/testing.rst
@@ -32,12 +32,15 @@ Run Docker Tests Locally for Feedstock
 --------------------------------------
 If you want to run the docker tests for a feedstock locally, go to the root
 feedstock directory and run, the ``.circleci/run_docker_build.sh`` script
-(or ``ci_support/run_docker_build.sh`` in older feedstocks).
+(or ``ci_support/run_docker_build.sh`` in older feedstocks). One should also
+specify the environment variable ``CONFIG``, to select one of the ``*.yaml``
+config files in ``.ci_support`` to use for the build (this is not needed for
+older feedstocks).
 
 .. code-block:: sh
 
     $ cd my-feedstock
-    $ ./.circleci/run_docker_build.sh
+    $ CONFIG="linux_" ./.circleci/run_docker_build.sh
 
 
 Run Docker Tests Locally for Staged Recipes


### PR DESCRIPTION
The Docker build script now lives in `.circleci`. So update the docs to reference that instead. Also make a note for the legacy location of `ci_support` for feedstocks using `conda-smithy` 2.