### PR TITLE
Drop no-deps and ignore-installed arguments

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -356,7 +356,7 @@ Normally Python packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+      script: "{{ PYTHON }} -m pip install . -vvv"
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the host requirements:


### PR DESCRIPTION
Fixes up the docs to include an intended change from another PR that was lost (as it changed autogenerated files).

cc @jjhelmus

xref: https://github.com/conda-forge/conda-forge.github.io/pull/653