### PR TITLE
Fixes link to conda-forge team members

### DIFF
--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -51,7 +51,7 @@ What happens after the PR to staged-recipes is merged
 
 * After the PR is merged, travis-ci will create a new git repo automatically. For example, the recipe for a package named ``pydstool`` will be moved to a new repository `https://github.com/conda-forge/pydstool-feedstock <https://github.com/conda-forge/pydstool-feedstock>`_.
 * CI services (travis-ci, circleci, appveyor) will be enabled automatically and a build will be triggered automatically which will build the conda package and upload to `https://anaconda.org/conda-forge <https://anaconda.org/conda-forge>`_
-* If this is your first contribution, you will be added to the conda-forge `team <https://github.com/orgs/conda-forge/teams/all-members>`_ and given access to the CI services so that you can stop and restart builds. You will also be given commit rights to the new git repository.
+* If this is your first contribution, you will be added to the conda-forge `team <https://github.com/orgs/conda-forge/people>`_ and given access to the CI services so that you can stop and restart builds. You will also be given commit rights to the new git repository.
 * If you want to make a change to the recipe, send a PR to the git repository from a fork. Branches of the main repository are used for maintaining different versions only.
 
 


### PR DESCRIPTION
When reading through the "Creating Conda Recipes" documentation, I ran across a broken link to the conda-forge team members. This PR simply fixes the link. 