### PR TITLE
pip requirements clarification

### DIFF
--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -107,7 +107,7 @@ If the build can be executed with one line, you may put this line in the
 ``script`` entry of the ``build`` section of the ``meta.yaml`` file with:
 ``script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"``.
 
-Remember to always add ``pip`` to the ``build`` and ``host`` requirements.
+Remember to always add ``pip`` to the host requirements.
 
 
 Maintainer Role

--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -107,7 +107,7 @@ If the build can be executed with one line, you may put this line in the
 ``script`` entry of the ``build`` section of the ``meta.yaml`` file with:
 ``script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"``.
 
-Remember to always add ``pip`` to the build requirements.
+Remember to always add ``pip`` to the ``build`` and ``host`` requirements.
 
 
 Maintainer Role


### PR DESCRIPTION
I was updating the `freud` package from a custom CMake build system to a more typical (Cython-based) build system. While doing this, I was a little confused by the docs. The `meta` and `recipe` pages offer different guidance on where to add `pip`.

On the `meta` page, it says to put `pip` in the `host` requirements. The `recipe` page says to put `pip` in the `build` requirements.

In my case, I saw the `recipe` page first. I found that `build`-only did not work, but `build` and `host` together worked. (I am now testing `host`-only and will update this PR accordingly if that works.)