### PR TITLE
Redirect ReadTheDocs 404's to current docs

### DIFF
--- a/rtd/conf.py
+++ b/rtd/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import shutil
 import sys
 import os
 
@@ -296,3 +297,15 @@ htmlhelp_basename = 'conda-forgedoc'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+
+def add_404(app, docname):
+    if app.builder.format == "html":
+        pth_index = os.path.join(app.outdir, "index.html")
+        pth_404 = os.path.join(app.outdir, "404.html")
+        if os.path.exists(pth_index):
+            shutil.copyfile(pth_index, pth_404)
+
+
+def setup(app):
+    app.connect("build-finished", add_404)


### PR DESCRIPTION
Follows [this documentation]( https://docs.readthedocs.io/en/stable/guides/custom-404-page.html#use-a-custom-404-not-found-page-on-my-project ) to setup a 404 page. The idea being it will redirect any other pages we don't provide (that would otherwise 404) to our current doc page. Reuses the same `index.html` to create the `404.html`.

Publishing to here: https://conda-forge.readthedocs.io/en/jakirkham-rtd_redirect_404

The idea is this ~~*should* (though currently doesn't)~~ does redirect: https://conda-forge.readthedocs.io/en/jakirkham-rtd_redirect_404/foobar.html