### PR TITLE
add a disclaimer about update-cb3

### DIFF
--- a/src/webservice.rst
+++ b/src/webservice.rst
@@ -31,6 +31,8 @@ for you.
 
 This command will attempt to update a recipe to the new conda-build 3 format. It can be sent either in an issue or a PR.
 
+Note that this update command is kind of a hack, and things might go wrong. Make sure to look over the changes, and ask for help if you're not sure about something.
+
 
 @conda-forge-admin, please lint
 -------------------------------


### PR DESCRIPTION
Just adds a warning to the docs about the `update-cb3` webservices command to be careful with the output.