### PR TITLE
Updates link formatting to recipe.rst

### DIFF
--- a/src/joining-the-team.rst
+++ b/src/joining-the-team.rst
@@ -26,8 +26,8 @@ Generally speaking your role is as follows:
 
 1. Keep up to date with the current best practices for conda packaging standards
 2. Provide recipe review which generally means making sure that the recipe
-   under review adheres to what we list on the :ref:`recipe`__ page.
-3. Open issues as needed, both on staged and on the other flagship repos 
+   under review adheres to what we list on the :doc:`recipe` page.
+3. Open issues as needed, both on staged and on the other flagship repos
    (smithy, webservices, etc), especially when problems occur.
 4. <Other people please chime in here with what the responsibilities are supposed to be>
 


### PR DESCRIPTION
This PR updates a link to `recipe.rst` in `joining-the-team.rst`. 

Currently looks like:

<img width="628" alt="screen shot 2018-05-14 at 9 16 45 pm" src="https://user-images.githubusercontent.com/11656932/40033039-418db9f6-57bc-11e8-8d8a-989351b0d4ea.png">

Should look like:

<img width="622" alt="screen shot 2018-05-14 at 9 16 59 pm" src="https://user-images.githubusercontent.com/11656932/40033043-468719d4-57bc-11e8-89ef-632202eab71c.png">
