### PR TITLE
[docs] fixed typo in maintainer docs about test block

### DIFF
--- a/docs/_sources/maintainer/adding_pkgs.rst.txt
+++ b/docs/_sources/maintainer/adding_pkgs.rst.txt
@@ -58,7 +58,7 @@ Step-by-step Instructions
    example recipe using the ``openssl`` tool. As an alternative, you can also
    go to the package description on `PyPi <https://pypi.org>`_ from which you
    can directly copy the SHA256.
-#. Be sure to fill in the ``tests`` section. The simplest test will simply
+#. Be sure to fill in the ``test`` section. The simplest test will simply
    test that the module can be imported, as described in the example.
 #. Remove all irrelevant comments in the ``meta.yaml``  file.
 

--- a/docs/maintainer/adding_pkgs.html
+++ b/docs/maintainer/adding_pkgs.html
@@ -110,7 +110,7 @@ unchanged!</p></li>
 example recipe using the <code class="docutils literal notranslate"><span class="pre">openssl</span></code> tool. As an alternative, you can also
 go to the package description on <a class="reference external" href="https://pypi.org">PyPi</a> from which you
 can directly copy the SHA256.</p></li>
-<li><p>Be sure to fill in the <code class="docutils literal notranslate"><span class="pre">tests</span></code> section. The simplest test will simply
+<li><p>Be sure to fill in the <code class="docutils literal notranslate"><span class="pre">test</span></code> section. The simplest test will simply
 test that the module can be imported, as described in the example.</p></li>
 <li><p>Remove all irrelevant comments in the <code class="docutils literal notranslate"><span class="pre">meta.yaml</span></code>  file.</p></li>
 </ol>

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -58,7 +58,7 @@ Step-by-step Instructions
    example recipe using the ``openssl`` tool. As an alternative, you can also
    go to the package description on `PyPi <https://pypi.org>`_ from which you
    can directly copy the SHA256.
-#. Be sure to fill in the ``tests`` section. The simplest test will simply
+#. Be sure to fill in the ``test`` section. The simplest test will simply
    test that the module can be imported, as described in the example.
 #. Remove all irrelevant comments in the ``meta.yaml``  file.
 


### PR DESCRIPTION
While reading through https://conda-forge.org/docs/maintainer/adding_pkgs.html#step-by-step-instructions today, I noticed what I think is a mistake.

The docs say:

> 7. Be sure to fill in the `tests` section.

However I think it should be `test`, not `tests`. It is `test` in [the conda-forge example recipe](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L48) and in [the `conda-build` docs on conda.io](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs.html#editing-the-meta-yaml-file).

Thanks for considering this PR!