### PR TITLE
Allow voting on non-helios platforms

### DIFF
--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -84,8 +84,9 @@ Voting items are labeled as either **standard** or **sensitive**.
 Standard items are ones where public record and discourse is
 preferable. Sensitive voting items are ones where the results of the
 vote should remain private to the voters after the vote has occurred.
-Sensitive votes should take place on
-`the Helios voting system <https://vote.heliosvoting.org/>`_ in order
+Sensitive votes should take place on a secure anonymous voting platform
+(such as `Polys <polys.me>`_ or
+`the Helios voting system <https://vote.heliosvoting.org/>`_) in order
 retain anonymity.
 
 The default voting period is 1 week (7 days). This may be modified at

--- a/src/orga/governance.rst
+++ b/src/orga/governance.rst
@@ -86,7 +86,7 @@ preferable. Sensitive voting items are ones where the results of the
 vote should remain private to the voters after the vote has occurred.
 Sensitive votes should take place on a secure anonymous voting platform
 (such as `Polys <polys.me>`_ or
-`the Helios voting system <https://vote.heliosvoting.org/>`_) in order
+`the Helios voting system <https://vote.heliosvoting.org/>`_) in order to
 retain anonymity.
 
 The default voting period is 1 week (7 days). This may be modified at


### PR DESCRIPTION
Since Helios is a rather cumbersome system we should not force ourselves via
governance document to use it.