### PR TITLE
Update maintainer docs for pushing to regro branch

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -32,7 +32,7 @@ When a new version of a package is released on PyPI/CRAN/.., we have a bot that 
 #. Manually setting up git remotes:
 
    - Clone the conda-forge feedstock repository
-   - Add the remote of the bot: ``git remote add regro-cf-autotick-bot https://github.com/regro-cf-autotick-bot/<package>-feedstock.git``
+   - Add the remote of the bot: ``git remote add regro-cf-autotick-bot git@github.com:regro-cf-autotick-bot/<package>-feedstock.git``
 
      .. important::
         It is not possible to push to a GitHub repository using the

--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -32,7 +32,7 @@ When a new version of a package is released on PyPI/CRAN/.., we have a bot that 
 #. Manually setting up git remotes:
 
    - Clone the conda-forge feedstock repository
-   - Add the remote of the bot: ``git add regro-cf-autotick-bot git@github.com:regro-cf-autotick-bot/<package>-feedstock.git``
+   - Add the remote of the bot: ``git remote add regro-cf-autotick-bot https://github.com/regro-cf-autotick-bot/<package>-feedstock.git``
 
      .. important::
         It is not possible to push to a GitHub repository using the


### PR DESCRIPTION
The docs were missing the `remote` bit of `git remote add`. Also, as `https` is the recommended way of working with remotes, switch to using that instead of `git:`