### PR TITLE
MAINT: libGL - rerender reminder

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -169,6 +169,7 @@ In addition to the required compilers ``{{ compiler('c') }}`` and/or ``{{ compil
 
 
 If you need a fully functional binary in the test phase, you have to also provide the shared libraries via ``yum_requirements.txt`` (see :ref:`yum_deps`).
+You will need to re-render the feedstock after making these changes.
 
 ::
 


### PR DESCRIPTION
I was trying to get libGL.so to work on https://github.com/conda-forge/refnx-feedstock/pull/20, but having major difficulties. I wasn't aware that a re-render was necessary. This PR points out that as well as making changes to meta.yaml and yum_requirements.txt, that a re-render is necessary.