### PR TITLE
doc: fix link to recipe doc link (#750)

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
                       <li><i class="mega-octicon fa-3x octicon-pencil"></i>
                           Add a new conda recipe in the "recipes" directory.
                           There is an example of a well written recipe there.
-                          <a href="docs/recipe.html">Further guidance on writing good recipes</a>.
+                          <a href="docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml">Further guidance on writing good recipes</a>.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-pull-request"></i>
                           Propose the change as a pull request.


### PR DESCRIPTION
Link target changed during restructuring. Closes #750.