### PR TITLE
Add cmake section to knowledge base.

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -803,7 +803,7 @@ If you are using cmake, be sure to make it a build requirement in the ``build`` 
 
 .. code-block:: yaml
 
-    host:
+    build:
       - cmake
 
 CMake requires you to supply a configuration file, usually called ``CMakeLists.txt``.

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -31,9 +31,6 @@ Some optional, but useful CMake options:
     - ``-DCMAKE_INSTALL_PREFIX=$PREFIX`` Specify the install location.
     - ``-DCMAKE_INSTALL_LIBDIR=lib`` Libraries will land in $PREFIX/lib, sometimes projects install
       into lib64 or similar but on conda-forge we keep shared libraries in simply lib.
-    - ``-DBUILD_TESTING=OFF`` Disable building the unit tests. We normally only test the existence of
-      certain files and don't build the whole unit tests suite. Disabling it saves a lot of compute
-      resources as well as minimizing the number of dependencies needed for the build.
     - ``-DBUILD_SHARED_LIBS=ON`` Instruct CMake to build shared libraries instead of static ones.
 
 Here are some basic commands to get you started. These are dependent on your source

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -28,7 +28,7 @@ code layout and aren't intended to be used "as is".
     cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
     cmake --build . --config Release
 
-**CMake lines for bld.bat (macOS/Linux):**
+**CMake lines for bld.bat (Windows):**
 
 .. code-block::
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -51,6 +51,8 @@ Some projects provide hooks for CMake to build the project. The following
 example ``bld.bat`` file demonstrates how to build a traditional, out-of-core
 build for such projects.
 
+See also the Using CMake section below.
+
 **CMake-based bld.bat:**
 
 .. code-block:: bat
@@ -790,6 +792,52 @@ Following implies that ``python`` is a runtime dependency and a Python matrix fo
       - True
 
 You need to rerender the feedstock after this change.
+
+Using CMake
+===========
+
+`CMake <https://cmake.org/>`__ can be used to build more complex projects in ``build.sh``
+or ``bld.bat`` scripts.
+
+If you are using cmake, be sure to make it a build requirement in the ``build`` or ``host`` section.
+
+.. code-block:: yaml
+
+    host:
+      - cmake
+
+CMake requires you to supply a configuration file, usually called ``CMakeLists.txt``.
+You can use the one from your source tar ball if it exists or include your own in the
+same directory as the conda-forge recipe file and copy it to the source directory.
+
+You can tell CMake which Python to use by passing ``-DPython3_EXECUTABLE="$PYTHON"``
+(macOS or Linux) or ``-DPython3_EXECUTABLE="%PYTHON%"`` (Windows) as a command line option
+to CMake.
+
+Here are some basic commands to get you started. These are highly dependent on your source
+code layout and aren't intended to be used "as is".
+
+.. code-block::
+
+    cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
+    cmake --build . --config Release
+
+.. code-block::
+
+    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE="%PYTHON%"
+    if errorlevel 1 exit /b 1
+
+Other useful options are ``-B<directory>`` and ``-S<directory>`` to specify build and source
+directories.
+
+Inside the ``CMakeLists.txt`` file, the following options may be useful.
+
+.. code-block::
+
+    find_package (Python3 COMPONENTS Development NumPy)
+    target_include_directories(${APP_NAME} PRIVATE ${Python3_INCLUDE_DIRS})
+    target_include_directories(${APP_NAME} PRIVATE ${Python3_NumPy_INCLUDE_DIRS})
+    target_link_libraries(${APP_NAME} ${PYTHON_LIBRARIES})
 
 Requiring newer macOS SDKs
 ==========================

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1,6 +1,47 @@
 Knowledge base
 **************
 
+Using CMake
+===========
+
+`CMake <https://cmake.org/>`__ can be used to build more complex projects in ``build.sh``
+or ``bld.bat`` scripts.
+
+If you are using cmake, be sure to make it a build requirement in the ``build`` section.
+
+.. code-block:: yaml
+
+    requirements:
+      build:
+        - cmake
+
+You can tell CMake which Python to use by passing ``-DPython3_EXECUTABLE="$PYTHON"``
+(macOS or Linux) or ``-DPython3_EXECUTABLE="%PYTHON%"`` (Windows) as a command line option.
+
+Here are some basic commands to get you started. These are dependent on your source
+code layout and aren't intended to be used "as is".
+
+**CMake lines for build.sh (macOS/Linux):**
+
+.. code-block::
+
+    cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
+    cmake --build . --config Release
+
+**CMake lines for bld.bat (macOS/Linux):**
+
+.. code-block::
+
+    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE="%PYTHON%"
+    if errorlevel 1 exit /b 1
+    cmake --build . --config Release
+    if errorlevel 1 exit /b 1
+
+See also the ``bld.bat`` in the Windows section below for an additional example.
+
+Other useful ``cmake`` options are ``-B<directory>`` and ``-S<directory>`` to specify build and source
+directories.
+
 Particularities on Windows
 ==========================
 
@@ -50,8 +91,6 @@ Simple CMake-Based ``bld.bat``
 Some projects provide hooks for CMake to build the project. The following
 example ``bld.bat`` file demonstrates how to build a traditional, out-of-core
 build for such projects.
-
-See also the Using CMake section below.
 
 **CMake-based bld.bat:**
 
@@ -792,52 +831,6 @@ Following implies that ``python`` is a runtime dependency and a Python matrix fo
       - True
 
 You need to rerender the feedstock after this change.
-
-Using CMake
-===========
-
-`CMake <https://cmake.org/>`__ can be used to build more complex projects in ``build.sh``
-or ``bld.bat`` scripts.
-
-If you are using cmake, be sure to make it a build requirement in the ``build`` or ``host`` section.
-
-.. code-block:: yaml
-
-    build:
-      - cmake
-
-CMake requires you to supply a configuration file, usually called ``CMakeLists.txt``.
-You can use the one from your source tar ball if it exists or include your own in the
-same directory as the conda-forge recipe file and copy it to the source directory.
-
-You can tell CMake which Python to use by passing ``-DPython3_EXECUTABLE="$PYTHON"``
-(macOS or Linux) or ``-DPython3_EXECUTABLE="%PYTHON%"`` (Windows) as a command line option
-to CMake.
-
-Here are some basic commands to get you started. These are highly dependent on your source
-code layout and aren't intended to be used "as is".
-
-.. code-block::
-
-    cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
-    cmake --build . --config Release
-
-.. code-block::
-
-    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE="%PYTHON%"
-    if errorlevel 1 exit /b 1
-
-Other useful options are ``-B<directory>`` and ``-S<directory>`` to specify build and source
-directories.
-
-Inside the ``CMakeLists.txt`` file, the following options may be useful.
-
-.. code-block::
-
-    find_package (Python3 COMPONENTS Development NumPy)
-    target_include_directories(${APP_NAME} PRIVATE ${Python3_INCLUDE_DIRS})
-    target_include_directories(${APP_NAME} PRIVATE ${Python3_NumPy_INCLUDE_DIRS})
-    target_link_libraries(${APP_NAME} ${PYTHON_LIBRARIES})
 
 Requiring newer macOS SDKs
 ==========================

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -7,16 +7,34 @@ Using CMake
 `CMake <https://cmake.org/>`__ can be used to build more complex projects in ``build.sh``
 or ``bld.bat`` scripts.
 
-If you are using cmake, be sure to make it a build requirement in the ``build`` section.
+If you are using cmake, be sure to make it a build requirement in the ``build`` section. You
+may also need to include ``make`` or ``ninja`` depending on your platform and build tools.
+On Windows, you can also use ``nmake`` to build, but that does not need to be explicitly included.
 
 .. code-block:: yaml
 
     requirements:
       build:
         - cmake
+        - make  # [not win]
+        - ninja  # [win]
 
-You can tell CMake which Python to use by passing ``-DPython3_EXECUTABLE="$PYTHON"``
+For CMake projects using the `FindPython3 <https://cmake.org/cmake/help/git-stage/module/FindPython3.html>`__
+module, you can tell CMake which Python to use by passing ``-DPython3_EXECUTABLE="$PYTHON"``
 (macOS or Linux) or ``-DPython3_EXECUTABLE="%PYTHON%"`` (Windows) as a command line option.
+Older CMake projects may require similar, but slightly different options.
+
+Some optional, but useful CMake options:
+
+    - ``-DCMAKE_BUILD_TYPE=Release`` Configure as release build. This is better done on the initial
+      ``cmake`` call as some packages construct different build configurations depending on this flag.
+    - ``-DCMAKE_INSTALL_PREFIX=$PREFIX`` Specify the install location.
+    - ``-DCMAKE_INSTALL_LIBDIR=lib`` Libraries will land in $PREFIX/lib, sometimes projects install
+      into lib64 or similar but on conda-forge we keep shared libraries in simply lib.
+    - ``-DBUILD_TESTING=OFF`` Disable building the unit tests. We normally only test the existence of
+      certain files and don't build the whole unit tests suite. Disabling it saves a lot of compute
+      resources as well as minimizing the number of dependencies needed for the build.
+    - ``-DBUILD_SHARED_LIBS=ON`` Instruct CMake to build shared libraries instead of static ones.
 
 Here are some basic commands to get you started. These are dependent on your source
 code layout and aren't intended to be used "as is".
@@ -32,7 +50,7 @@ code layout and aren't intended to be used "as is".
 
 .. code-block::
 
-    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE="%PYTHON%"
+    cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE="%PYTHON%"
     if errorlevel 1 exit /b 1
     cmake --build . --config Release
     if errorlevel 1 exit /b 1


### PR DESCRIPTION
<!--
Thank you for pull request.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Supersedes https://github.com/conda-forge/conda-forge.github.io/pull/1015

Basic CMake build notes. I decided to make it different from the existing section since the existing section is Windows-specific. May consider merging/expanding the two sections in the future.