### PR TITLE
Add link to docker local testing

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,6 +213,7 @@
                           Add a new conda recipe in a new "recipes/[your-package-name]" directory.
                           There is an example of a well-written recipe in "recipes/example" you can copy.
                           <a href="docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml">Further guidance on writing good recipes</a>.
+                          <a href="docs/maintainer/adding_pkgs.html#running-tests-locally-for-staged-recipes">You can also test the recipe locally.</a>
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-pull-request"></i>
                           Propose the change as a pull request.


### PR DESCRIPTION
I think it is helpful to direct users initially to a way to test their packages locally. It is faster than waiting for CI to test them and puts less train on your servers.
