### PR TITLE
DOC added docs on matplotlib-base

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -672,7 +672,8 @@ Matplotlib
 
 ``matplotlib`` on ``conda-forge`` comes in two parts. The core library is in ``matplotlib-base``. The
 actual ``matplotlib`` package is this core library plus ``pyqt``. Most, if not all, packages that have
-dependence at runtime on ``matplotlib`` should list this dependence as ``matplotlib-base``. 
+dependence at runtime on ``matplotlib`` should list this dependence as ``matplotlib-base`` unless they 
+explicitly need ``pyqt``. ``pyqt`` is a rather large package, so not requiring it is better for users.
 
 
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -673,7 +673,9 @@ Matplotlib
 ``matplotlib`` on ``conda-forge`` comes in two parts. The core library is in ``matplotlib-base``. The
 actual ``matplotlib`` package is this core library plus ``pyqt``. Most, if not all, packages that have
 dependence at runtime on ``matplotlib`` should list this dependence as ``matplotlib-base`` unless they 
-explicitly need ``pyqt``. ``pyqt`` is a rather large package, so not requiring it is better for users.
+explicitly need ``pyqt``. ``pyqt`` is a rather large package, so not requiring it indirectly is better for users.
+Rationale is that a user installing ``matplotlib`` explicitly would get the batteries included version, but
+it should not be installed indirectly.
 
 
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -665,6 +665,16 @@ BLAS ``3.8.0`` API.  This means that, at install time, the user can select what 
 they like without any knowledge of the version of the BLAS implementation needed.
 
 
+.. _knowledge:mpl:
+
+Matplotlib
+----------
+
+``matplotlib`` on ``conda-forge`` comes in two parts. The core library is in ``matplotlib-base``. The
+actual ``matplotlib`` package is this core library plus ``pyqt``. Most, if not all, packages that have
+dependence at runtime on ``matplotlib`` should list this dependence as ``matplotlib-base``. 
+
+
 
 Noarch builds
 =============


### PR DESCRIPTION
Per the discussion in #933, most packages only need a dependence on `matplotlib-base` as opposed to the `matplotlib` package (which includes `pyqt`). This PR adds docs for that.

<!--
Thank you for pull request.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Closes #933 