### PR TITLE
Initial move of inactive members to emeritus

### DIFF
--- a/src/core.csv
+++ b/src/core.csv
@@ -1,16 +1,14 @@
+github_username,email,name
 mbargull,marcel.bargull@udo.edu,Marcel Bargull
 mwcraig,mattwcraig@gmail.com,Matt Craig
 ericdill,ericdill@pm.me,Eric Dill
-pelson,pelson.pub@gmail.com,Phil Elson
 ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes
 isuruf,isuruf@gmail.com,Isuru Fernando
-bgruening,bjoern.gruening@gmail.com,Björn Grüning
 jjhelmus,jjhelmus@gmail.com,Jonathan J. Helmus
 jakirkham,kirkhamj@janelia.hhmi.org,John Kirkham
 mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
 msarahan,msarahan@gmail.com,Mike Sarahan
 scopatz,scopatz@gmail.com,Anthony Scopatz
-patricksnape,patricksnape@gmail.com,Patrick Snape
 dougalsutherland,dougal@gmail.com,Dougal J. Sutherland
 CJ-Wright,cjwright4242@gmail.com,Christopher J. Wright
 loriab,lori.burns@gmail.com,Lori A. Burns

--- a/src/emeritus.csv
+++ b/src/emeritus.csv
@@ -1,0 +1,4 @@
+github_username,email,name
+pelson,pelson.pub@gmail.com,Phil Elson
+patricksnape,patricksnape@gmail.com,Patrick Snape
+bgruening,bjoern.gruening@gmail.com,Björn Grüning


### PR DESCRIPTION
Hi @patricksnape @pelson and @bgruening,

As per the recent addition to our governance docs (in #795) we have added the notion of an emeritus member of the conda-forge community. The primary way in which your role is changing is called out in #795, but bears repeating here:

> Emeritus core members can still vote and be back to active core any time, the only difference is that emeritus-core will not count as the total core members when computing the necessary votes a poll needs to pass.

The @conda-forge/core team would like to thank you for contributions to the community. We will happily welcome you back to /core if you become active again on the core team!