### PR TITLE
add guidelines on how to take over maintenance

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -218,6 +218,30 @@ package (an example would be to re-render the feedstock to support new Python ve
 
 If you believe a feedstock should be archived, please contact `@conda-forge/core <https://github.com/orgs/conda-forge/teams/core>`__.
 
+.. _maint_updating_maintainers:
+
+Updating the maintainer list
+============================
+
+The list of maintainers of a feedstock is recorded in the recipe itself. The list of maintainers can be updated with following steps:
+
+1. Add your github-id to the ``recipe-maintainers`` section at the bottom of the ``recipe/meta.yaml`` file in the feedstock:
+
+  .. code-block:: yaml
+
+    extra:
+      recipe-maintainers:
+        - current-maintainer
+        - your-github-id
+
+2. Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
+
+3. :ref:`Rerender<dev_update_rerender>` the feedstock by posting ``@conda-forge-admin, please rerender`` as a new comment in the :term:`PR`.
+
+4. Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
+
+Once the PR is merged, our infrastructure will grant and revoke maintainer permissions.
+
 
 Maintaining several versions
 ============================

--- a/src/orga/guidelines.rst
+++ b/src/orga/guidelines.rst
@@ -121,27 +121,10 @@ by default. However, the package remains available so as to avoid the problems l
 To get your package relabeled as ``broken`` instead of ``main``, please refer to :ref:`maint_fix_broken_packages`.
 
 
-.. _becoming_maintainer:
-
 Becoming a maintainer
 =====================
 
 Conda-forge is a community project and it can therefore happen that feedstocks become temporarily abandoned.
-You can join the maintainer team by following steps:
+You can join the maintainer team of a feedstock by adding your github-id to the ``recipe-maintainers`` section in the recipe's ``meta.yaml``. 
+Please refer to :ref:`maint_updating_maintainers` for detailed instructions.
 
-1) Add your github-id to the ``recipe-maintainers`` section at the bottom of the ``recipe/meta.yaml`` file in the feedstock:
-
-  .. code-block:: yaml
-
-    extra:
-      recipe-maintainers:
-        - current-maintainer
-        - your-github-id
-
-2) Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
-
-3) :ref:`Rerender<dev_update_rerender>` the feedstock by posting ``@conda-forge-admin, please rerender`` as a new comment in the :term:`PR`.
-
-4) Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
-
-Once the PR is merged, our infrastructure will grant you maintainer permissions.

--- a/src/orga/guidelines.rst
+++ b/src/orga/guidelines.rst
@@ -121,6 +121,8 @@ by default. However, the package remains available so as to avoid the problems l
 To get your package relabeled as ``broken`` instead of ``main``, please refer to :ref:`maint_fix_broken_packages`.
 
 
+.. _becoming_maintainer:
+
 Becoming a maintainer
 =====================
 
@@ -138,6 +140,8 @@ You can join the maintainer team by following steps:
 
 2) Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
 
-3) Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
+3) :ref:`Rerender<dev_update_rerender>` the feedstock by posting ``@conda-forge-admin, please rerender`` as a new comment in the :term:`PR`.
+
+4) Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
 
 Once the PR is merged, our infrastructure will grant you maintainer permissions.

--- a/src/orga/guidelines.rst
+++ b/src/orga/guidelines.rst
@@ -90,9 +90,9 @@ Renaming Packages
 Sometimes packages are misnamed.
 To correct the name of the package, please submit a PR into staged-recipes with the correct name.
 During the review process please make certain to note that the package is a rename and contact a member of conda-forge/core to remove the old feedstock (and potentially package if needed).
-Occasionally the .gitmodules file in the `feedstocks <https://github.com/conda-forge/feedstocks/blob/master/.gitmodules>` needs to be updated to remove the old feedstock.
+Occasionally the .gitmodules file in the `feedstocks <https://github.com/conda-forge/feedstocks/blob/master/.gitmodules>`__ needs to be updated to remove the old feedstock.
 It's not entirely clear what those circumstances are.
-See `conda-forge.github.io#1070 <https://github.com/conda-forge/conda-forge.github.io/issues/1070>`.
+See `conda-forge.github.io#1070 <https://github.com/conda-forge/conda-forge.github.io/issues/1070>`__.
 
 .. _fix_broken_packages:
 
@@ -119,3 +119,25 @@ drops the "main" label and replaces it with "broken". This still makes it unavai
 by default. However, the package remains available so as to avoid the problems listed above.
 
 To get your package relabeled as ``broken`` instead of ``main``, please refer to :ref:`maint_fix_broken_packages`.
+
+
+Becoming a maintainer
+=====================
+
+Conda-forge is a community project and it can therefore happen that feedstocks become temporarily abandoned.
+You can join the maintainer team by following steps:
+
+1) Add your github-id to the ``recipe-maintainers`` section at the bottom of the ``recipe/meta.yaml`` file in the feedstock:
+
+  .. code-block:: yaml
+
+    extra:
+      recipe-maintainers:
+        - current-maintainer
+        - your-github-id
+
+2) Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
+
+3) Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
+
+Once the PR is merged, our infrastructure will grant you maintainer permissions.


### PR DESCRIPTION
adds guideline for taking over maintainer role. (see also https://github.com/conda-forge/conda-forge.github.io/issues/1078)