### PR TITLE
Recommended using --no-deps with pip

### DIFF
--- a/src/meta.rst
+++ b/src/meta.rst
@@ -356,7 +356,7 @@ Normally Python packages should use this line:
 .. code-block:: yaml
 
     build:
-      script: "{{ PYTHON }} -m pip install . -vv"
+      script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 as the installation script in the ``meta.yml`` file or ``bld.bat/build.sh`` script files,
 while adding ``pip`` to the host requirements:


### PR DESCRIPTION
Replaces #704 and adds `--no-deps` to the recommended pip install command.