### PR TITLE
VOTE: formation of documentation sub-team

### DIFF
--- a/src/orga/subteams.rst
+++ b/src/orga/subteams.rst
@@ -83,3 +83,41 @@ Members
 - Jonathan Helmus <jjhelmus@gmail.com>
 - Marius van Niekerk <marius.v.niekerk@gmail.com>
 - Mark Harfouche <mark.harfouche@gmail.com>
+
+
+Doc Sub-Team
+============
+
+Role
+----
+
+Maintain and improve the documentation; review, organize and help with documentation related issues. 
+
+Charter
+-------
+Dynamic
+
+Responsibility
+--------------
+
+A good documentation is an important corner stone of a successful community project.
+An accurate, well organized and comprehensive documentation not only benefits users, but also frees the core team by decreasing support requests.
+
+The documentation team is responsible for
+
+ - keeping the documentation accurate and up-to-date.
+ - help expanding the documentation by identifying new topics of common interest.
+ - improving the documentation by reorganizing and clarifying its contents.
+ - giving feedback on community contributions to the documentation.
+
+As such following task are performed by the documentation team:
+
+ - reviewing and organizing documentation related issues and PRs in ``conda-forge.github.io``.
+ - proposing improvements and new content by opening issues and pull requests.
+ - engaging with the community to ensure the effectiveness of the documentation.
+
+
+Members
+-------
+- Anthony Scopatz <scopatz@gmail.com>
+- Christian Roth <ch.m.roth@gmail.com>

--- a/src/orga/subteams.rst
+++ b/src/orga/subteams.rst
@@ -100,8 +100,8 @@ Dynamic
 Responsibility
 --------------
 
-A good documentation is an important corner stone of a successful community project.
-An accurate, well organized and comprehensive documentation not only benefits users, but also frees the core team by decreasing support requests.
+Good documentation is an important corner stone of a successful community project.
+Accurate, well organized and comprehensive documentation not only benefits users, but also frees the core team by decreasing support requests.
 
 The documentation team is responsible for
 

--- a/src/orga/subteams.rst
+++ b/src/orga/subteams.rst
@@ -121,3 +121,4 @@ Members
 -------
 - Anthony Scopatz <scopatz@gmail.com>
 - Christian Roth <ch.m.roth@gmail.com>
+- Lori A. Burns <lori.burns@gmail.com>


### PR DESCRIPTION
After getting some initial positive feedback, I would like to officially propose the sub-team formation of a doc team.

I would be happy to 
 - receive feedback on the sub-team description
 - find volunteers for the member list

I started by adding @scopatz, as he has worked with me on the restructuring in the last weeks. I hope this is ok.

@conda-forge/core - this is a sub-team formation vote and requires a 50% majority to pass, or 9/17 core members

xref: #729