### PR TITLE
Docs: .circleci should now be .azure-pipelines

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -141,19 +141,21 @@ Testing changes locally
 
 If you have docker installed on your system, you can test builds locally on your machine under the same settings as it is built by our :term:`CI`.
 
-If you want to build and test updates to  a feedstock locally, go to the root
-feedstock directory and run, the ``.circleci/run_docker_build.sh`` script.
+If you want to build and test updates to a feedstock locally, go to the root
+feedstock directory and run:
 
-The environment variable ``CONFIG`` is required to select one of the ``*.yaml``
-config files in ``.ci_support`` to use for the build.
-older feedstocks).
+.. code-block:: shell
 
-For example, the docker build with the config in ``.ci_support/linux_.yaml`` can be invoked by:
+    python build-locally.py
 
-.. code-block:: sh
 
-    $ cd my-feedstock
-    $ CONFIG="linux_" ./.circleci/run_docker_build.sh
+This will prompt you to choose one of the ``*.yaml`` config files in ``.ci_support/``.
+
+Alternatively, you can specify ahead which config to use with e.g. (assuming you wish to build and test python 3.6 on linux, and such a config file exists at ``.ci_support/linux_python3.6.yaml``):
+
+.. code-block:: shell
+
+    python build-locally.py linux_python3.6
 
 
 Removing broken packages


### PR DESCRIPTION
Looking at a recently created feedstock, it appears `.circleci/run_docker_build.sh` should now be `.azure-pipelines/run_docker_build.sh`

See e.g.
- https://github.com/conda-forge/vose-alias-method-feedstock/tree/master/.azure-pipelines
- https://github.com/conda-forge/vose-alias-method-feedstock/tree/master/.circleci

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
