### PR TITLE
Use square brackets instead of angle brackets in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
                           Create a new branch from the staged-recipes master branch.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-pencil"></i>
-                          Add a new conda recipe in the "recipes/<your-package-name>" directory.
+                          Add a new conda recipe in a new "recipes/[your-package-name]" directory.
                           There is an example of a well-written recipe in "recipes/example" you can copy.
                           <a href="docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml">Further guidance on writing good recipes</a>.
                       </li>


### PR DESCRIPTION
In #808, I used angle brackets to denote a name the user should replace. Of course, this did not render in HTML. This replaces the angle brackets with square brackets.
