### PR TITLE
DOC Describe azure store_build_artifacts flag for conda-forge.yml

### DIFF
--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -66,6 +66,9 @@ mapping for Azure-specific configuration options. For example:
       upload_packages: False
       # flag for forcing the building all supported providers
       force: False
+      # toggle for storing the conda build_artifacts directory (including the
+      # built packages) as an Azure pipeline artifact that can be downloaded
+      store_build_artifacts: False
 
 bot
 ---


### PR DESCRIPTION
Flag was added to conda-smithy with https://github.com/conda-forge/conda-smithy/pull/1355.

<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
