### PR TITLE
Add FAQ entry for conda package not appearing

### DIFF
--- a/src/maintainer/maintainer_faq.rst
+++ b/src/maintainer/maintainer_faq.rst
@@ -63,3 +63,8 @@ FAQ
 
    Sadly in the Azure Windows images, `MSBuild.exe` is not correctly setup for CMake builds with the ``Visual Studio`` generators. To work around this, you can use a different CMake generator, e.g. ``cmake -GNinja`` or ``cmake -G"NMake Makefiles JOM"``. These two are preferred because they allow for concurrent builds in contrast to e.g. only using ``cmake -G"NMake Makefiles"``
 
+.. _mfaq_anaconda_delay:
+
+:ref:`(Q) <mfaq_anaconda_delay>` **Why does my new version appear on Anaconda Cloud, but is not installable with conda?**
+
+   For certain, high-traffic channels (main & conda-forge), Anaconda uses a CDN to decrease costs. The CDN is only reindexed every 20 min, however Anaconda.org uses the original channel that the CDN mirrors.  Therefore, packages will show up on the anaconda.org ~20-40 min before they are downloadable by conda.  You can use conda search <pkg>  to see if the package is installable, because this command reads from the CDN.


### PR DESCRIPTION
I was confused when I released a new version of a package, and it showed up on the package page, but I wasn't able to download it locally. @scopatz explained to me this is because of a CDN. I added this explanation to the FAQ to help others who have the same question.

<!--
Thank you for pull request.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
