### PR TITLE
specify usage of personal fork in docs/maintainers/updating_pkgs.html

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 <!--
 Thank you for pull request.
+Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
+to `.html` files will only be effective if applied to the respective `.rst`.
 -->
 
 <!--

--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -22,7 +22,7 @@ For updates, using a branch in the main repo is discouraged because,
    This means if you push a version update to a branch and then create a :term:`PR`, conda packages will be published to anaconda.org before the PR is merged.
 
 .. important::
-  For these reasons, maintainers are asked to fork the feedstock, push to a branch in the fork and then open a PR to the ``conda-forge`` repo.
+  For these reasons, maintainers are asked to fork the feedstock to their personal account, push to a branch in the fork and then open a PR to the ``conda-forge`` repo.
 
 Pushing to regro-cf-autotick-bot branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently only personal forks allow the "allow maintainer changes"
functionality in a PR.
refs https://github.com/conda-forge/webservices-dispatch-action/issues/4

