### PR TITLE
stop recommending --no-cache-dir be used with pip

### DIFF
--- a/docs/_sources/meta.rst.txt
+++ b/docs/_sources/meta.rst.txt
@@ -356,7 +356,7 @@ Normally Python packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the host requirements:

--- a/docs/_sources/meta.rst.txt
+++ b/docs/_sources/meta.rst.txt
@@ -356,7 +356,7 @@ Normally Python packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+      script: "{{ PYTHON }} -m pip install . -vvv"
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the host requirements:


### PR DESCRIPTION
The --no-cache-dir argument supressed wheel building when used with pip.  This
results in egg-info rather than .dist-info metadata directories being created.
A local cache directory is provided by conda-build since 3.14.0 which avoid any
issues with the global cache directory.