### PR TITLE
Update adding_pkgs.rst

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -556,7 +556,7 @@ You can include files required for testing with the ``source_files`` section:
       imports:
         - package_name
       requires:
-        - pytest tests test_pkg_integration.py
+        - pytest
       source_files:
         - tests
         - test_pkg_integration.py

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -560,6 +560,8 @@ You can include files required for testing with the ``source_files`` section:
       source_files:
         - tests
         - test_pkg_integration.py
+      commands:
+        - pytest tests test_pkg_integration.py
 
 The ``source_files`` section works for files and directories.
 


### PR DESCRIPTION
removes typo from "Copying test files" section in docs. tests and example .py file can't be also in the requires section

<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
