### PR TITLE
CI: Switch conda activate to source activate

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -12,7 +12,7 @@ if [ -n "$GH_TOKEN" ]; then
     git checkout -b new_site_content
     # Generate html requires a GitHub token in order to query the available feedstocks.
     conda env create -f ./.ci_scripts/environment.yml
-    conda activate conda-forge-docs
+    source activate conda-forge-docs
 
     # rebuild elm
     # uncomment to restore search


### PR DESCRIPTION
Currently getting the following error on CI. My fix is to switch `conda activate` -> `source activate` unless there is a reason not to

```
conda activate conda-forge-docs
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run
    $ conda init <SHELL_NAME>
Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell
See 'conda init --help' for more information and options.
IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```