### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
                           but the distribution will not yet be available on the conda-forge channel.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-merge"></i>
-                          Once the recipe is ready it will be merged and new "feedstock" repository will automatically be created for the recipe.
+                          Once the recipe is ready it will be merged and a new "feedstock" repository will automatically be created for the recipe.
                           The build and upload processes take place in the feedstock, and once complete the package will be available on the conda-forge channel.</li>
                       </ul>
                     </p>


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
