### PR TITLE
Only add OpenMP libraries to `build`

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -612,7 +612,7 @@ Without a preferred ``nompi`` variant, recipes that require mpi are much simpler
 OpenMP
 ------
 
-You can enable OpenMP on macOS by adding the ``llvm-openmp`` package to the ``build``, ``host``, and ``run`` sections of the ``meta.yaml``.
+You can enable OpenMP on macOS by adding the ``llvm-openmp`` package to the ``build`` section of the ``meta.yaml``.
 For Linux OpenMP support is on by default, however it's better to explicitly depend on the `libgomp` package which is the OpenMP
 implementation from the GNU project.
 


### PR DESCRIPTION
As the libraries use `run_exports/strong`, there should be no need to add them to `host` and `run` as long as they are in `build`.