### PR TITLE
 Remove recommendation to use environ["RECIPE_DIR"]

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -42,7 +42,7 @@ It can then be refered to in the ``meta.yaml`` as if it was in the source direct
 .. code-block:: yaml
 
     about:
-      license_file: 'LICENSE.txt'
+      license_file: LICENSE.txt
 
 
 Populating the ``hash`` Field

--- a/src/meta.rst
+++ b/src/meta.rst
@@ -37,12 +37,12 @@ This means that the ``about/license_file`` entry *must* be included in the
 tarball of the source code.
 
 To get around this, the licence should be put in the recipe directory.
-It can then be refered to in the ``meta.yaml`` via,
+It can then be refered to in the ``meta.yaml`` as if it was in the source directory,
 
 .. code-block:: yaml
 
     about:
-      license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+      license_file: 'LICENSE.txt'
 
 
 Populating the ``hash`` Field


### PR DESCRIPTION
Initially discussed in https://github.com/conda-forge/staged-recipes/pull/7464, I've done some testing and it looks like this isn't necessary (perhaps historically it was?). Testing a new recipe with old versions of conda-build, I found the following:

conda-build 3.9.2: The following error is produced:
`Undefined Jinja2 variables remain (['PYTHON']).  Please enable source downloading and try again.`

conda-build 3.10.9: The following error is produced:
```
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Traceback (most recent call last):
  File "D:\conda\lib\site-packages\conda_build\metadata.py", line 214, in yamlize
    loaded_data = yaml.load(data, Loader=loader)
  File "D:\conda\lib\site-packages\yaml\__init__.py", line 72, in load
    return loader.get_single_data()
  File "D:\conda\lib\site-packages\yaml\constructor.py", line 35, in get_single_data
    node = self.get_single_node()
  File "ext\_yaml.pyx", line 707, in _yaml.CParser.get_single_node
  File "ext\_yaml.pyx", line 725, in _yaml.CParser._compose_document
  File "ext\_yaml.pyx", line 776, in _yaml.CParser._compose_node
  File "ext\_yaml.pyx", line 890, in _yaml.CParser._compose_mapping_node
  File "ext\_yaml.pyx", line 776, in _yaml.CParser._compose_node
  File "ext\_yaml.pyx", line 890, in _yaml.CParser._compose_mapping_node
  File "ext\_yaml.pyx", line 732, in _yaml.CParser._compose_node
  File "ext\_yaml.pyx", line 905, in _yaml.CParser._parse_next_event
yaml.scanner.ScannerError: while parsing a quoted scalar
  in "<unicode string>", line 15, column 11
found unknown escape character
  in "<unicode string>", line 15, column 14

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\conda\Scripts\conda-build-script.py", line 10, in <module>
    sys.exit(main())
  File "D:\conda\lib\site-packages\conda_build\cli\main_build.py", line 420, in main
    execute(sys.argv[1:])
  File "D:\conda\lib\site-packages\conda_build\cli\main_build.py", line 411, in execute
    verify=args.verify)
  File "D:\conda\lib\site-packages\conda_build\api.py", line 200, in build
    notest=notest, need_source_download=need_source_download, variants=variants)
  File "D:\conda\lib\site-packages\conda_build\build.py", line 2155, in build_tree
    bypass_env_check=True)
  File "D:\conda\lib\site-packages\conda_build\render.py", line 740, in render_recipe
    allow_no_other_outputs=True, bypass_env_check=bypass_env_check)
  File "D:\conda\lib\site-packages\conda_build\render.py", line 646, in distribute_variants
    bypass_env_check=bypass_env_check)
  File "D:\conda\lib\site-packages\conda_build\metadata.py", line 969, in parse_until_resolved
    bypass_env_check=bypass_env_check)
  File "D:\conda\lib\site-packages\conda_build\metadata.py", line 910, in parse_again
    path=self.meta_path)
  File "D:\conda\lib\site-packages\conda_build\metadata.py", line 323, in parse
    res = yamlize(data)
  File "D:\conda\lib\site-packages\conda_build\metadata.py", line 223, in yamlize
    raise exceptions.UnableToParse(original=e)
conda_build.exceptions.UnableToParse
```

conda-build 3.11.0 or newer: Package builds successfully, LICENSE.txt file is included in resulting conda package.

Given that, going back as far as I can (conda-build 3.11.0) without the build failing for other reasons, `{{ environ["RECIPE_DIR"] }}` isn't necessary, I propose removing its usage from the documentation for 	
packaging the license manually.