### PR TITLE
Decrease recommended pip verbosity

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -356,7 +356,7 @@ Normally Python packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: "{{ PYTHON }} -m pip install . -vvv"
+      script: "{{ PYTHON }} -m pip install . -vv"
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the host requirements:

--- a/src/recipe.rst
+++ b/src/recipe.rst
@@ -105,7 +105,7 @@ Pure Python packages almost never need them.
 
 If the build can be executed with one line, you may put this line in the
 ``script`` entry of the ``build`` section of the ``meta.yaml`` file with:
-``script: "{{ PYTHON }} -m pip install . -vvv"``.
+``script: "{{ PYTHON }} -m pip install . -vv"``.
 
 Remember to always add ``pip`` to the host requirements.
 


### PR DESCRIPTION
Decreased recommended pip verbosity from `-vvv` to `-vv`, so the docs are in sync with the example recipe.

https://github.com/conda-forge/staged-recipes/commit/d701836f5b45e334102b0c6dd959be471a93e285