### PR TITLE
First draft on emeritus core

### DIFF
--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -35,7 +35,7 @@ Here are defined the primary teams participating in conda-forge activities.
   and voting on polls) in the past year will be asked if they want to become emeritus-core
   developers. They can still vote and be back to active core anytime, the only difference is
   that emeritus-core will not count as the total core members when computing the necessary
-  votes a poll need to pass.
+  votes a poll needs to pass.
 
 Sub-Teams
 ---------

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -32,7 +32,7 @@ Here are defined the primary teams participating in conda-forge activities.
   contributors, collaborators, and funders. They have no special rights within
   the conda-forge organization itself.
 * **emeritus-core:** Core members that are inactive (commits, GitHub comments/issues/reviews,
-  and voting on polls) in the past six months will be asked if they want to become emeritus-core
+  dev meetings and voting on polls) in the past six months will be asked if they want to become emeritus-core
   developers. Any core member can also request to become emeritus if they wish to do so
   (e.g. taking a sabbatical or long vacation).
   Emeritus core members can still vote and be back to active core anytime, the only difference is

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -33,9 +33,11 @@ Here are defined the primary teams participating in conda-forge activities.
   the conda-forge organization itself.
 * **emeritus-core:** Core members that are inactive (commits, GitHub comments/issues/reviews,
   and voting on polls) in the past six months will be asked if they want to become emeritus-core
-  developers. They can still vote and be back to active core anytime, the only difference is
+  developers. Any core member can also request to become emeritus if they wish to do so
+  (e.g. taking a sabbatical or long vacation).
+  Emeritus core members can still vote and be back to active core anytime, the only difference is
   that emeritus-core will not count as the total core members when computing the necessary
-  votes a poll needs to pass.
+  votes a poll needs to pass. The `core.csv` list should be update when change in the status of a member occurs.
 
 Sub-Teams
 ---------

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -37,7 +37,7 @@ Here are defined the primary teams participating in conda-forge activities.
   (e.g. taking a sabbatical or long vacation).
   Emeritus core members can still vote and be back to active core anytime, the only difference is
   that emeritus-core will not count as the total core members when computing the necessary
-  votes a poll needs to pass. The `core.csv` list should be update when change in the status of a member occurs.
+  votes a poll needs to pass. The ``core.csv`` list should be update when change in the status of a member occurs.
 
 Sub-Teams
 ---------

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -10,7 +10,7 @@ appreciate all good faith contributions.
 Code of Conduct
 ---------------
 Conda-forge adheres to the
-`Numfocus Code of Conduct <https://www.numfocus.org/code-of-conduct>`_.
+`NumFOCUS Code of Conduct <https://www.numfocus.org/code-of-conduct>`_.
 
 Teams & Roles
 -------------
@@ -31,6 +31,11 @@ Here are defined the primary teams participating in conda-forge activities.
   core, part of staged-recipes, or maintainers. This includes first time
   contributors, collaborators, and funders. They have no special rights within
   the conda-forge organization itself.
+* **emeritus-core:** Core members that are inactive (commits, GitHub comments/issues/reviews,
+  and voting on polls) in the past year will be asked if they want to become emeritus-core
+  developers. They can still vote and be back to active core anytime, the only difference is
+  that emeritus-core will not count as the total core members when computing the necessary
+  votes a poll need to pass.
 
 Sub-Teams
 ---------

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -37,7 +37,7 @@ Here are defined the primary teams participating in conda-forge activities.
   (e.g. taking a sabbatical or long vacation).
   Emeritus core members can still vote and be back to active core anytime, the only difference is
   that emeritus-core will not count as the total core members when computing the necessary
-  votes a poll needs to pass. The ``core.csv`` list should be update when change in the status of a member occurs.
+  votes a poll needs to pass. The ``core.csv`` list should be updated when change in the status of a member occurs.
 
 Sub-Teams
 ---------

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -32,7 +32,7 @@ Here are defined the primary teams participating in conda-forge activities.
   contributors, collaborators, and funders. They have no special rights within
   the conda-forge organization itself.
 * **emeritus-core:** Core members that are inactive (commits, GitHub comments/issues/reviews,
-  and voting on polls) in the past year will be asked if they want to become emeritus-core
+  and voting on polls) in the past six months will be asked if they want to become emeritus-core
   developers. They can still vote and be back to active core anytime, the only difference is
   that emeritus-core will not count as the total core members when computing the necessary
   votes a poll needs to pass.


### PR DESCRIPTION
As we discussed in our past meeting the emeritus-core still have all the rights of a core member but they will not count to the total number of core members to avoid sticky situations with polls that need majority votes to pass.