### PR TITLE
added instructions to display conda-forge packages in Anaconda Navigator

### DIFF
--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -82,3 +82,18 @@ From now on using ``conda install <package-name>`` will also find packages in ou
   Miniforge installers are available here: https://github.com/conda-forge/miniforge/#download
 
   Please refer to :ref:`multiple_channels` for pitfalls and more information.
+
+
+
+Display conda-forge packages in Anaconda Navigator
+------------------------------------------------------------
+
+#. Open **Anaconda Navigator** by running ``anaconda-navigator``
+#. Go to the **Environments** tab.
+#. Click the **Channels** button.
+#. Click the **Add** button.
+#. Enter the channel url ``https://conda.anaconda.org/conda-forge/``
+#. Press the **Enter key** on your keyboard.
+#. Click the **Update channels** button.
+
+From now on, whenever the **package filter** is set to **All** on the Environments tab, all conda-forge packages will be displayed.


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
fixes #1141

<!--
Please add any other relevant info below:
-->
