### PR TITLE
Remove deprecated mention of --no-deps

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -371,8 +371,7 @@ These options should be used to ensure a clean installation of the package witho
 dependencies. This helps make sure that we're only including this package,
 and not accidentally bringing any dependencies along into the conda package.
 
-Note that the ``--no-deps`` line means that for pure-Python packages,
-usually only ``python`` and ``pip`` are needed as ``build`` or ``host`` requirements;
+For pure-Python packages usually only ``python`` and ``pip`` are needed as ``build`` or ``host`` requirements;
 the real package dependencies are only ``run`` requirements.
 
 


### PR DESCRIPTION
Since #653 the recommended `pip` installation command hasn't included `--no-deps`. This PR edits the related text to be consistent.