### PR TITLE
Drop `sudo: false` from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 # python distribution for the scientific python stack.
 language: generic
 
-sudo: false
-
 env:
     global:
        - CONDA_INSTALL_LOCN="${HOME}/conda"


### PR DESCRIPTION
As noted in recent Travis CI announcements (most notably the linked blog below), support for `sudo: false` on Linux workers is being dropped. All user will be migrated to Linux virtual-machines. This makes the needed change to the Travis CI configuration file as part of this migration effort.

ref: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration