### PR TITLE
Corrected typos and grammar accross documentation

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -8,7 +8,7 @@ Contributing packages
 The staging process
 ===================
 
-This document presents an overview over  how to contribute packages to conda-forge.
+This document presents an overview over how to contribute packages to conda-forge.
 
 
 Getting Started
@@ -53,7 +53,7 @@ Step-by-step Instructions
 #. Edit the copied recipe (meta.yml) as needed. For details, see
    :ref:`meta_yaml`.
 #. Generate the SHA256 key for your source code archive, as described in the
-   example recipe using the ``openssl`` tool. As an alternative you can also
+   example recipe using the ``openssl`` tool. As an alternative, you can also
    go to the package description on `PyPi <https://pypi.org>`_ from which you
    can directly copy the SHA256.
 #. Be sure to fill in the ``tests`` section. The simplest test will simply
@@ -70,7 +70,7 @@ Checklist
 * In case your project has tests included, you need to decide if these tests should be executed while building the conda-forge feedstock.
 * Make sure that all tests pass successfully at least on your development machine.
 * Recommended: run the test locally on your source code to ensure the recipe works locally (see  :ref:`staging_test_locally`).
-* Make sure that your changes do not interfere with other recipes that are int the ``recipes`` folder (e.g. the ``example`` recipe).
+* Make sure that your changes do not interfere with other recipes that are in the ``recipes`` folder (e.g. the ``example`` recipe).
 
 
 Feedback and revision
@@ -84,7 +84,7 @@ After merging the :term:`PR`, our infrastructure will build the package and make
 
 .. note::
 
-  If you have questions or have not heard back for a while, you can notify us by including ``@conda-forge/staged-recipes`` in your github message.
+  If you have questions or have not heard back for a while, you can notify us by including ``@conda-forge/staged-recipes`` in your GitHub message.
 
 
 Post staging process
@@ -106,9 +106,9 @@ The maintainer's job is to:
 
   - Bumping the version number and checksum.
   - Making sure that feedstock's requirements stay accurate.
-  - Make sure the test requirements match those of the of the updated package.
+  - Make sure the test requirements match those of the updated package.
 
-- Answer eventual question about the package on the feedstock issue tracker.
+- Answer eventual questions about the package on the feedstock issue tracker.
 
 
 .. _meta_yaml:
@@ -117,13 +117,13 @@ The recipe meta.yaml
 ====================
 
 The ``meta.yaml`` file in the recipe directory is at the heart of every conda package.
-It defines everything that is required build and use the  package.
+It defines everything that is required to build and use the package.
 
 ``meta.yaml`` is in `yaml <https://en.wikipedia.org/wiki/YAML>`__ format, augmented with `Jinja <http://jinja.pocoo.org/>`__ templating.
 
 A full reference of the structure and fields of ``meta.yaml`` file can be found in the `Defining metadata (meta.yaml) <https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html>`__ section in the conda-build documentation.
 
-In the following we highlight particularly important and conda-forge specific information and guidelines, ordered by section in ``meta.yaml``.
+In the following, we highlight particularly important and conda-forge specific information and guidelines, ordered by section in ``meta.yaml``.
 
 
 Source
@@ -142,7 +142,7 @@ There are several reasons behind this rule:
   - Repositories are not checksummed.  Thus, using a tarball has a
     stronger guarantee that the download that is obtained to build from is
     in fact the intended package.
-  - On some systems it is possible to not have permission to remove a repo once it is created.
+  - On some systems, it is possible to not have permission to remove a repo once it is created.
 
 Populating the ``hash`` field
 .............................
@@ -244,7 +244,7 @@ Build, host and run
 ...................
 
 Conda-build distinguishes three different kinds of dependencies.
-In the following paragraphs we give a very short overview what packages go where.
+In the following paragraphs, we give a very short overview what packages go where.
 For a detailed explanation please refer to the `conda-build documentation <https://docs.conda.io/projects/conda-build/en/latest/source/resources/define-metadata.html#requirements-section>`__.
 
 **Build**
@@ -285,7 +285,7 @@ Avoid external dependencies
 
 As a general rule: all dependencies have to be packaged by conda-forge as well. This is necessary to assure :term:`ABI` compatibility for all our packages.
 
-There are only few exceptions to this rule:
+There are only a few exceptions to this rule:
 
 #. Some dependencies have to be satisfied with :term:`CDT` packages (see :ref:`cdt_packages`).
 
@@ -332,7 +332,7 @@ For more information on pinning, please refer to :ref:`pinned_deps`.
 Constraining packages at runtime
 ................................
 
-The ``run_constrained`` section allows to define restrictions on packages at runtime without depending on the package. It can be used to restrict allowed versions of optional dependencies and defining incompatible packages.
+The ``run_constrained`` section allows defining restrictions on packages at runtime without depending on the package. It can be used to restrict allowed versions of optional dependencies and defining incompatible packages.
 
 Defining non-dependency restrictions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -349,7 +349,7 @@ In this case ``run_dependencies`` can be used to restrict ``awesome-software`` t
     run_constrained:
       - awesome-software 1.*
 
-Here ``run_constrained`` acts as a means to protect users from incompatible version without introducing an unwanted dependency.
+Here ``run_constrained`` acts as a means to protect users from incompatible versions without introducing an unwanted dependency.
 
 Defining conflicts
 ^^^^^^^^^^^^^^^^^^
@@ -393,7 +393,7 @@ Sometimes defining tests seems to be hard, e.g. due to:
  - test suites may take too long to run on limited :term:`CI` infrastructure.
  - tests may take too much bandwidth.
 
-In these cases conda-forge may not be able to execute the prescribed test suite.
+In these cases, conda-forge may not be able to execute the prescribed test suite.
 
 However, this is no reason for the recipe to not have tests. At the very least
 we want to verify that the package has installed the desired files in the desired
@@ -441,7 +441,7 @@ Note that ``package_name`` is the name imported by python;
 not necessarily the name of the conda package (they are sometimes different).
 
 Testing for an import will catch the bulk of the packaging errors, generally
-including presence of dependencies. However, it does not assure that the
+including the presence of dependencies. However, it does not assure that the
 package works correctly. In particular, it doesn't test if it works
 correctly with the versions of dependencies used.
 
@@ -463,7 +463,7 @@ Test requirements
 Sometimes there are packages required to run the tests that are not required
 to simply use the package. This is usually a test-running framework, such as
 nose or pytest. You can ensure that it is included by adding it to requirements
-in the the test stanza:
+in the test stanza:
 
 .. code-block:: yaml
 
@@ -572,7 +572,7 @@ This requires that you have docker installed on your machine.
 About
 -----
 
-Packaging the licence manually
+Packaging the license manually
 ..............................
 
 Sometimes upstream maintainers do not include a license file in their tarball despite being demanded by the license.
@@ -598,7 +598,7 @@ Miscellaneous
 Activate scripts
 ----------------
 
-Recipes are allowed to have activate scripts, which will be ``sourced``\ d or
+Recipes are allowed to have activate scripts, which will be ``source``\ d or
 ``call``\ ed when the environment is activated. It is generally recommended to avoid using
 activate scripts when another option is possible because people do not always
 activate environments the expected way and these packages may then misbehave.
@@ -642,7 +642,7 @@ These expressions are written in `Jinja <http://jinja.pocoo.org/>`__ syntax.
 
 Jinja expressions serve following purposes in the meta.yaml:
 
-- They allow defining variables to avoid code duplication. Using a variable for the ``version`` allows to change the version only once with every update.
+- They allow defining variables to avoid code duplication. Using a variable for the ``version`` allows changing the version only once with every update.
 
   .. code-block:: yaml
 

--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -23,7 +23,7 @@ Smithy contains maintenance code for conda-forge, which is used by the ``conda s
  - the recipe linter
  - :term:`CI` support utils
 
-``conda-smithy`` also contains the commandline tool that you will use if you rerender manually from the commandline (see :ref:`dev_update_rerender`).
+``conda-smithy`` also contains the command line tool that you will use if you rerender manually from the command line (see :ref:`dev_update_rerender`).
 
 
 Web services
@@ -63,7 +63,7 @@ conda-forge is running a webservice on heroku called `conda-forge-webservices <h
 
 The following services are run by default on a feedstock:
 
-- It will lint the recipes in the PRs and report back whether recipe is in excellent condition or not.
+- It will lint the recipes in the PRs and report back whether the recipe is in excellent condition or not.
 - When maintainers are added to a recipe, the maintainer will be added to the team and given push access.
 
 The webservice also listens to issue and PR comments so that you can ask for the following services to be done.

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -145,7 +145,7 @@ Core dependency tree packages (CDT)
 -----------------------------------
 
 Dependencies outside of the conda-forge channel should be avoided (see :ref:`no_external_deps`).
-However there are very few exceptions: some dependencies are so close to the system that they are not packaged with conda-forge.
+However, there are very few exceptions: some dependencies are so close to the system that they are not packaged with conda-forge.
 These dependencies have to be satisfied with *Core Dependency Tree* packages.
 
 In conda-forge this currently affects only packages that link against libGL.
@@ -185,7 +185,7 @@ You will need to re-render the feedstock after making these changes.
 Building Against NumPy
 ----------------------
 
-Packages that link against NumPy need a special treatment in the dependency section.
+Packages that link against NumPy need special treatment in the dependency section.
 Finding ``numpy.get_include()`` in ``setup.py`` or ``cimport`` statements in ``.pyx`` or ``.pyd`` files are a telltale sign that the package links against NumPy.
 
 In the case of linking, you need to use the ``pin_compatible`` function to ensure having a compatible numpy version at run time:
@@ -241,8 +241,8 @@ How are MPI variants best handled in conda-forge?
 There are a few broad cases:
 
 - package requires a specific MPI provider (easy!)
-- package works with any MPI provider (e.g. mpich, openmpi)
-- package works with/without MPI
+- the package works with any MPI provider (e.g. mpich, openmpi)
+- the package works with/without MPI
 
 
 
@@ -342,7 +342,7 @@ or
 
 This doesn't extend to ``nompi``, because there is no ``nompi`` variant of the mpi metapackage. And there probably shouldn't be, because some packages built with mpi doesn't preclude other packages in the env that *may* have an mpi variant from using the no-mpi variant of the library (e.g. for a long time, fenics used mpi with no-mpi hdf5 since there was no parallel hdf5 yet. This works fine, though some features may not be available).
 
-Typically, if there is a preference it will be packages with a nompi variant, where the serial build is preferred, such that installers/requirers of the package only get the mpi build if explicitly requested.
+Typically, if there is a preference it will be packaged with a nompi variant, where the serial build is preferred, such that installers/requirers of the package only get the mpi build if explicitly requested.
 
 
 .. admonition:: Outdated
@@ -634,7 +634,7 @@ You can switch your BLAS implementation by doing,
 This would change the BLAS implementation without changing the conda packages depending
 on BLAS.
 
-Following legacy commands are also supported as well.
+The following legacy commands are also supported as well.
 
 .. code-block:: bash
 
@@ -655,7 +655,7 @@ time of writing is ``3.8.0``. Since the BLAS API is stable, a downstream package
 ``3.*`` of ``libblas`` and ``libcblas``. On the other hand, ``liblapack`` and ``liblapacke`` pins to
 ``3.8.*``.
 
-In addition to the above netlib package there are other variants like ``libblas=*=*openblas``,
+In addition to the above netlib package, there are other variants like ``libblas=*=*openblas``,
 which has ``openblas`` as a dependency and has a symlink from ``libblas.so.3`` to ``libopenblas.so``.
 ``libblas=3.8.0=*openblas`` pins the ``openblas`` dependency to a version that is known to support the
 BLAS ``3.8.0`` API.  This means that at install time, the user can select what BLAS implementation
@@ -682,7 +682,7 @@ In order to qualify as a noarch python package, all of the following criteria mu
 
   - No compiled extensions
   - No post-link or pre-link or pre-unlink scripts
-  - No OS specific build scripts
+  - No OS-specific build scripts
   - No python version specific requirements
   - No skips except for python version. If the recipe is py3 only, remove skip
     statement and add version constraint on python in ``host`` and ``run``
@@ -698,7 +698,7 @@ In order to qualify as a noarch python package, all of the following criteria mu
   ``skip: True  # [py2k]`` can sometimes be replaced with a constrained python version in the host and run subsections: say ``python >=3`` instead of just ``python``.
 
 .. note::
-  Only ``console_script`` entrypoints have to be listed in meta.yaml. Other entrypoints do not conflict with ``noarch`` and therefore do not require extra treatment.
+  Only ``console_script`` entry points have to be listed in meta.yaml. Other entry points do not conflict with ``noarch`` and therefore do not require extra treatment.
 
 If an existing python package qualifies to be converted to a noarch package, you can request the required changes by opening a new issue and including ``@conda-forge-admin, please add noarch: python``.
 
@@ -735,7 +735,7 @@ Following implies that ``python`` is a runtime dependency and a Python matrix fo
     host:
       - python
 
-``conda-forge.yml``'s build matrices is removed in conda-smithy=3. To get a build matrix, create a ``conda_build_config.yaml`` file inside recipe folder. For example following will give you 2 builds and you can use the selector ``vtk_with_osmesa`` in the ``meta.yaml``
+``conda-forge.yml``'s build matrices is removed in conda-smithy=3. To get a build matrix, create a ``conda_build_config.yaml`` file inside the recipe folder. For example, the following will give you 2 builds and you can use the selector ``vtk_with_osmesa`` in the ``meta.yaml``
 
 .. code-block:: yaml
 

--- a/src/maintainer/pinning_deps.rst
+++ b/src/maintainer/pinning_deps.rst
@@ -10,7 +10,7 @@ Globally pinned packages
 
 Globally pinned packages are defined in the `conda_build_config.yaml <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml>`_ file located in the ``conda-forge-pinning`` feedstock.
 
-When a rerendering happens, conda-smithy will render the recipe using conda-build and output configuration files for each job and save them in a yaml file in ``.ci_support`` folder. For example there's a output configuration file for each OS, each python version, etc.
+When a rerendering happens, conda-smithy will render the recipe using conda-build and output configuration files for each job and save them in a yaml file in ``.ci_support`` folder. For example, there's an output configuration file for each OS, each python version, etc.
 
 These output configuration files are stripped to options that are used in the build and therefore a change in the config files in ``.ci_support`` folder implies that there needs to be a new build.
 
@@ -36,7 +36,7 @@ Should be replaced by
       run:
         - gmp
 
-When there's a new ABI version of gmp (say 7.0), then conda-forge-pinning will be updated. A rerendering of a package using gmp will change. Therefore to check that a recipe needs to be rebuilt for updated pinnings, you only need to check if the package needs a rerender.
+When there's a new ABI version of gmp (say 7.0), then conda-forge-pinning will be updated. A re-rendering of a package using gmp will change. Therefore to check that a recipe needs to be rebuilt for updated pinnings, you only need to check if the package needs a rerender.
 
 .. note::
 

--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -22,13 +22,13 @@ For updates, using a branch in the main repo is discouraged because,
    This means if you push a version update to a branch and then create a :term:`PR`, conda packages will be published to anaconda.org before the PR is merged.
 
 .. important::
-  For these reasons maintainers are asked to fork the feedstock, push to a branch in the fork and then open a PR to the ``conda-forge`` repo.
+  For these reasons, maintainers are asked to fork the feedstock, push to a branch in the fork and then open a PR to the ``conda-forge`` repo.
 
 
 Example workflow for updating a package
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Here we assume that your would like to update the feedstock ``<feedstock>``. Feedstock is a placeholder and can e.g. be replaced by ``numpy-feedstock``.
+Here we assume that you would like to update the feedstock ``<feedstock>``. Feedstock is a placeholder and can e.g. be replaced by ``numpy-feedstock``.
 
 #. Forking the feedstock
 
@@ -52,13 +52,13 @@ Here we assume that your would like to update the feedstock ``<feedstock>``. Fee
    Now you are ready to update the recipe
 
    - Create and switch to a new branch: ``git checkout -b <branch-name>``. ``<branch-name>`` can be e.g. ``update_1_0_1``.
-   - Make your chances locally
+   - Make your changes locally
    - Review your changes then use ``git add <changed-files>``. Where ``<changed-files>`` are a whitespace separated list of filenames you changed.
    - Create a commit by ``git commit -m <commit-msg>``, where ``<commit-msg>`` can be ``updated feedstock to version 1.0.1``
 
-#. Pushing your changes to github and propose a PR
+#. Pushing your changes to GitHub and propose a PR
 
-   - Push the branch with changes to your fork in github:  ``git push origin <branch-name>``
+   - Push the branch with changes to your fork on GitHub:  ``git push origin <branch-name>``
    - Create a pull request via the web interface by navigating to ``https://github.com/<your-github-id>/<feedstock>`` with your web browser and clicking the button ``create pull request``.
 
 
@@ -103,7 +103,7 @@ Rerendering can be done in two ways:
 Rerendering with conda-smithy locally
 -------------------------------------
 
-First step is to install ``conda-smithy`` in your root environment
+The first step is to install ``conda-smithy`` in your root environment
 
 .. code-block:: shell
 
@@ -139,7 +139,7 @@ We need to re-render when there are changes the following parts of the feedstock
 Testing changes locally
 =======================
 
-If you have docker installed on your system, you can test builds locally on your machine under the same settings as it is  built by our :term:`CI`.
+If you have docker installed on your system, you can test builds locally on your machine under the same settings as it is built by our :term:`CI`.
 
 If you want to build and test updates to  a feedstock locally, go to the root
 feedstock directory and run, the ``.circleci/run_docker_build.sh`` script.
@@ -159,7 +159,7 @@ For example, the docker build with the config in ``.ci_support/linux_.yaml`` can
 Removing broken packages
 ========================
 
-Sometimes mistakes happen and a broken package ends up being uploaded to the conda-forge channel. In this case core can help you (see :ref:`fix_broken_packages`)
+Sometimes mistakes happen and a broken package ends up being uploaded to the conda-forge channel. In this case, core can help you (see :ref:`fix_broken_packages`)
 
 Maintaining several versions
 ============================

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -28,7 +28,7 @@ Here are defined the primary teams participating in conda-forge activities.
   of one or more feedstock repositories and packages. Maintainers have the ability
   to merge pull requests into the feedstock of only the packages they maintain.
 * **external contributors:** This group encompasses all others who are not on
-  core, part of staged-recipes, or maintainers. This includes first time
+  core, part of staged-recipes, or maintainers. This includes first-time
   contributors, collaborators, and funders. They have no special rights within
   the conda-forge organization itself.
 
@@ -65,7 +65,7 @@ calling a vote are as follows:
 * There must only be one vote active on a particular item at any time.
 * The act of calling for a vote cannot itself violate the code of
   conduct. For example, Sam repeatedly called for votes immediately
-  after a previous votes failed to achieve Sam's result. Sam is
+  after a previous vote failed to achieve Sam's result. Sam is
   attempting to bully other members of core into agreeing, and is thus
   violating the code of conduct.
 * Voting yes moves the proposal forward;
@@ -150,7 +150,7 @@ To call for a standard vote, here is a template PR comment:
     "ask for forgiveness and not for permission" way so bad situations
     are handled quickly. The lock must be justified in the thread itself
     with a text explaining the reasons for locking and how the participants
-    may can contest it.
+    can contest it.
 
     * Standard
     * No need for voting to lock a thread

--- a/src/orga/guidelines.rst
+++ b/src/orga/guidelines.rst
@@ -11,7 +11,7 @@ to conda-forge. These aren't hard and fast rules and are open reasonable
 interpretation and reviewer judgement.
 
 It is the aspiration that almost all recipes from those repos shall be
-proposed for addition here, thought it may be decided that a few don't
+proposed for addition here, though it may be decided that a few don't
 actually belong or should not be supported anymore.
 
 When adding a package from either location, inspect the commit history
@@ -40,7 +40,7 @@ Windows, make sure to add ``skip: True  # [win]`` to the ``build``
 section. The ``about`` section must have the ``home`` URL (verify the
 URL is still correct), ``license`` (verify the correct license is present),
 and a one sentence (or few word) ``summary``. When specifying the version it
-is strongly recommend that jinja templating be used to set the version
+is strongly recommended that jinja templating be used to set the version
 at the top (e.g. ``{% set version = "0.10.1" %}``) and then replace all
 uses of the version with ``{{ version }}``. Preference should be given to
 compressed source balls as opposed to version control checkouts. Make sure
@@ -48,7 +48,7 @@ all links to compressed source balls allow for easy changing of the version
 (using latest is not acceptable). Also, a checksum should be included with
 all compressed source balls to allow for verification of downloads.
 
-It is required to add tests with all packages. These can included but are
+It is required to add tests with all packages. These can include but are
 not limited to checking libraries are installed, python imports, simple
 code snippet to compile or run a basic test, command line usage (checking
 help or version). It is suggested that compiled code run all tests (e.g.
@@ -62,7 +62,7 @@ build against). From a practical perspective, there are limitations on the
 continuous integration resources and also on what reviewers are able/willing
 to review in a single pull request.
 A large pull request with many recipes makes it more difficult to review.
-If the recipes make it through these two constraints and is merged, race
+If the recipes make it through these two constraints and are merged, race
 conditions amongst the different feedstocks may require work by you and/or
 core maintainers to restart them in such a way to build everything in a
 suitable order.
@@ -81,7 +81,7 @@ Maintainers' time and CI resources are what enable conda-forge. They are as scar
 Publishing a package to conda-forge signals it is suitable for users not involved with development. However, publishing does not always happen error-free. Multiple commits are acceptable when debugging issues with the release process itself.
 
 Fortunately, there are options for optimizing the development of a package.
-  - `conda-smithy <https://github.com/conda-forge/conda-smithy>`__ is a tool used by conda-forge itself to manage feedstocks. conda-smithy can be used to create an internal development feedstock that is seperate from conda-forge.
+  - `conda-smithy <https://github.com/conda-forge/conda-smithy>`__ is a tool used by conda-forge itself to manage feedstocks. conda-smithy can be used to create an internal development feedstock that is separate from conda-forge.
   - `ci-helpers <https://github.com/astropy/ci-helpers>`__ is a set of scripts that drive various CI services using environment variables.
 
 Renaming Packages

--- a/src/orga/joining-the-team.rst
+++ b/src/orga/joining-the-team.rst
@@ -23,7 +23,7 @@ staged-recipes Responsibilities
 
 You are the welcoming committee for new recipes coming in to the conda-forge
 community! Please give new (and experienced) contributors a pleasant experience!
-Generally speaking your role is as follows:
+Generally speaking, your role is as follows:
 
 1. Keep up to date with the current best practices for conda packaging standards
 2. Provide recipe review which generally means making sure that the recipe
@@ -39,5 +39,5 @@ Generally speaking your role is as follows:
 
 .. todo::
 
-  - Add description of core team responsibilities
-  - Add description of how we add new core team members
+  - Add a description of core team responsibilities
+  - Add a description of how we add new core team members

--- a/src/orga/subteams.rst
+++ b/src/orga/subteams.rst
@@ -26,7 +26,7 @@ Example migrations that can happen include:
 - Python version bump
 - R version bump
 - Build number bumps of the ecosystem when a pinned package version updates and
-  there is a binary incompatibility which necessitate downstream rebuilds.
+  there is a binary incompatibility which necessitates downstream rebuilds.
 - Automatically version bumping of feedstocks when the package releases a new version.
 
 For large scale (affecting >20% of packages) this sub-team will inform and
@@ -100,7 +100,7 @@ Dynamic
 Responsibility
 --------------
 
-Good documentation is an important corner stone of a successful community project.
+Good documentation is an important cornerstone of a successful community project.
 Accurate, well organized and comprehensive documentation not only benefits users, but also frees the core team by decreasing support requests.
 
 The documentation team is responsible for

--- a/src/user/faq.rst
+++ b/src/user/faq.rst
@@ -17,7 +17,7 @@ FAQ
 
 :ref:`(Q) <faq_report_issue>` **A package from conda-forge is outdated or broken, where can I report the issue?**
 
-  You can open an issue in the packages feedstock repository on github. Search for the repository ``conda-forge/<package-name>-feedstock``. There you can also suggest fixes or even become a maintainer. Please refer to :ref:`maintaining_pkgs` for details.
+  You can open an issue in the packages feedstock repository on GitHub. Search for the repository ``conda-forge/<package-name>-feedstock``. There you can also suggest fixes or even become a maintainer. Please refer to :ref:`maintaining_pkgs` for details.
 
 .. _faq_contact:
 

--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -11,9 +11,9 @@ What is conda-forge?
 
 conda-forge is a community effort that provides conda packages for a wide range of software.
 
-**Missing a package that you would love to install with conda?** - Chances are we already packaged it for you!
+**Missing a package that you would love to install with conda?** - Chances are we have already packaged it for you!
 
-You can `search <https://anaconda.org/>`__ for packages online. Look out for packages provided  by our ``conda-forge`` organization.
+You can `search <https://anaconda.org/>`__ for packages online. Look out for packages provided by our ``conda-forge`` organization.
 
 **Cannot find a package or only outdated versions of a package?** - Everybody is welcome to contribute to our package stack! Please refer to :ref:`becoming_involved`, for an overview over how to start contributing.
 
@@ -28,7 +28,7 @@ In the past users only had the option to create an `anaconda cloud <https://anac
 
 This came with a list of disadvantages:
 
- - locating packages was difficult due them being scattered over many channels.
+ - locating packages was difficult due to them being scattered over many channels.
  - combining packages across channels was not always possible due to binary incompatibilities.
  - packages were only available for architectures the developer was interested in or had access to. 
  - channels were often abandoned, updating required locating new channels
@@ -38,7 +38,7 @@ conda-forge is a community effort that tackles these issues:
  - all packages are shared in a single channel named ``conda-forge``
  - care is taken that all packages are up-to-date
  - common standards ensure that all packages have compatible versions
- - by default we build packages for macOS, linux amd64 and windows amd64
+ - by default, we build packages for macOS, linux amd64 and windows amd64
  - many packages are updated by multiple maintainers with an easy option to become a maintainer
  - an active core developer team is trying to also maintain abandoned packages
 

--- a/src/user/tipsandtricks.rst
+++ b/src/user/tipsandtricks.rst
@@ -21,9 +21,9 @@ That happens because either the correct version of ``icu``,
 or any other package in the error,
 is not present or the package is missing altogether.
 
-Once can confirm by issuing the command ``conda list`` and searching for the package in question.
+Once you can confirm by issuing the command ``conda list`` and searching for the package in question.
 
-Why that happens?
+Why does that happen?
 -----------------
 
 The ``conda-forge`` and ``defaults`` are not 100% compatible.
@@ -58,14 +58,14 @@ Here is how a ``.condarc`` file would look like:
       - conda-forge
       - defaults
 
-In addition to the channel priority we recommend to always install your packages inside a new environment instead the root environment from anaconda/miniconda.
+In addition to the channel priority, we recommend to always install your packages inside a new environment instead of the root environment from anaconda/miniconda.
 Using envs make it easier to debug problems with packages and ensure the stability of your root env.
 
 .. note::
   In the past ``conda-forge`` used to vendorize some of ``defaults`` dependencies that were not built in our infrastructure,
   like compilers run-times, to avoid the mixing channel problem.
   However, with the ``strict`` option, we no longer have to vendorize those (this led to its own set of problems),
-  instead we removed everything that is not built in ``conda-forge`` and let ``strict`` pull those from ``defaults``.
+  instead, we removed everything that is not built in ``conda-forge`` and let ``strict`` pull those from ``defaults``.
 
   TL;DR if you are experiencing missing compilers run-times like ``libgcc-ng``,
   that is probably because you removed ``defaults``,


### PR DESCRIPTION
This is one of my first contributions to a project, I hope I didn't do anything wrong :)

There is one last sentence that causes problems, it is on line 77 of src/orga/governance.rst, and should be reworded:

> Standard items are ones where **_public record and discourse and record_** is preferable. Sensitive voting items are ones where the results of the preferable.

Sorry for having a commit for each file, I was using the web editor, and can't squash the commits...