### PR TITLE
docs: reverse minutes order - most recent one now on the top

### DIFF
--- a/src/minutes/00_intro.rst
+++ b/src/minutes/00_intro.rst
@@ -3,6 +3,7 @@ Core team meeting minutes
 
 .. toctree::
   :glob:
+  :reversed:
   :titlesonly:
 
   *


### PR DESCRIPTION
Reversing the minutes so that the most recent meeting is on the top:

![image](https://user-images.githubusercontent.com/15384900/67616154-a29fff00-f7d5-11e9-95a6-a475620e9bb5.png)
