### PR TITLE
Add notes exported from Dropbox Paper

### DIFF
--- a/src/orga/minutes/2017-05-10.md
+++ b/src/orga/minutes/2017-05-10.md
@@ -1,0 +1,27 @@
+# conda-forge meetings
+ 
+**Download Markdown:** [**https://conda-forge.hackpad.com/ep/pad/export/2YkV96cvxPG/latest?format=md**](https://conda-forge.hackpad.com/ep/pad/export/2YkV96cvxPG/latest?format=md)
+ 
+
+# 2017-05-10: General Discussion
+
+Time: 17:00 (UTC)
+Hangout link: [https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)
+ 
+**Attendees**
+Jonathan Helmus, Eric Dill,  Filipe, @Michael Sarahan, Ray Donnelly
+ 
+**Notes**
+
+* [ ] Move to conda 4.3
+* [ ] Dropbox paper: Create conda-forge account and share the credentials amongst core devs. Will need an email account to register on dropbox, so someone would need to create a shared email account too (strawman: conda-forge@gmail.com). cc @John Kirkham
+* [ ] The token used to generate repos at staged-recipes got revoked by GitHub. @John Kirkham is working to fix that by using a token from a bot [John] has access to. Hoping we will be back up and running with a workaround. Complete fix will require Phil's help once he is able.
+* [ ] Where is conda-forge on using better compilers? libgomp, etc.
+* [ ] How much overlap is there between conda-build 3 and conda-build-all?
+* [ ] Any plans for conda-build to build packages in parallel implicitly? Mike says no.
+* [ ] should we pin toolchain to some version number?
+* [ ] No changes to toolchain for now until conda-build 3 and then Mike and Ray's new compilers
+
+
+ 
+

--- a/src/orga/minutes/2017-11-16.md
+++ b/src/orga/minutes/2017-11-16.md
@@ -1,0 +1,94 @@
+# 2017-11-16 compiler meeting notes
+Scheduled time: 9 AM central.  Meeting link: https://anaconda.webex.com/anaconda-en/j.php?MTID=m11b5ddad66325da22bbe58d7d1c02809
+
+
+# Adopting Anaconda compilers
+- Linux: gcc 7.2
+    - Prefixed compilers: require activation
+    - Common adaptations required for new anaconda compilers:
+- Mac: LLVM/clang 4.0.1
+    - prefixed compilers: require activation
+    - common adaptations required for new anaconda compilers:
+- Windows: activation scripts
+    - Need adaptation for Appveyor compiler locations
+    - common adaptations required:
+        - cmake 
+            - clear CC and/or CXX vars
+
+
+
+    import os
+    
+    print("Hello World")
+# Compiler flag unification
+- GCC
+    - toolchain: https://github.com/conda-forge/toolchain-feedstock/blob/master/recipe/activate.sh
+    - toolchain3: https://github.com/conda-forge/toolchain3-feedstock/blob/master/recipe/activate.sh
+    - anaconda: https://github.com/AnacondaRecipes/aggregate/blob/master/ctng-compilers-activation-feedstock/recipe/conda_build_config.cos6.x86_64.yaml#L41-L54
+| Variable | toolchain only                          | anaconda only                                                                                                                                             |  |
+| -------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |  |
+| CFLAGS   | -m${ARCH}                               | march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe                                                            |  |
+| CPPFLAGS |                                         | -D_FORTIFY_SOURCE=2 -O2                                                                                                                                   |  |
+| CXXFLAGS | -DBOOST_MATH_DISABLE_FLOAT128 -m${ARCH} | -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe |  |
+| LDFLAGS  | -Wl,-rpath,$PREFIX/lib                  | Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now                                                                                          |  |
+
+- LLVM/clang
+    - toolchain: https://github.com/conda-forge/toolchain-feedstock/blob/master/recipe/activate.sh
+    - toolchain3: https://github.com/conda-forge/toolchain3-feedstock/blob/master/recipe/activate.sh
+    - anaconda: https://github.com/AnacondaRecipes/aggregate/blob/master/clang/build.sh
+| Variable   | toolchain only                                                          | anaconda only                                                                                                                                                                |
+| ---------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CPPFLAGS   |                                                                         | -mmacosx-version-min=${MACOSX_VERSION_MIN}                                                                                                                                   |
+| CFLAGS     | -mmacosx-version-min=${MACOSX_VERSION_MIN} -m${ARCH}                    | -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe                                                                          |
+| CXXFLAGS   | -mmacosx-version-min=${MACOSX_VERSION_MIN} -m${ARCH}                    | -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 |
+| LDFLAGS    | -mmacosx-version-min=${MACOSX_VERSION_MIN} -lc++ -Wl,-rpath,$PREFIX/lib | -pie                                                                                                                                                                         |
+| LDFLAGS_CC |                                                                         | -Wl,-pie -Wl,-headerpad_max_install_names                                                                                                                                    |
+|            |                                                                         |                                                                                                                                                                              |
+
+- Fortran
+    - toolchain: (not set)
+    - toolchain3: (not set)
+    - anaconda: 
+        - Linux: https://github.com/AnacondaRecipes/aggregate/blob/master/ctng-compilers-activation-feedstock/recipe/conda_build_config.cos6.x86_64.yaml#L46
+        - Mac: https://github.com/AnacondaRecipes/aggregate/blob/master/gfortran-feedstock/recipe/build.sh#L5
+- Windows: flags that affect some things (cmake)
+| Variable       | anaconda value                  |
+| -------------- | ------------------------------- |
+| CFLAGS         | %CFLAGS% -MD -GL                |
+| CXXFLAGS       | %CXXFLAGS% -MD -GL              |
+| LDFLAGS_SHARED | %LDFLAGS_SHARED% -LTCG ucrt.lib |
+
+
+Overall: everyone receptive to new compilers.  Mike to provide way of keeping host and build prefix separate, even when not cross compiling.  This would avoid need for things like “always_include_files” and would facilitate conda-forge keeping their llvmdev recipe as is (for cling usage).  
+
+Filipe: this is really little more than a vendor change.  We already depend on other vendors for compilers (RH for devtoolset2; apple for existing clang), we’re only switching to a different vendor, not fundamentally changing what we do.
+
+Need to maintain llvm with cling patches, but this will not be the default compiler.
+
+# Conda-build 3: strategy for moving
+- install and use with c-b-a (no cb3 matrix)
+    - Waiting on feedback from issue https://github.com/conda-tools/conda-build-all/issues/94 but mostly seems OK.
+- Mike: needs to fix —skip-existing.  Concern is that re-rendering should not generate new packages when only some dependency has changed (bugfix bump?)
+    - Jonathan to explore ways to skip uploads when only hash has changed as a temporary workaround.
+- replace c-b-a with cb3 matrix support
+    - replace pinning script with central conda_build_config.yaml
+        - Re-render installs from conda-forge central config package, uses that config
+        - Each recipe can have its own conda_build_config.yaml alongside its meta.yaml file to override anything
+    - Where/how to store intermediate files and distribute CI jobs
+        - John recommended committing these to the feedstock repo during re-rendering
+        - Jonathan wondered about committing the full conda_build_config.yaml to the repo, or pulling it in as a dependency at build time, but then reducing it using environment variables.
+        - Mike wondered about CONDA_VARIANT_* as a pattern for environment variables that CB might recognize, so that we keep the current CI scheme.  This probably also integrates with Jonathan’s idea of reducing the matrix on a per-job basis.  Conda-smithy would create the set of jobs, each with different env vars to reduce the overall matrix for each job.
+- use run_exports and use either c-b-a or cb3
+    - People generally interested, but needs to be implemented and proven over time.  Good experience so far with defaults.
+
+
+# Fortran support on Windows
+- gfortran (msys2) / Flang
+- Timeline for adding either
+- Mike asked that whatever is done is done with community approval, for the sake of maintaining a high quality user experience.
+
+
+# OpenMP behavior
+- Currently, needs extra package on mac, but is included on Linux (not active in flags, though)
+- What is desirable default behavior?
+

--- a/src/orga/minutes/2018-02-20.md
+++ b/src/orga/minutes/2018-02-20.md
@@ -1,0 +1,48 @@
+# 2018-02-20 meeting notes
+
+
+- GSoC, ideas page, mentors, prospective students
+        Item #2 (conda skeleton) has largely been done in conda-build 3
+        Chris Wright has interest and perhaps has a student
+        Potential project: package graph - building it, storing it, updating it efficiently, traversing (part of) it
+        
+- conda-forge e-mail, dropbox paper, webpage, twitter account, etc
+        Who has access, who wants access?
+        Twitter: anyone who wants access should contact Filipe
+        Webpage : 
+            new work to search for a feedstock, and make it faster
+        Social: want to make our name easier to find and more out front
+
+
+- NumFOCUS updates
+        Filipe is trying to get a face to face with NumFOCUS in April
+        Have another meeting before then
+        Filipe has filled out forms and sent in but has not heard back, hoping to finished process during meeting in April
+        
+- Status of the conda-build 3 move
+        Michael did work to get conda-smithy to work with c-b 3
+        Isuru worked on conda-forge pinning’s to work with c-b 3
+        
+        TODO:
+        Linter needs a bit more work
+        Have staged-recipes use conda build 3 directly vs conda-build-all
+        Need to start merging changes from Anaconda to use new compilers, etc.
+        Need conda smithy 3 release before moving changes
+        How to deal with removal of pins
+            Most can be deal with via run_exports in upstream package
+        For new compilers:
+            Need to find find graph and rework recipes from ground up.
+            New channel to avoid conflicts?
+                Build under a label, do bulk build outside current system?
+
+
+- SciPy tutorial/BoF/Sprint
+    - Submitted tutorial : Michael, JC, Matt, Filipe, Jonathan, Ray, …?
+    - Sprints : needs people to help those who come
+        - Other plans at the sprints : conda-smithy, etc?
+        
+- Next meeting date/time and agenda
+        Same time/date, bi-weekly
+
+Think about writing down process for selecting core members, and teams
+

--- a/src/orga/minutes/2018-03-06.md
+++ b/src/orga/minutes/2018-03-06.md
@@ -1,0 +1,38 @@
+# 2018-03-06 meeting agenda
+
+- Drop win32
+    - Drop and see if users complain? (my bad idea!)
+    - We do not know who the windows users are.
+    - Open issue, tweet, mailing list, gitter to gauge interest 
+    - Link to a google form: https://goo.gl/forms/F2PqL9WP9E609TEF2
+    - Link to edit the form (DO NOT SHARE THIS ONE!!): https://docs.google.com/forms/d/1DbPWfHw1AhYWNsfsYzEo1AxZzKOpxoc-b7zaqY_AMls/edit?usp=sharing
+- Build python 3.7 rc
+    - Jonathan will start building rc in May when rc1 is scheduled
+- Status of the conda-build 3 move
+    - rebuild all packages that are pinned with conda-build 3 with run_exports ~30-40 packages, then release new version of conda-smithy 3.0.0 (release new packages to rc tag)
+    - Move to conda build 3, then move to compilers
+    - Listing of packages to rebuild in issue ( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/27 ).
+- How to reduce binary size (strip our binaries?)
+    - stripping binary can reduce size, has not be investigated much
+    - switching to conda provided compilers will reduce binary sizes, devtoolset partially statically links libstdc++, libgcc 
+    - Issue discussing stripping binaries ( https://github.com/conda-forge/conda-forge.github.io/issues/520 )
+- AnacondaCon agenda
+    - Eric (maybe), John, Filipe, Anthony, [Jonathan, Michael], CJ (maybe)
+    - Have we heard anything from Peter? (esp. funding)
+    - [+AnacondaCon agenda](https://paper.dropbox.com/doc/AnacondaCon-agenda-uBSJ4E3ZOVWMkej0w6zfe) 
+- Use zoom for meetings?
+    - Zoom can handle more people than Hangouts
+    - Zoom needs native client, does include linux
+    - Try Zoom next week, see which is better
+    - join the “ericdill” meeting
+![](https://d2mxuefqeaa7sj.cloudfront.net/s_57464F4B7415C9BBE96DB47EA828626069A32FB50D4583E364666C6B96187A80_1520365117191_Screen+Shot+2018-03-06+at+2.34.23+PM.png)
+![](https://d2mxuefqeaa7sj.cloudfront.net/s_57464F4B7415C9BBE96DB47EA828626069A32FB50D4583E364666C6B96187A80_1520365117172_Screen+Shot+2018-03-06+at+2.34.32+PM.png)
+
+- Next week: 
+    - Policy for pulling/moving packages to broken
+    - Policy for orphan packages
+
+
+Hangout link: 
+https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie
+

--- a/src/orga/minutes/2018-03-20.md
+++ b/src/orga/minutes/2018-03-20.md
@@ -1,0 +1,57 @@
+# 2018-03-20 conda-forge meeting
+
+Attendence: Eric, CJ, John, Michael, Jonathan, Filipe
+
+
+- Policy for pulling/moving packages to broken
+    - Okay with current setup but when package is part of the stack should be more careful.
+    - Use conda verify to catch some of the issue that cause us to pull packages.
+    - pip 9.0.2 https://github.com/pypa/pip/issues/5081 and https://gitter.im/conda-forge/conda-forge.github.io?at=5ab12c6b6f8b4b99464b3c37
+    - Should new version of packages with API incompatible changes should we hold off upgrades for the benefit of the ecosystem?
+    - Many linux distributions avoid this by having a testing vs stable 
+    - Document policy, open issue to track long term plan  Eric/Jonathan/John
+        - stable repository of packages or latest versions that might be broken? 
+        - Related (old) proposal: [+Staged Releases](https://paper.dropbox.com/doc/Staged-Releases-r9My2gvS5vb2VMIlf3xue) 
+    - Is conda forge a place where we make a good-faith effort to have interoperable packages or a place where we allow developers to release their code without as much concern for how well those packages interoperate? (This feels like a CFEP)
+- Policy for orphan packages (packages with no maintainer)
+    - archive the repository (this blocks pull requests)
+    - what do we do with the packages ?
+        - They are unmaintained and are not getting security updates.
+    - Options:
+        - Have the core team maintain the package indefinitely
+        - Have a group of foster maintainers who can help.
+        - Have the bot look for recipes that have no maintainers, add an issue to that repo that says “this package is unmaintained and will be archived in 90 days. post here if you want to be a maintainer or submit a PR that adds you as a maintainer blah blah blah”
+    - ref: https://github.com/conda-forge/conda-forge.github.io/issues/539
+    - All the bob-feedstocks are archived and the bob-packages were moved to “broken” label.
+- Creation of staged-recipes subteams for different languages
+    - TODOs
+        - PR template that enumerates who to ping for each team
+        - Add to the docs on conda-forge.orgT
+        - Make the subteams [Done]
+        - Make issue for people to tell us which subteams they want to be on [Done]
+
+
+
+- We’ll try zoom for the next meeting:
+    - Zoom can handle more people than Hangouts
+    - Zoom needs native client, does include linux (linux: https://support.zoom.us/hc/en-us/articles/204206269-Linux-Installation)
+    - Try Zoom next week, see which is better
+    - join the “ericdill” meeting
+![](https://d2mxuefqeaa7sj.cloudfront.net/s_57464F4B7415C9BBE96DB47EA828626069A32FB50D4583E364666C6B96187A80_1520365117191_Screen+Shot+2018-03-06+at+2.34.23+PM.png)
+![](https://d2mxuefqeaa7sj.cloudfront.net/s_57464F4B7415C9BBE96DB47EA828626069A32FB50D4583E364666C6B96187A80_1520365117172_Screen+Shot+2018-03-06+at+2.34.32+PM.png)
+
+
+
+- Go over [+AnacondaCon agenda](https://paper.dropbox.com/doc/AnacondaCon-agenda-uBSJ4E3ZOVWMkej0w6zfe) 
+----------
+- Win32 poll results: https://docs.google.com/forms/d/1DbPWfHw1AhYWNsfsYzEo1AxZzKOpxoc-b7zaqY_AMls/edit?usp=sharing
+    91 responses, 5 are using Win32, only 1 is using Win32 exclusively.
+- Collaboration (or at least communication) with the pypi/warehouse devs
+- How do we want the bot to handle non-release releases (alpha/beta/dev/pre/etc.) https://github.com/regro/cf-scripts/issues/86 and https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3 and https://github.com/conda-forge/matplotlib-feedstock/pull/24#issuecomment-221496870
+    - conda-forge-pre?
+- John suggested (on gitter) that we reach out to intel and NVIDIA to get copies of their toolchains and development libraries.
+- Adding people to cf/staged-recipes
+    - Marius van Niekerk offered to help review on staged-recipes
+- Optionally building wheels for some packages. ( https://github.com/conda-forge/conda-smithy/issues/608 )
+- flit install as build step?
+

--- a/src/orga/minutes/2018-04-03.md
+++ b/src/orga/minutes/2018-04-03.md
@@ -1,0 +1,40 @@
+# 2018-04-03 conda-forge meeting
+**New items**
+
+- Community management
+    - Community policy
+        - Governance
+        - Code of Conduct: https://docs.google.com/document/d/10dxX0Zse0Rx1HqsxC73Wfsghmy5m8PP8cHuBIOhWKpc/edit
+    - Contributing guidelines
+    - Org policy
+    - Research into wikipedia’s governance https://www.youtube.com/watch?v=ZSQJYEVcMWM&index=27&list=PLwfR9EQmUekU3AprkcCVcoRKXXVIt-5E_
+    - What to do with hostile maintainers, eg: https://github.com/conda-forge/lmfit-feedstock/pull/13 and https://github.com/conda-forge/asteval-feedstock/pull/6
+    - Creating a core mailing list
+        - Reach out to phil for email access to the <thing>@conda-forge.org
+
+**Done**
+
+- Adding people to cf/staged-recipes
+    - Marius van Niekerk offered to help review on staged-recipes
+- Win32 poll results: https://docs.google.com/forms/d/1DbPWfHw1AhYWNsfsYzEo1AxZzKOpxoc-b7zaqY_AMls/edit?usp=sharing
+    91 responses, 5 are using Win32, only 1 is using Win32 exclusively.
+    - nsis only works on 32-bit — it is used by constructor on windows so it’s a critical package to keep working
+    - Filipe will craft an email to let the community know.
+- pypi/anaconda.org/wheel/conda-package
+    - Collaboration (or at least communication) with the pypi/warehouse devs
+    - Optionally building wheels for some packages. ( https://github.com/conda-forge/conda-smithy/issues/608 )
+    - TODO: Chat at anacondacon about this
+- How do we want the bot to handle non-release releases (alpha/beta/dev/pre/etc.) https://github.com/regro/cf-scripts/issues/86 and https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3 and https://github.com/conda-forge/matplotlib-feedstock/pull/24#issuecomment-221496870
+    - conda-forge-pre?
+    - TODO:
+        - We will blacklist all “non-release” releases and not support automated releases from these tags. Do not support rc releases for now.
+        - Better maintainer training (branching structure, etc.)
+- John suggested (on gitter) that we reach out to intel and NVIDIA to get copies of their toolchains and development libraries.
+    - We’ll cross this bridge when we have interest/time
+    - GPU discussion - https://github.com/conda-forge/conda-forge.github.io/issues/63
+    - pygdf as a test case with NVIDIA folks - https://github.com/gpuopenanalytics/pygdf
+        - https://github.com/gpuopenanalytics/pygdf/tree/master/conda-recipes/pygdf
+- flit install as build step?
+    - TODO: Write some dev documentation about supported modes of install
+
+

--- a/src/orga/minutes/2018-04-17.md
+++ b/src/orga/minutes/2018-04-17.md
@@ -1,0 +1,49 @@
+# 2018-04-17 conda-forge meeting
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+
+
+- Debriefing on the AnacondaCon meeting (for those that weren’t there)
+- conda-smithy 3 and conda-build 3 move
+    - issue the releases for conda-smithy 3 and conda-forge-pinning
+    - review the list from packages that must be rebuilt with the new compilers
+        - Look for packages that have toolchain in their deps
+        - MichaelS to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - CJ reports ~763 packages that use “toolchain” in build deps.  MichaelS to get that list from CJ, and will divide into two sets:
+            - recipes that have already been done in AnacondaRecipes and should be PR’ed to Conda-forge
+            - recipes that need modification for new compilers and remove python as mechanism for activating VC features
+----------
+- How do we want the bot to handle non-release releases (alpha/beta/dev/pre/etc.) https://github.com/regro/cf-scripts/issues/86 and https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3 and https://github.com/conda-forge/matplotlib-feedstock/pull/24#issuecomment-221496870
+    - conda-forge-pre?
+- John suggested (on gitter) that we reach out to intel and NVIDIA to get copies of their toolchains and development libraries.
+    - Intel
+        - Chatting in the background with Intel about using their compilers on the CI services
+        - defaults uses:
+            -  intel fortran compiler to build SciPy (fortran only; VS used for C/C++)
+            - defaults to visual studio compilers for all appropriate versions of python
+            - mingw on py27/vs2008 for exceptional cases
+            - Julia discussion around MKL, https://github.com/JuliaLang/julia/issues/18374
+    - Nvidia
+        - pygdf - gpu only package that works on the nvidia GPU Jenkins stack
+        - John: Get a pygdf-feedstock on conda-forge and ping the Nvidia folks
+- Adding people to cf/staged-recipes
+    - ~~Marius van Niekerk offered to help review on staged-recipes~~ Invited to staged recipes
+~~~~    - Igor T. Ghisi (igortg) was also interested in helping
+- Adding people to core
+    - Invite one or more from bioconda. 
+        - Bjorn (Filipe will invite)
+        - Marcel Bargull, @mbargull has been a very involved conda contributor and may be interested.
+- Optionally building wheels for some packages. ( https://github.com/conda-forge/conda-smithy/issues/608 )
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- Governance, CoD, and NumFOCUS affiliation.
+    - numfocus affiliation: https://github.com/numfocus/projects-director/blob/master/projects/Matplotlib.md
+- conda-forge blog
+- Video conferencing solution?
+https://docs.google.com/document/d/10dxX0Zse0Rx1HqsxC73Wfsghmy5m8PP8cHuBIOhWKpc/edit
+
+
+[https://docs.google.com/document/d/10dxX0Zse0Rx1HqsxC73Wfsghmy5m8PP8cHuBIOhWKpc/edit](https://docs.google.com/document/d/10dxX0Zse0Rx1HqsxC73Wfsghmy5m8PP8cHuBIOhWKpc/edit)
+

--- a/src/orga/minutes/2018-05-01.md
+++ b/src/orga/minutes/2018-05-01.md
@@ -1,0 +1,32 @@
+# 2018-05-01 conda-forge meeting
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+
+
+- Michael Sarahan to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - 5/1: Will wait for more people on the dev call before Mike talks about this
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+----------
+- Adding people to cf/staged-recipes
+    - Igor T. Ghisi (igortg) was also interested in helping
+- Adding people to core
+        - ~~Bjorn (Filipe will invite)~~ Done.
+        - Marcel Bargull, @mbargull has been a very involved conda contributor and may be interested.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- Governance, CoD, and NumFOCUS affiliation.
+    - numfocus affiliation: https://github.com/numfocus/projects-director/blob/master/projects/Matplotlib.md
+    - Scopatz said he was interested in pushing this forward :)
+- conda-forge blog
+- Video conferencing solution?
+    - We’ll loose Eric’s zoom. The options are:
+        - go back to google hangouts
+        - use webex
+- discuss numpy pinning (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/44)
+    - Merged!
+    - Michael working on different scheme.  numpy-base has all files.  numpy is metapackage that implies only python API usage.  numpy-devel is metapackage that implies C API linkage, and imposes run_exports
+

--- a/src/orga/minutes/2018-05-29.md
+++ b/src/orga/minutes/2018-05-29.md
@@ -1,0 +1,62 @@
+# 2018-05-29 conda-forge meeting
+**Pinned Items**
+
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+
+- Run_exports etc: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/58
+- Michael Sarahan to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - 5/1: Will wait for more people on the dev call before Mike talks about this
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Finding a good solution to sharing passwords among core
+- switch to cb3
+    - what kind of things are going to break when we change compilers?
+        - (@Jonathan H had a great response that I hope he’ll clarify here:) tl;dr C++ ABI
+        - Some details on libstdc++ dual ABI, https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+- Sprint in NYC June 18th through 20th for REST API for conda-forge graph and better inspection of CLI/imports/includes for conda-forge packages.
+- **Actionable things to check in at the June 12 meeting**
+    - add something to the bot to add new PRs that manage the cb2 → cb3
+        - e.g., if a compiler is detected, add the right compilers for the right files (Justin, nominally — @Christopher W @Mike S and @Anthony S will probably be reviewing those PRs)
+    - @Mike S is working on a secondary channel to push the rebuilt cb3 packages
+----------
+
+**Existing Items**
+
+****
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+        - It’s easy to do this per doc with a link
+        - This is less clear to accomplish with a folder of docs
+            - Could add all share links into one Dropbox paper doc that is world readable
+            - Could add all share links in some file in some repo (webpage repo?)
+            - Some other aggregation solution?
+    - other options are to just post the notes somewhere public after the meeting
+- Governance, CoD, and NumFOCUS affiliation.
+    - numfocus affiliation: https://github.com/numfocus/projects-director/blob/master/projects/Matplotlib.md
+    - Scopatz said he was interested in pushing this forward :)
+- conda-forge blog
+- discuss numpy pinning (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/44)
+    - Merged!
+    - Michael working on different scheme.  numpy-base has all files.  numpy is metapackage that implies only python API usage.  numpy-devel is metapackage that implies C API linkage, and imposes run_exports
+----------
+
+**Done**
+
+- Adding new members (email sent on 5/29. Thanks @Filipe F )
+    - Adding people to cf/staged-recipes
+        - Igor T. Ghisi (igortg) was also interested in helping
+    - Adding people to core
+            - Joshua Adelman @synapticarbors
+            - Marcel Bargull, @mbargull has been a very involved conda contributor and may be interested.
+            - Marius van Niekerk has been very involved recently
+- Video conferencing solution?
+    - We’ll lose Eric’s zoom, but we gained Marius’ zoom! https://flatiron.zoom.us/j/3620044703
+

--- a/src/orga/minutes/2018-06-12.md
+++ b/src/orga/minutes/2018-06-12.md
@@ -1,0 +1,64 @@
+# 2018-06-12 conda-forge meeting
+2018-05-29 conda-forge meeting
+**Pinned Items**
+
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- **Actionable things to check in at the June 12 meeting**
+    - add something to the bot to add new PRs that manage the cb2 → cb3
+        - e.g., if a compiler is detected, add the right compilers for the right files (Justin, nominally — @Christopher W @Mike S and @Anthony S will probably be reviewing those PRs) See issue: https://github.com/regro/cf-scripts/issues/162
+    - @Mike S is working on a secondary channel to push the rebuilt cb3 packages
+- Finding a good solution to sharing passwords among core
+
+
+- Run_exports etc: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/58
+- Michael Sarahan to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - 5/1: Will wait for more people on the dev call before Mike talks about this
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- switch to cb3
+    - what kind of things are going to break when we change compilers?
+        - (@Jonathan H had a great response that I hope he’ll clarify here:) tl;dr C++ ABI
+        - Some details on libstdc++ dual ABI, https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+- Sprint in NYC June 18th through 20th for REST API for conda-forge graph and better inspection of CLI/imports/includes for conda-forge packages.
+----------
+
+**Existing Items**
+
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+- discuss numpy pinning (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/44)
+    - Merged!
+    - Michael working on different scheme.  numpy-base has all files.  numpy is metapackage that implies only python API usage.  numpy-devel is metapackage that implies C API linkage, and imposes run_exports
+----------
+
+**Discussed Items**
+
+- Governance, CoD, and NumFOCUS affiliation.
+    - PyPA discussions at PyCON
+        - Some general agreement by PyPA that pip/wheels shouldn’t be used for everything
+        - No clear delineation as to where pip/wheels should stop and other tools begin
+    - numfocus affiliation: https://github.com/numfocus/projects-director/blob/master/projects/Matplotlib.md
+    - Scopatz said he was interested in pushing this forward :)
+        - [conda-forge/conda-forge.github.io#598](https://github.com/conda-forge/conda-forge.github.io/pull/598)
+    - Idea of [“emeritus” maintainers](https://github.com/envoyproxy/envoy/blob/master/OWNERS.md) — basically, if someone wants to step away from the project then we can still call them out as having been core members in the past but are no longer contributing. Switching between emeritus and active is as simple as the emeritus member beginning to contribute again. This has not been an issue yet, but if we do fail to reach a vote threshold as outlined in the governance document then we will revisit the idea of emeritus maintainers
+----------
+
+**Done**
+
+https://packaging.python.org/guides/installing-scientific-packages/
+https://packaging.python.org/guides/tool-recommendations/
+
+
+https://github.com/conda-forge/conda-forge.github.io/pull/598
+
+

--- a/src/orga/minutes/2018-06-26.md
+++ b/src/orga/minutes/2018-06-26.md
@@ -1,0 +1,49 @@
+# 2018-06-26 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- CJ: report on June 18-20 NYC sprint
+    - Sprint in NYC June 18th through 20th for REST API for conda-forge graph and better inspection of CLI/imports/includes for conda-forge packages.
+    - Potential place for additional metadata in conda recipes?
+        - (from @Jonathan H ) you can clobber/append portions of a recipe with an extra file with conda-build 3
+        - recipe_url info for recording repo where a recipe came from: https://github.com/conda/conda-build/pull/2489
+- Moving compiler syntax
+    - Run syntax in topo order https://github.com/regro/cf-scripts/issues/214
+    - Run compiler move as soon as syntax has moved
+    - Formalize pushing to different label (maybe as optional arg to `conda-smithy`?) (this would also help with RC releases)
+----------
+
+**Existing Items**
+
+- Finding a good solution to sharing passwords among core
+- Run_exports etc: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/58
+- Michael Sarahan to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - 5/1: Will wait for more people on the dev call before Mike talks about this
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- switch to cb3
+    - what kind of things are going to break when we change compilers?
+        - (@Jonathan H had a great response that I hope he’ll clarify here:) tl;dr C++ ABI
+        - Some details on libstdc++ dual ABI, https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+----------
+
+**Done**
+
+- add something to the bot to add new PRs that manage the cb2 → cb3
+    - e.g., if a compiler is detected, add the right compilers for the right files (Justin, nominally — @Christopher W @Mike S and @Anthony S will probably be reviewing those PRs) See issue: https://github.com/regro/cf-scripts/issues/162
+

--- a/src/orga/minutes/2018-07-17.md
+++ b/src/orga/minutes/2018-07-17.md
@@ -1,0 +1,62 @@
+# 2018-07-17 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Finalize compiler migration discussion (see: [+2018-07-17 conda-forge meeting](https://paper.dropbox.com/doc/2018-07-17-conda-forge-meeting-DbS8FTAlF94QgFO7SoRkk) )
+    - Update on current status
+        - Number of packages left to syntax migrate
+        - Number of packages needing re-compile
+            - Total number ready
+            - Number ready in the first layer
+        - Build number increase by N for new things at build time non static
+            - determine build number with conda render clobber file
+    - Decide on migration order [Outcome: make super graph of py37 + compilers (run with one walker), drop 3.5 when 3.7 starts]
+        - py37
+        - compilers
+        - remaining compiler syntax
+    - Decide on resource strat [Outcome: do everything online]
+        - ~~Offline (without CIs)~~
+        - Online (with CI)
+    - Decide on channel strat [Outcome: new label for new compilers, run two labels]
+        - upload re-compiled packages to new label and continue pushing to current label
+        - upload re-compiled packages to current label, push updates to current era compilers to different branch
+    - Establish next steps/action items/gh issues
+    - Decide on a policy for when maintainers stop maintaining
+    - Related to 2k-ish pending bot PRs…
+    - Sharing passwords (to start off the meeting next time)
+----------
+
+**Existing Items**
+
+- Moving compiler syntax
+    - Decide on strat
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Run_exports etc: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/58
+- Michael Sarahan to document and give demo on how to transition old recipes to new style
+        - https://github.com/conda-forge/AnacondaRecipesSync
+        - 5/1: Will wait for more people on the dev call before Mike talks about this
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- switch to cb3
+    - what kind of things are going to break when we change compilers?
+        - (@Jonathan H had a great response that I hope he’ll clarify here:) tl;dr C++ ABI
+        - Some details on libstdc++ dual ABI, https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+----------
+
+**Done**
+

--- a/src/orga/minutes/2018-07-24.md
+++ b/src/orga/minutes/2018-07-24.md
@@ -1,0 +1,73 @@
+# 2018-07-24 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issueing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+----------
+
+**Existing Items**
+
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+- Finalize compiler migration discussion (see: [+2018-07-17 conda-forge meeting](https://paper.dropbox.com/doc/2018-07-17-conda-forge-meeting-DbS8FTAlF94QgFO7SoRkk) )
+    - Update on current status
+        - Number of packages left to syntax migrate
+        - Number of packages needing re-compile
+            - Total number ready
+            - Number ready in the first layer
+        - Build number increase by N for new things at build time non static
+            - determine build number with conda render clobber file
+    - Decide on migration order [Outcome: make super graph of py37 + compilers (run with one walker), drop 3.5 when 3.7 starts]
+        - py37
+        - compilers
+        - remaining compiler syntax
+    - Decide on resource strat [Outcome: do everything online]
+        - ~~Offline (without CIs)~~
+        - Online (with CI)
+    - Decide on channel strat [Outcome: new label for new compilers, run two labels]
+        - upload re-compiled packages to new label and continue pushing to current label
+        - upload re-compiled packages to current label, push updates to current era compilers to different branch
+----------
+
+**Done**
+

--- a/src/orga/minutes/2018-08-07.md
+++ b/src/orga/minutes/2018-08-07.md
@@ -1,0 +1,95 @@
+# 2018-08-07 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Voting procedure modifications: https://github.com/conda-forge/conda-forge.github.io/pull/612
+    - Merged
+    - MichaelS owes a PR to the docs for current run_exports best practices
+    - MVN owes a CFEP for dual compiler output
+- Subgroup proposal: have smaller groups that meet outside of core meetings with different frequency
+    - Each of these need to be put up as a proposal (to ????), which then needs a core vote for creation.  Each proposal should have a scope of the group and initial members, as well as how the group is expected to coordinate and communicate.
+    - Proposed initial groups:
+        - bot: people responsible for bot architecture, implementation, maintenance.  NOT actual uses of bot (e.g. creating large migrations)
+        - fiscal: how to allocate resources from NumFOCUS/approve expenditures periodically
+        - toolchain: compilers, when to update to new ABI’s
+        - R ecosystem: 
+- NumFOCUS summit: http://summit.numfocus.org/pages/schedule.html
+- Conda 4.5.9 (features thing):
+    - Filipe asking for option to error if conda tries to use packages from a lower-priority channel over their higher priority channel.  Allow fallback, but only for things that don’t exist.
+- Dougal raising issue with conda-build creating noarch packages.  Conda-build wants to use new python, then runs into unsatisfiable deps (python 3.7 isn’t totally built out yet).
+    - https://github.com/conda-forge/google-cloud-bigquery-feedstock/pull/14
+    - on closer inspection, the problem is that conda-forge does not yet have a protobuf package built for py3.7 yet, and defaults’ protobuf package does not exclude conda-forge’s libprotobuf, so the mix of the two breaks due to C++ ABI incompatibility.
+
+**Existing Items**
+
+- Discuss the recipes syncing between defaults and conda-forge and some issues we are facing:
+    - large number of patches
+    - the use of `cdt` jinja (ping Peter Willians on the benchmark @pkg)
+    - new compiler specific stuff on the build scripts
+    - multiple outputs and new names: curl/libcurl, etc
+    - the use of features (https://github.com/conda-forge/blas-feedstock/pull/12)
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issuing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+- Finalize compiler migration discussion (see: [+2018-07-17 conda-forge meeting](https://paper.dropbox.com/doc/2018-07-17-conda-forge-meeting-DbS8FTAlF94QgFO7SoRkk) )
+    - Update on current status
+        - Number of packages left to syntax migrate
+        - Number of packages needing re-compile
+            - Total number ready
+            - Number ready in the first layer
+        - Build number increase by N for new things at build time non static
+            - determine build number with conda render clobber file
+    - Decide on migration order [Outcome: make super graph of py37 + compilers (run with one walker), drop 3.5 when 3.7 starts]
+        - py37
+        - compilers
+        - remaining compiler syntax
+    - Decide on resource strat [Outcome: do everything online]
+        - ~~Offline (without CIs)~~
+        - Online (with CI)
+    - Decide on channel strat [Outcome: new label for new compilers, run two labels]
+        - upload re-compiled packages to new label and continue pushing to current label
+        - upload re-compiled packages to current label, push updates to current era compilers to different branch
+----------
+
+**Done**
+

--- a/src/orga/minutes/2018-08-21.md
+++ b/src/orga/minutes/2018-08-21.md
@@ -1,0 +1,94 @@
+# 2018-08-21 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- NumFOCUS news
+    - Assign to person to go through checklist [Anthony]
+- Compiler migration has started (finished in Q1 2019)
+    - Updated needed to Python: https://github.com/conda-forge/python-feedstock/pull/190
+- GPL/non-GPL issues https://github.com/conda-forge/conda-forge.github.io/issues/209#issuecomment-414756953
+- Votes/discussion in progress or need start:
+    - https://github.com/conda-forge/conda-forge.github.io/pull/628
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/10
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/11
+    - Subteams which need PR into conda-forge.github.io
+        - fiscal: how to allocate resources from NumFOCUS/approve expenditures periodically
+        - toolchain: compilers, when to update to new ABI’s (MichaelS needs to put up proposal)
+        - R ecosystem
+    - MichaelS **still** owes a PR to the docs for current run_exports best practices
+- Conda 4.5.9 (features thing):
+    - Filipe asking for option to error if conda tries to use packages from a lower-priority channel over their higher priority channel.  Allow fallback, but only for things that don’t exist.
+        - Implementation by Jonathan at https://github.com/conda/conda/pull/7660
+- ruamel_yaml broke things on Sunday (conda and conda-smithy)
+    - downstreams testing
+        - Conda-feedstock needs to run conda’s test
+        - PRs
+            - https://github.com/conda-forge/conda-feedstock/pull/63
+            - https://github.com/conda-forge/conda-smithy-feedstock/pull/104
+
+**Existing Items**
+
+- Dougal raising issue with conda-build creating noarch packages.  Conda-build wants to use new python, then runs into unsatisfiable deps (python 3.7 isn’t totally built out yet).
+    - https://github.com/conda-forge/google-cloud-bigquery-feedstock/pull/14
+    - on closer inspection, the problem is that conda-forge does not yet have a protobuf package built for py3.7 yet, and defaults’ protobuf package does not exclude conda-forge’s libprotobuf, so the mix of the two breaks due to C++ ABI incompatibility.
+- Discuss the recipes syncing between defaults and conda-forge and some issues we are facing:
+    - large number of patches
+    - the use of `cdt` jinja (ping Peter Williams on the benchmark @pkgw)
+    - new compiler specific stuff on the build scripts
+    - multiple outputs and new names: curl/libcurl, etc
+    - the use of features (https://github.com/conda-forge/blas-feedstock/pull/12)
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issuing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+- 
+----------
+
+**Done**
+
+- NumFOCUS summit: http://summit.numfocus.org/pages/schedule.html
+    - Marius and Anthony attending (maybe CJ)
+- Subgroup proposal: have smaller groups that meet outside of core meetings with different frequency
+    - Each of these need to be put up as a proposal (to conda-forge.github.io), which then needs a core vote for creation.  Each proposal should have a scope of the group and initial members, as well as how the group is expected to coordinate and communicate.
+    - Proposed initial groups:
+        - bot: people responsible for bot architecture, implementation, maintenance.  NOT actual uses of bot (e.g. creating large migrations)
+

--- a/src/orga/minutes/2018-09-04.md
+++ b/src/orga/minutes/2018-09-04.md
@@ -1,0 +1,88 @@
+# 2018-09-04 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Meet with NumFOCUS RE: Fiscal sponsorship
+- [numfocus.org/rocket](https://numfocus.org/rocket/)
+- Need .la removal for compiler rebuilds
+
+**Existing Items**
+
+- Compiler migration has started (finished in Q1 2019)
+    - Updated needed to Python: https://github.com/conda-forge/python-feedstock/pull/190
+- Votes/discussion in progress or need start:
+    - https://github.com/conda-forge/conda-forge.github.io/pull/628
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/10
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/11
+    - Subteams which need PR into conda-forge.github.io
+        - fiscal: how to allocate resources from NumFOCUS/approve expenditures periodically
+        - toolchain: compilers, when to update to new ABI’s (MichaelS needs to put up proposal)
+        - R ecosystem
+    - MichaelS **still** owes a PR to the docs for current run_exports best practices
+- Conda 4.5.9 (features thing):
+    - Filipe asking for option to error if conda tries to use packages from a lower-priority channel over their higher priority channel.  Allow fallback, but only for things that don’t exist.
+        - Implementation by Jonathan at https://github.com/conda/conda/pull/7660
+- Dougal raising issue with conda-build creating noarch packages.  Conda-build wants to use new python, then runs into unsatisfiable deps (python 3.7 isn’t totally built out yet).
+    - https://github.com/conda-forge/google-cloud-bigquery-feedstock/pull/14
+    - on closer inspection, the problem is that conda-forge does not yet have a protobuf package built for py3.7 yet, and defaults’ protobuf package does not exclude conda-forge’s libprotobuf, so the mix of the two breaks due to C++ ABI incompatibility.
+- Discuss the recipes syncing between defaults and conda-forge and some issues we are facing:
+    - large number of patches
+    - the use of `cdt` jinja (ping Peter Williams on the benchmark @pkgw)
+    - new compiler specific stuff on the build scripts
+    - multiple outputs and new names: curl/libcurl, etc
+    - the use of features (https://github.com/conda-forge/blas-feedstock/pull/12)
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issuing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+- 
+----------
+
+**Done**
+
+- NumFOCUS summit: http://summit.numfocus.org/pages/schedule.html
+    - Marius and Anthony attending (maybe CJ)
+- Subgroup proposal: have smaller groups that meet outside of core meetings with different frequency
+    - Each of these need to be put up as a proposal (to conda-forge.github.io), which then needs a core vote for creation.  Each proposal should have a scope of the group and initial members, as well as how the group is expected to coordinate and communicate.
+    - Proposed initial groups:
+        - bot: people responsible for bot architecture, implementation, maintenance.  NOT actual uses of bot (e.g. creating large migrations)
+

--- a/src/orga/minutes/2018-09-18.md
+++ b/src/orga/minutes/2018-09-18.md
@@ -1,0 +1,100 @@
+# 2018-09-18 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Compiler rebuild status
+    - Ongoing, pending python and maybe perl
+- New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+- Docker image issues/discussion
+    - https://github.com/conda-forge/conda-smithy/issues/890
+- NumFOCUS summit Fri-Tues
+    - Anthony and Marius
+    - Requests
+        - Heroku currently payed for by Phil
+        - S3 buckets, EC2, RDS
+    - Look into Azure build service
+        - Lead by @John K 
+        - Has the big three platforms
+
+**Existing Items**
+
+- Compiler migration has started (finished in Q1 2019)
+    - Updated needed to Python: https://github.com/conda-forge/python-feedstock/pull/190
+- Votes/discussion in progress or need start:
+    - https://github.com/conda-forge/conda-forge.github.io/pull/628
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/10
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/11
+    - Subteams which need PR into conda-forge.github.io
+        - fiscal: how to allocate resources from NumFOCUS/approve expenditures periodically
+        - toolchain: compilers, when to update to new ABI’s (MichaelS needs to put up proposal)
+        - R ecosystem
+    - ~~MichaelS~~ ~~**still**~~ ~~owes a PR to the docs for current run_exports best practices~~ PR at https://github.com/conda-forge/conda-forge.github.io/pull/648
+- Conda 4.5.9 (features thing):
+    - Filipe asking for option to error if conda tries to use packages from a lower-priority channel over their higher priority channel.  Allow fallback, but only for things that don’t exist.
+        - Implementation by Jonathan at https://github.com/conda/conda/pull/7660
+- Dougal raising issue with conda-build creating noarch packages.  Conda-build wants to use new python, then runs into unsatisfiable deps (python 3.7 isn’t totally built out yet).
+    - https://github.com/conda-forge/google-cloud-bigquery-feedstock/pull/14
+    - on closer inspection, the problem is that conda-forge does not yet have a protobuf package built for py3.7 yet, and defaults’ protobuf package does not exclude conda-forge’s libprotobuf, so the mix of the two breaks due to C++ ABI incompatibility.
+- Discuss the recipes syncing between defaults and conda-forge and some issues we are facing:
+    - large number of patches
+    - the use of `cdt` jinja (ping Peter Williams on the benchmark @pkgw)
+    - new compiler specific stuff on the build scripts
+    - multiple outputs and new names: curl/libcurl, etc
+    - the use of features (https://github.com/conda-forge/blas-feedstock/pull/12)
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issuing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+----------
+
+**Discussed Items**
+
+- 
+----------
+
+**Done**
+
+- NumFOCUS summit: http://summit.numfocus.org/pages/schedule.html
+    - Marius and Anthony attending (maybe CJ)
+- Subgroup proposal: have smaller groups that meet outside of core meetings with different frequency
+    - Each of these need to be put up as a proposal (to conda-forge.github.io), which then needs a core vote for creation.  Each proposal should have a scope of the group and initial members, as well as how the group is expected to coordinate and communicate.
+    - Proposed initial groups:
+        - bot: people responsible for bot architecture, implementation, maintenance.  NOT actual uses of bot (e.g. creating large migrations)
+

--- a/src/orga/minutes/2018-10-02.md
+++ b/src/orga/minutes/2018-10-02.md
@@ -1,0 +1,90 @@
+# 2018-10-02 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Compiler rebuild status
+    - python done for both compiler stacks
+    - pending: openblas (numeric stack currently held up)
+- New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+- Docker image issues/discussion
+    - https://github.com/conda-forge/conda-smithy/issues/890
+- 
+
+**Existing Items**
+
+- NumFOCUS summit Fri-Tues
+    - Anthony and Marius
+    - Requests
+        - Heroku currently payed for by Phil
+        - S3 buckets, EC2, RDS
+    - Look into Azure build service
+        - Lead by @John K 
+        - Has the big three platforms
+        - Marius, John, ?? had good meeting with Azure CI team.  Azure CI team willing to take some of that on on their side.
+            - ~100 concurrent builds floated.  Seemed OK with them.
+            - Requires Microsoft account.  Let Marius know your account and he can add you.
+- Compiler migration has started (finished in Q1 2019)
+    - Updated needed to Python: https://github.com/conda-forge/python-feedstock/pull/190
+- Votes/discussion in progress or need start:
+    - https://github.com/conda-forge/conda-forge.github.io/pull/628
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/10
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/11
+    - Subteams which need PR into conda-forge.github.io
+        - fiscal: how to allocate resources from NumFOCUS/approve expenditures periodically
+        - toolchain: compilers, when to update to new ABI’s (MichaelS needs to put up proposal)
+        - R ecosystem
+    - ~~MichaelS~~ ~~**still**~~ ~~owes a PR to the docs for current run_exports best practices~~ PR at https://github.com/conda-forge/conda-forge.github.io/pull/648
+- Conda 4.5.9 (features thing):
+    - Filipe asking for option to error if conda tries to use packages from a lower-priority channel over their higher priority channel.  Allow fallback, but only for things that don’t exist.
+        - Implementation by Jonathan at https://github.com/conda/conda/pull/7660
+- Dougal raising issue with conda-build creating noarch packages.  Conda-build wants to use new python, then runs into unsatisfiable deps (python 3.7 isn’t totally built out yet).
+    - https://github.com/conda-forge/google-cloud-bigquery-feedstock/pull/14
+    - on closer inspection, the problem is that conda-forge does not yet have a protobuf package built for py3.7 yet, and defaults’ protobuf package does not exclude conda-forge’s libprotobuf, so the mix of the two breaks due to C++ ABI incompatibility.
+- Discuss the recipes syncing between defaults and conda-forge and some issues we are facing:
+    - large number of patches
+    - the use of `cdt` jinja (ping Peter Williams on the benchmark @pkgw)
+    - new compiler specific stuff on the build scripts
+    - multiple outputs and new names: curl/libcurl, etc
+    - the use of features (https://github.com/conda-forge/blas-feedstock/pull/12)
+- Sharing passwords (to start off the meeting next time)
+    - Try something out and move on to more interesting problems
+    - Let’s try KeyBase. Eric D. just sent out invites to most of the core team.
+- Establish next steps/action items/gh issues for migrations
+    - MVN will coordinate with CJ on issuing prs for the things that need compilers that don’t actually call it out nicely.
+    - Parse graph find everything which could be py 3.7 but no compiler and not noarch, run rebuild on that.
+    - May need to have two versions of pinnings + smithy whilst graph is being rebuilt.
+- Decide on a policy for when maintainers stop maintaining
+    - Come back to later
+- Related to 2k-ish pending bot PRs…
+    - MVN will give CJ a list of merge-conflicted feedstocks that were closed and not merged.
+    - Auto close out of date PRs
+    - Auto delete closed/merged bot PR
+- run_exports vote https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102
+    - John questioned run_exports practice: https://github.com/conda-forge/staged-recipes/pull/4858#discussion_r204076032
+    - Dougal redirected discussion to https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issue-343171939
+    - John questioned validity of vote on run_exports: 
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406672840
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/102#issuecomment-406681093
+    - Filipe to add to governance doc on process to un-stick situations like this
+    - Overall: we need a community standards communication scheme.  Mike S dropped the ball on communicating the results of the poll.
+    - Related: governance doc may need definition of how a valid poll is to be conducted.
+- Expiring (i.e., auto-closing with a bot) “old” PRs into staged-recipes?
+    - Put on label, add message (stale), ping relevant parties to close 
+    - Decide on policy
+- Finding a good solution to sharing passwords among core
+    - Git Secret? https://github.com/sobolevn/git-secret
+- Build packages on C3I and upload to conda-forge
+    - Make is missing from the base image for PowerPC internal to Anaconda. Fun times!
+    - Mike is open to other people helping with this.  If interested, reach out!  Helping means trying recipes, debugging any issues, and resolving any merge conflicts that have happened since Mike pulled them in last.  Moving target.
+    - Packages that have been built https://anaconda.org/cf-cb3 - these may need more work regarding versions.  The graph was computed with the versions, but probably should have ignored them.  When a pin is older than a newer recipe, the upstream recipe gets missed as a real dependency because of the version mismatch.
+- Making the agenda and notes public again.
+    - John will see if we can make dropbox paper readable by the world
+    - other options are to just post the notes somewhere public after the meeting
+- conda-forge blog
+

--- a/src/orga/minutes/2018-10-30.md
+++ b/src/orga/minutes/2018-10-30.md
@@ -1,0 +1,30 @@
+# 2018-10-30 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- migrate r-base to **x.x** and **noarch: generic**, see https://github.com/conda-forge/r-base-feedstock/pull/60
+    - Nobody in the meeting really knows anything about this. Follow up with Isuru, Ray, …?
+
+**Previous items**
+
+- Compiler rebuild status
+    - python done for both compiler stacks
+    - ~~pending: openblas (numeric stack currently held up)~~
+~~~~    - Qt: try to build on Azure?
+- New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+    - Might be possible to not be totally insecure with work. But nobody is volunteering to do that work right now. :)
+    - Pushing PR builds to a staging channel might be a nice UX improvement so you can test anyway.
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+    - Just wait for new conda 3.6 with strict channel priority, and then add main label to those builds
+- Mergify = auto-merge version bump PRs when CIs pass?
+    - https://github.com/conda-forge/conda-forge-maintenance/issues/49
+    - Worry about bot not detecting dependency changes
+    - Definitely opt-in only at first
+    - One possibility: only after an approved review (so you can say “merge assuming CIs pass”)
+- Add overlinking error flag by default?
+

--- a/src/orga/minutes/2018-11-13.md
+++ b/src/orga/minutes/2018-11-13.md
@@ -1,0 +1,29 @@
+# 2018-11-13 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- ~~Discussing binary size and stripping options (~~`~~-S~~`~~,~~ `~~-s~~`~~,~~ `~~-0s~~`~~)~~
+    - Solved. Not worth pursuing and the recommend is to strip after if space is an issue.
+
+**Previous items**
+
+- Compiler rebuild status
+    - python done for both compiler stacks
+    - Qt: try to build on Azure?
+- (DISCUSSED/Postponed) New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+    - Might be possible to not be totally insecure with work. But nobody is volunteering to do that work right now. :)
+    - Pushing PR builds to a staging channel might be a nice UX improvement so you can test anyway.
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+    - Just wait for new conda 4.6 with strict channel priority, and then add main label to those builds
+- (DISCUSSED/Postponed)Mergify = auto-merge version bump PRs when CIs pass?
+    - https://github.com/conda-forge/conda-forge-maintenance/issues/49
+    - Worry about bot not detecting dependency changes
+    - Definitely opt-in only at first
+    - One possibility: only after an approved review (so you can say “merge assuming CIs pass”)
+- Add overlinking error flag by default?
+

--- a/src/orga/minutes/2018-11-27.md
+++ b/src/orga/minutes/2018-11-27.md
@@ -1,0 +1,39 @@
+# 2018-11-27 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- CloudFlare Migration
+    - Sophia will add a diagram of the system
+    - To go live tomorrow, Wed Nov 28, morning (~9 AM central).  Anaconda will monitor it actively.
+    - MichaelS/Sophia will announce this start time on gitter along with the diagram and a rehash of the reasoning and changes proposed.
+- NumFOCUS Small Grant Proposal accept and we just got 3000USD for the "conda-forge sprint at SciPy 2019”
+- ESIP second change for a small grant 6-10k
+    - https://www.esipfed.org/esip-lab/funding-opportunities/f2018rfp
+- GSoC 2019
+    - https://developers.google.com/open-source/gsoc/timeline
+- Journal article
+    - https://github.com/conda-forge/conda-forge-paper
+    - Put together sections see who is interested in writing
+
+**Previous items**
+
+- Compiler rebuild status
+    - python done for both compiler stacks
+    - Qt: try to build on Azure?
+- (DISCUSSED/Postponed) New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+    - Might be possible to not be totally insecure with work. But nobody is volunteering to do that work right now. :)
+    - Pushing PR builds to a staging channel might be a nice UX improvement so you can test anyway.
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+    - Just wait for new conda 4.6 with strict channel priority, and then add main label to those builds
+- (DISCUSSED/Postponed)Mergify = auto-merge version bump PRs when CIs pass?
+    - https://github.com/conda-forge/conda-forge-maintenance/issues/49
+    - Worry about bot not detecting dependency changes
+    - Definitely opt-in only at first
+    - One possibility: only after an approved review (so you can say “merge assuming CIs pass”)
+- Add overlinking error flag by default?
+

--- a/src/orga/minutes/2019-01-09.md
+++ b/src/orga/minutes/2019-01-09.md
@@ -1,0 +1,54 @@
+# 2019-01-09 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Journal article update
+    - https://github.com/conda-forge/conda-forge-paper
+    - A draft of a skeleton is in PR, comments, edits, and more are encouraged! https://github.com/conda-forge/conda-forge-paper/pulls
+    - Who should be authors on the paper?  
+    - xref bioconda nature methods paper: https://www.nature.com/articles/s41592-018-0046-7
+- Elections
+    - Sylvain
+        - Pending Mike for vote tallies
+            - Pole is complete, Mike will post results soon
+    - Matthew Becker
+        - done (or at least on https://github.com/orgs/conda-forge/teams/staged-recipes/members – nothing else to do, right? we should document that)
+- Meta Channel
+    - https://github.com/regro/conda-metachannel
+- New Arches
+    - aarch64 and ppc building
+        - Shippable
+        - Qemu on CI
+- When to add gcc7 to main or flip the channels?
+        - Proposal: Jan 15th
+- Conda-forge on Open Source Directions
+
+**Previous items**
+
+- CloudFlare Migration
+    - Sophia will add a diagram of the system
+    - To go live tomorrow, Wed Nov 28, morning (~9 AM central).  Anaconda will monitor it actively.
+    - MichaelS/Sophia will announce this start time on gitter along with the diagram and a rehash of the reasoning and changes proposed.
+- NumFOCUS Small Grant Proposal accept and we just got 3000USD for the "conda-forge sprint at SciPy 2019”
+- GSoC 2019
+    - https://developers.google.com/open-source/gsoc/timeline
+- Compiler rebuild status
+    - python done for both compiler stacks
+    - Qt: try to build on Azure?
+- (DISCUSSED/Postponed) New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
+    - Might be possible to not be totally insecure with work. But nobody is volunteering to do that work right now. :)
+    - Pushing PR builds to a staging channel might be a nice UX improvement so you can test anyway.
+- Copying packages to gcc7 label https://github.com/conda-forge/conda-smithy/issues/892
+    - MPI metapackage
+    - Just wait for new conda 4.6 with strict channel priority, and then add main label to those builds
+- (DISCUSSED/Postponed)Mergify = auto-merge version bump PRs when CIs pass?
+    - https://github.com/conda-forge/conda-forge-maintenance/issues/49
+    - Worry about bot not detecting dependency changes
+    - Definitely opt-in only at first
+    - One possibility: only after an approved review (so you can say “merge assuming CIs pass”)
+- Add overlinking error flag by default?
+

--- a/src/orga/minutes/2019-01-23.md
+++ b/src/orga/minutes/2019-01-23.md
@@ -1,0 +1,45 @@
+# 2019-01-23 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Journal article update
+    - Target date maybe around March 2019
+        - sections
+- Elections
+    - aarch64 team
+        - administrative bits needed ito user group
+        - @conda-forge/arm-arch is the new team name
+- The great switchover
+    - Secondary Label model
+        - Probably not that needed for smaller migrations
+    - Future migrations
+        - Add gcc gxx gfortran compiler versions to pinnings (so we can build in main)
+    - Core owns a bunch of “orphan” packages.
+    - Auto Pinning migration sketch
+        - https://github.com/regro/cf-scripts/issues/44#issuecomment-455817718
+        - Need to handle run exports as well: watch all run_exported packages and see if their version bumps are beyond their max pin info, if so issue downstream rebuild PRs
+- Meta Channel
+    - https://github.com/regro/conda-metachannel
+        - Blocking parts
+        - Still need a domain / subdomain so that we can add some TLS
+    - probably not ready yet for use internally in 
+- New Arches
+    - aarch64 and ppc building
+        - Shippable
+        - Qemu on CI
+        - no py2k
+        - targeted leaf packages and rebuild accordingly
+            - numpy
+            - scipy
+            - opencv
+            - jupyter
+- Conda-forge on Open Source Directions
+    - 
+- GPU builds, Stan’s email
+- Azure status
+- ESIP update
+

--- a/src/orga/minutes/2019-02-06.md
+++ b/src/orga/minutes/2019-02-06.md
@@ -1,0 +1,55 @@
+# 2019-02-06 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Elections
+    - Nomination of Chris Burr to Staged recipes
+    - Move forward to Helios
+- Introducing Kai Tietz at Anaconda
+- Migrations
+    - Power and Arm
+        - https://github.com/regro/cf-scripts/blob/master/conda_forge_tick/migrators.xsh#L905
+    - Openssl
+        - https://github.com/conda-forge/conda-forge.github.io/issues/701
+        - https://github.com/regro/cf-scripts/issues/409
+        - https://www.openssl.org/blog/blog/2018/11/28/version/
+        - Channel priority doesn’t stop default’s python being installed with the newest openssl
+        - rebuild against openssl as soon as possible
+            - Anaconda to take this on for their next sprint (starting Monday, Feb 11).
+    - Readline
+        - ABI change
+- Meta Channel
+    - https://github.com/regro/conda-metachannel
+        - Blocking parts
+        - Still need a domain / subdomain so that we can add some TLS
+    - probably not ready yet for use internally in 
+    - Want benchmarks
+- Conda-forge on Open Source Directions
+- Azure status
+    - Linux and OSX ready to go
+    - Need to fix windows (vc9 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - Postpone to next meeting
+- ESIP update
+- Journal article update
+    - https://github.com/conda-forge/conda-forge-paper
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - noarch
+    - base stack
+    - Many perl packages on bioconda (600+)
+    - Perl ABI?
+        - https://abi-laboratory.pro/?view=timeline&l=perl
+    - move forward with plan to incorporate perl into CF
+

--- a/src/orga/minutes/2019-02-20.md
+++ b/src/orga/minutes/2019-02-20.md
@@ -1,0 +1,68 @@
+# 2019-02-20 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Elections
+    - Staged
+        - mjscosta
+            - “I can review C++ and Python, and Python + extensions recipes.”
+        - 
+- Discuss https://github.com/conda-forge/conda-forge.github.io/issues/712
+    - Two kinds of migration
+        - No breakage (everything is pinned properly so everything can live side by side)
+        - Breakage (current pins are incorrect, need second channel or hotfix repodata)
+- Plans for AnacondaCon
+- Migrations
+    - gfortran
+        - Need to build a migrator for new osx gfortran
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - Fixed some bugs, graph is fuller now
+    - Openssl
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/191
+        - https://github.com/conda-forge/conda-forge.github.io/issues/701
+        - https://github.com/regro/cf-scripts/issues/409
+        - https://www.openssl.org/blog/blog/2018/11/28/version/
+        - Channel priority doesn’t stop default’s python being installed with the newest openssl
+        - rebuild against openssl as soon as possible
+            - Anaconda to take this on for their next sprint (starting Monday, Feb 11).
+        - Pending new pinning
+    - Readline
+        - ABI change
+        - Needs migrator
+- 
+- Meta Channel
+    - https://github.com/regro/conda-metachannel
+        - Blocking parts
+        - Still need a domain / subdomain so that we can add some TLS
+    - probably not ready yet for use internally in 
+    - Want benchmarks
+- Conda-forge on Open Source Directions
+- Azure status
+    - Linux and OSX ready to go
+    - Need to fix windows (vc9 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - Postpone to next meeting
+- ESIP update
+    - choose a date and place for the sprint
+    - decide how much we will use for CIs vs Sprint/Travel (1000USD/4000USD?)
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - noarch
+    - base stack
+    - Many perl packages on bioconda (600+)
+    - Perl ABI?
+        - https://abi-laboratory.pro/?view=timeline&l=perl
+    - move forward with plan to incorporate perl into CF
+

--- a/src/orga/minutes/2019-03-06.md
+++ b/src/orga/minutes/2019-03-06.md
@@ -1,0 +1,85 @@
+# 2019-03-06 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Elections
+    - Staged
+        - mjscosta
+            - “I can review C++ and Python, and Python + extensions recipes.”
+        - xhochy
+        - let’s put an election for those two.
+- Blis vendor
+    - https://github.com/orgs/conda-forge/teams/core/discussions/2
+    - make the package a variant
+- CFEP-9
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/13
+    - Ongoing discussion, please visit the issue and comment!
+- Plans for AnacondaCon
+    - arrive before the conference if possible, 2nd, 3rd as a tentative days for our meeting.
+- Migrations
+    - gfortran
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - Fixed some bugs, graph is fuller now
+    - Openssl
+        - In progress https://conda-forge.org/status/
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/191
+        - https://github.com/conda-forge/conda-forge.github.io/issues/701
+        - https://github.com/regro/cf-scripts/issues/409
+        - https://www.openssl.org/blog/blog/2018/11/28/version/
+        - Channel priority doesn’t stop default’s python being installed with the newest openssl
+        - rebuild against openssl as soon as possible
+            - Anaconda to take this on for their next sprint (starting Monday, Feb 11).
+        - Pending new pinning
+    - Readline
+        - ABI change
+        - Needs migrator
+        - May want to wait
+    - libnetcdf
+        - @isuru suggested repo patch from X.X to X.X.X
+            - @Filipe F does not like the repo patch idea. @Mike S partially joked that repo patches are addictive :)
+        - Is the other option to migrate the pinnings?
+    - @Christopher W : Add link to migration docs for conda-forge.github.io
+- Meta Channel
+    - https://metachannel.conda-forge.org/ ← This URL renders markdown as raw text btw
+    - https://github.com/regro/conda-metachannel
+    - probably not ready yet for use internally in 
+    - Want benchmarks
+- ESIP update
+    - choose a date and place for the sprint
+    - decide how much we will use for CIs vs Sprint/Travel (1000USD/4000USD?)
+        - @Filipe F will fill the MOU form and ask about AirBnB for AnacondaCon
+    - Pay for airbnb for AnacondaCon
+    - Travel costs for Scipy
+    - Establish Effort reporting things (labels and such)
+- Conda-Forge miniconda
+    - Sophia did some benchmarks and showed that using a conda-pack’d archive reduced CI setup time down to about 2 seconds instead of the 40 seconds it takes to install miniconda and switch out all the packages for the conda-forge ones: https://gitter.im/conda-forge/conda-forge.github.io?at=5c79a37dd2d62067b72a849d
+    - Mike’s point was who owns the support for a conda-forge miniconda distro? https://gitter.im/conda-forge/conda-forge.github.io?at=5c7992a9e1446a6ebe6871d2
+- Azure status
+    - Linux and OSX ready to go
+    - Need to fix windows (vc9 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - Postpone to next meeting
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - noarch
+    - base stack
+    - Many perl packages on bioconda (600+)
+    - Perl ABI?
+        - https://abi-laboratory.pro/?view=timeline&l=perl
+    - move forward with plan to incorporate perl into CF
+- Conda-forge on Open Source Directions
+

--- a/src/orga/minutes/2019-03-20.md
+++ b/src/orga/minutes/2019-03-20.md
@@ -1,0 +1,79 @@
+# 2019-03-20 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Should we send something for the SciPy Tools plenary? https://docs.google.com/forms/d/e/1FAIpQLSdyemkK_NV1k6kp9ZakHm566nYUxrfCv7lO_MlNXKEoUv2I8w/viewform
+    - Not done, CJ following up on what we need to do
+- Elections/Governance
+    - Staged
+        - Progress?
+        - mjscosta
+            - “I can review C++ and Python, and Python + extensions recipes.”
+        - xhochy
+        - let’s put an election for those two.
+    - Split help teams from staged-recipes permissions?
+        - Go forward with splitting help teams from staged
+    - Staged team in Governance doc
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc
+- Should we “dogfood”  `strict`, which may be default in the next conda, in our CIs? The only known issue is `numpy` /`scipy`  on Windows because of BLAS requirements `1openblas`  (`numpy`)vs `mkl` (`scipy`). We need to either make `mkl` a first class citizen on Windows or have a `scipy` build with `openblas`.
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Perform switch after blas migration is more finished
+- Azure status
+    - Running in production for Linux and OSX
+    - Ran register script for any stragglers and things should work now
+    - Need to fix windows (vc9 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.))
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline
+        - ABI change
+        - Needs migrator
+        - May want to wait
+    - libnetcdf/libspatialindex
+        - @isuru suggested repo patch from X.X to X.X.X
+        - @Filipe F does not like the repo patch idea. @Mike S partially joked that repo patches are addictive :)
+        - Is the other option to migrate the pinnings? (No.)
+    - @Christopher W : Add link to migration docs for conda-forge.github.io
+- ESIP update
+    - Link for travel reimbursement
+- Conda-Forge miniconda
+    - Sophia did some benchmarks and showed that using a conda-pack’d archive reduced CI setup time down to about 2 seconds instead of the 40 seconds it takes to install miniconda and switch out all the packages for the conda-forge ones: https://gitter.im/conda-forge/conda-forge.github.io?at=5c79a37dd2d62067b72a849d
+    - Mike’s point was who owns the support for a conda-forge miniconda distro? https://gitter.im/conda-forge/conda-forge.github.io?at=5c7992a9e1446a6ebe6871d2
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+- Conda-forge on Open Source Directions
+

--- a/src/orga/minutes/2019-04-03.md
+++ b/src/orga/minutes/2019-04-03.md
@@ -1,0 +1,75 @@
+# 2019-04-03 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Conda-forge on Open Source Directions
+- Should we send something for the SciPy Tools plenary? https://docs.google.com/forms/d/e/1FAIpQLSdyemkK_NV1k6kp9ZakHm566nYUxrfCv7lO_MlNXKEoUv2I8w/viewform
+    - Not done, CJ following up on what we need to do
+- SciPy plans and how to spend ESIP/NumFOCUS sprint grant money.
+- Elections/Governance (let’s put an election for those two.)
+    - Staged
+        - Progress?
+        - mjscosta
+            - “I can review C++ and Python, and Python + extensions recipes.”
+        - xhochy
+        - etadeu
+    - Core
+        - pkgw
+    - Split help teams from staged-recipes permissions?
+        - Go forward with splitting help teams from staged
+    - Staged team in Governance doc
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc
+- Should we “dogfood”  `strict`, which may be default in the next conda, in our CIs? The only known issue is `numpy` /`scipy`  on Windows because of BLAS requirements `1openblas`  (`numpy`)vs `mkl` (`scipy`). We need to either make `mkl` a first class citizen on Windows or have a `scipy` build with `openblas`.
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Perform switch after blas migration is more finished
+- Azure status
+    - Need to fix windows (vc9 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.))
+    - How to restart an Azure job?
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline
+        - ABI change
+        - Needs migrator
+        - May want to wait
+    - @Christopher W : Add link to migration docs for conda-forge.github.io
+- Conda-Forge miniconda (Should we mark this as resolved and proceed with conda-pack?)
+    - Sophia did some benchmarks and showed that using a conda-pack’d archive reduced CI setup time down to about 2 seconds instead of the 40 seconds it takes to install miniconda and switch out all the packages for the conda-forge ones: https://gitter.im/conda-forge/conda-forge.github.io?at=5c79a37dd2d62067b72a849d
+    - Mike’s point was who owns the support for a conda-forge miniconda distro? https://gitter.im/conda-forge/conda-forge.github.io?at=5c7992a9e1446a6ebe6871d2
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+

--- a/src/orga/minutes/2019-04-17.md
+++ b/src/orga/minutes/2019-04-17.md
@@ -1,0 +1,84 @@
+# 2019-04-17 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Conda-forge on Open Source Directions
+- Should we send something for the SciPy Tools plenary? https://docs.google.com/forms/d/e/1FAIpQLSdyemkK_NV1k6kp9ZakHm566nYUxrfCv7lO_MlNXKEoUv2I8w/viewform
+    - Not done, CJ following up on what we need to do
+- SciPy plans and how to spend ESIP/NumFOCUS sprint grant money.
+- Elections/Governance (let’s put an election for those two.)
+    - Elections called - closing in a day.
+        - Staged
+            - Progress?
+            - mjscosta
+                - “I can review C++ and Python, and Python + extensions recipes.”
+            - xhochy
+            - etadeu
+        - Core
+            - pkgw
+        Upcoming helper for staged-recipes
+        - jan jansen
+    - Split help teams from staged-recipes permissions?
+        - Go forward with splitting help teams from staged
+            - GO make a github issue
+    - Staged team in Governance doc
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc
+- Should we “dogfood”  `strict`, which may be default in the next conda, in our CIs? The only known issue is `numpy` /`scipy`  on Windows because of BLAS requirements `openblas`  (`numpy`)vs `mkl` (`scipy`). We need to either make `mkl` a first class citizen on Windows or have a `scipy` build with `openblas`.
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Perform switch after blas migration is more finished
+        - Need to either copy over new compiler activation scripts package to cf
+        - Or delete ours entirely
+        - TODO: Verify that smithy and pinnings are fine for the compilers
+- Azure status
+    - Need to fix windows (vc9/14 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.))
+    - How to restart an Azure job?
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+    - Progress on colo talks for bins of gpus at Anaconda
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline
+        - ABI change
+        - Needs migrator
+        - May want to wait
+    - @Christopher W : Add link to migration docs for conda-forge.github.io
+- Conda-Forge miniconda (Should we mark this as resolved and proceed with conda-pack?)
+    - Sophia did some benchmarks and showed that using a conda-pack’d archive reduced CI setup time down to about 2 seconds instead of the 40 seconds it takes to install miniconda and switch out all the packages for the conda-forge ones: https://gitter.im/conda-forge/conda-forge.github.io?at=5c79a37dd2d62067b72a849d
+    - Mike’s point was who owns the support for a conda-forge miniconda distro? https://gitter.im/conda-forge/conda-forge.github.io?at=5c7992a9e1446a6ebe6871d2
+    - Should make an installer for AARCH64
+- Nvidia relationship
+    - Anaconda met with Rapids (NVIDIA) team
+    - Reach out to NVIDIA to attend meetings
+    - Add NVIDIA person to core?
+    - Add to governance discussing donations and governance.
+    - More followup with NVIDIA needed
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - Maybe form a working group?
+- Perl ecosystem?
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+

--- a/src/orga/minutes/2019-05-15.md
+++ b/src/orga/minutes/2019-05-15.md
@@ -1,0 +1,67 @@
+# 2019-05-15 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- Discuss the use of Drone (native ARM) in conda-forge.
+    - https://github.com/conda-forge/conda-smithy/pull/1069
+- Make conda-forge enhancements proposal a “first class citizen”  and it a voting process for approving them in our governance docs. (scopatz volunteered to add it to the docs.)
+- SciPy plans and how to spend ESIP/NumFOCUS sprint grant money.
+    - Buy dedicated machines.
+- Elections/Governance
+        Upcoming helper for staged-recipes
+        - jan jansen (TODO)
+    - Staged-recipes team in Governance doc (Review and merge)
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc.
+    - Make the spreadsheets available to all (NumFOCUS team drive folder).
+- Should we “dogfood”  `strict`, which may be default in the next conda, in our CIs?
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Perform switch after blas migration is more finished (ocefpaf: check the blas migration status.)
+        - Need to either copy over new compiler activation scripts package to cf
+        - Or delete ours entirely
+        - TODO: Verify that smithy and pinnings are fine for the compilers
+- Azure status
+    - Need to fix windows (vc9/14 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.)
+    - How to restart an Azure job?
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+    - Progress on colo talks for bins of gpus at Anaconda (Waiting on Mike W. on this.)
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran (wait for cfep-09)
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline (wait for cfep-09)
+        - ABI change
+        - Needs migrator
+    - @Christopher W : Add link to migration (conda-forge status?) docs for conda-forge.github.io (ocefpaf: I’ll add the status link to the docs)
+- Nvidia relationship
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - GPU compiler shim package: https://github.com/conda-forge/staged-recipes/pull/8229
+    - Maybe form a working group?
+- Perl ecosystem? (ocefpaf:Ask bBjorn G.)
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+- R 3.6 migration? (ocefpaf: Ask bBjorn G.)
+    - https://github.com/conda-forge/r-base-feedstock/pull/82
+

--- a/src/orga/minutes/2019-05-29.md
+++ b/src/orga/minutes/2019-05-29.md
@@ -1,0 +1,93 @@
+# 2019-05-29 conda-forge meeting
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- We need to share two passwords: @condaforge twitter account and the staged-recipes GH account that register the feedstocks. Is everybody OK with keybase?
+    - Just move the passwords to keybase
+- NumFOCUS summit will be in late Oct/early Nov it would be nice to have a strong conda-forge representation there.
+- We have 1 small grant development from NumFOCUS (3k) with the goal of a SciPy sprint. I’m writing a new one (this round is 5k) for a better recipe regeneration in conda-skeleton. If anyone is interested please let me know. (I’ll share a Google docs soon.)
+    - Is this specific to the pypi generation? Yes!
+    - This might be a helpful starting point https://github.com/ericdill/conda-skeletor (This is a real dumb name, so please don’t keep the legacy of this name haha)
+- We have a NumFOCUS team Google drive folder for conda-forge. Who has access to it? Should we make it available to all conda-forge core members?
+    - Scopatz to check during the call
+- SciPy 2019
+    - BoF and Sprint submitted! We need to know who wants to go, present, use FA, etc.
+    - Coordinate more SciPy activities: lightning talks, lunch/dinner?
+    - ~~TODO: Open an issue on github conda-forge.github.io to keep track of who is going to Scipy 2019~~
+    - https://github.com/conda-forge/conda-forge.github.io/issues/791
+~~~~- Discuss a strategy to manage qt patches (23!) and new version builds in the CIs.
+- ESIP update:
+    - balance: 3827.78 USD
+    - use part of the money to pay for Azure dedicated machines: Windows and Linux to build Qt.
+    - Use money to fund travel to SciPy this year?
+- http://conda-forge.org does not auto-upgrade to https
+- CFEP9 conda-smithy
+    - PR is now doing the right thing but requires some minor changes to conda-build to make it less gross
+    - Works for VC14→ 14.1 and VS2015→ VS2017 as a test case.  
+- Emiritus Change model
+    - TODO: Governance model similar to sklearn for moving users to non-voting
+
+**Old items**
+
+- “Dogfood”  `strict`, which may be default in the next conda, in our CIs?
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Currently we have a problem with `vc` on Windows. If we activate `strict` only the `vc` present in conda-forge, which is vc 14, will be used but we are building without `strict` and depending on `vc 14.1` from `defaults`. That means we would need to remove conda-forge `vc` packages and probably do some rebuilds. (Tried to rebuild `qt` with strict and hit a wall there even when removing our `vc`, which means more things must be rebuild first, maybe a migrator would be the best course of action here.)
+- Discuss the use of Drone (native ARM) in conda-forge.
+    - https://github.com/conda-forge/conda-smithy/pull/1069
+- Make conda-forge enhancements proposal a “first class citizen”  and it a voting process for approving them in our governance docs. (scopatz volunteered to add it to the docs.)
+- Elections/Governance
+        Upcoming helper for staged-recipes
+        - jan jansen (TODO)
+    - Staged-recipes team in Governance doc (Review and merge)
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc.
+    - Make the spreadsheets available to all (NumFOCUS team drive folder).
+    - Perform switch after blas migration is more finished (ocefpaf: check the blas migration status.)
+        - Need to either copy over new compiler activation scripts package to cf
+        - Or delete ours entirely
+        - TODO: Verify that smithy and pinnings are fine for the compilers
+- Azure status
+    - Need to fix windows (vc9/14 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.)
+    - How to restart an Azure job?
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+    - Progress on colo talks for bins of gpus at Anaconda (Waiting on Mike W. on this.)
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran (wait for cfep-09)
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline (wait for cfep-09)
+        - ABI change
+        - Needs migrator
+    - @Christopher W : Add link to migration (conda-forge status?) docs for conda-forge.github.io (ocefpaf: I’ll add the status link to the docs)
+- Nvidia relationship
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - GPU compiler shim package: https://github.com/conda-forge/staged-recipes/pull/8229
+    - Maybe form a working group?
+- Perl ecosystem? (ocefpaf:Ask bBjorn G.)
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+- R 3.6 migration? (ocefpaf: Ask bBjorn G.)
+    - https://github.com/conda-forge/r-base-feedstock/pull/82
+

--- a/src/orga/minutes/2019-06-12.md
+++ b/src/orga/minutes/2019-06-12.md
@@ -1,0 +1,108 @@
+# 2019-06-12 Meeting Notes
+**Pinned Items**
+
+- Zoom instructions: [+How to connect to zoom](https://paper.dropbox.com/doc/How-to-connect-to-zoom-odl94oveHyiRv6UqTtZE5) 
+----------
+
+**New items**
+
+- We need to share two passwords: 
+    - Just move the passwords to keybase
+    [x] @Eric D uploaded the Twitter conda forge PW to keybase 2019-06-12
+    [ ] Upload stages recipes GH acct pw to keybase
+- 2fa for bots
+    - How do we share creds for these?  Photos of the QR code in keybase? (Or share the passcode that the QR code represents)
+- NumFOCUS summit will be in late Oct/early Nov it would be nice to have a strong conda-forge representation there.
+- We have 1 small grant development from NumFOCUS (3k) with the goal of a SciPy sprint. I’m writing a new one (this round is 5k) for a better recipe regeneration in conda-skeleton. If anyone is interested please let me know. (I’ll share a Google docs soon.)
+    - Is this specific to the pypi generation? Yes!
+    - This might be a helpful starting point https://github.com/ericdill/conda-skeletor (This is a real dumb name, so please don’t keep the legacy of this name haha)
+- We have a NumFOCUS team Google drive folder for conda-forge. Who has access to it? Should we make it available to all conda-forge core members?
+    - Scopatz to check during the call
+- SciPy 2019
+    - BoF and Sprint submitted! We need to know who wants to go, present, use FA, etc.
+    - Coordinate more SciPy activities: lightning talks, lunch/dinner?
+    - ~~TODO: Open an issue on github conda-forge.github.io to keep track of who is going to Scipy 2019~~
+    - https://github.com/conda-forge/conda-forge.github.io/issues/791
+- Discuss a strategy to manage qt patches (23!) and new version builds in the CIs.
+    - Should be able to drop some of the patches and simplify when python 2.7 deprecates. QT 5.9 is the last version for py27 b/c QT is not supporting vs 2008 after the 5.9 rev. 
+- ESIP update:
+    - balance: 3827.78 USD
+    - use part of the money to pay for Azure dedicated machines: Windows and Linux to build Qt.
+    - Use money to fund travel to SciPy this year?
+- Long running build setup on linux
+    - Set up build nodes on linux on azure.
+    - Autoscaling group: then we don't have to pre-determine the instance sizing. 
+    - TODO: Ask azure maybe?
+- Nvidia money has not arrived for may profit / loss conda-forge report. Eric will ping Lynn and ask about these phantom dollars. 
+- http://conda-forge.org does not auto-upgrade to https. This is a Marius thing.
+- CFEP9 conda-smithy
+    - PR is now doing the right thing but requires some minor changes to conda-build to make it less gross
+    - Works for VC14→ 14.1 and VS2015→ VS2017 as a test case.  
+    - How does staged-recipes need to be changed to account for these new migrators / pinnings
+- Emiritus Change model
+    - TODO: Governance model similar to sklearn for moving users to non-voting
+    - https://github.com/conda-forge/conda-forge.github.io/pull/795
+- Handling rc label with strict channel priority
+    - https://github.com/conda/conda/issues/8752
+    - https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/3
+
+**Old items**
+
+- “Dogfood”  `strict`, which may be default in the next conda, in our CIs?
+    - https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/50
+    - https://github.com/conda-forge/staged-recipes/pull/8009
+    - Currently we have a problem with `vc` on Windows. If we activate `strict` only the `vc` present in conda-forge, which is vc 14, will be used but we are building without `strict` and depending on `vc 14.1` from `defaults`. That means we would need to remove conda-forge `vc` packages and probably do some rebuilds. (Tried to rebuild `qt` with strict and hit a wall there even when removing our `vc`, which means more things must be rebuild first, maybe a migrator would be the best course of action here.)
+- Discuss the use of Drone (native ARM) in conda-forge.
+    - https://github.com/conda-forge/conda-smithy/pull/1069
+- Make conda-forge enhancements proposal a “first class citizen”  and it a voting process for approving them in our governance docs. (scopatz volunteered to add it to the docs.)
+- Elections/Governance
+        Upcoming helper for staged-recipes
+        - jan jansen (TODO)
+    - Staged-recipes team in Governance doc (Review and merge)
+        - https://github.com/conda-forge/conda-forge.github.io/pull/738
+    - Add formal budget team to Governance doc.
+    - Make the spreadsheets available to all (NumFOCUS team drive folder).
+    - Perform switch after blas migration is more finished (ocefpaf: check the blas migration status.)
+        - Need to either copy over new compiler activation scripts package to cf
+        - Or delete ours entirely
+        - TODO: Verify that smithy and pinnings are fine for the compilers
+- Azure status
+    - Need to fix windows (vc9/14 and cmake)
+    - Credentials issues (need pipelines account to access Azure, will move to GH auth soon)
+    - How to handle bespoke build agents (for builds taking longer than 6 hours (qt, compilers, etc.)
+    - How to restart an Azure job?
+- NVIDIA
+    - Louder communication path for large ecosystem shifts (compiler migrations)
+        - Banner on AnacondaCloud, status updates on channel
+        - Print something while using `conda install`
+        - More frequent updates
+    - AnacondaCloud can fall over (mirroring conda)
+    - Try to track down hard linked drivers in GPU packages.
+    - Progress on colo talks for bins of gpus at Anaconda (Waiting on Mike W. on this.)
+- Migrations
+    - Blas
+        - Underway
+    - Libprotobuf
+        - Underway
+    - gfortran (wait for cfep-09)
+        - Need to build a migrator for new osx gfortran
+        - https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/174 maybe?
+    - Power and Arm
+        - Ongoing https://conda-forge.org/status/
+        - More leafs to target?
+    - Openssl
+        - Underway
+    - Readline (wait for cfep-09)
+        - ABI change
+        - Needs migrator
+    - @Christopher W : Add link to migration (conda-forge status?) docs for conda-forge.github.io (ocefpaf: I’ll add the status link to the docs)
+- Nvidia relationship
+    - Building GPU packages using conda-forge packages, upload to their own channel after building with cudatoolkit on their own Jenkins system.
+    - GPU compiler shim package: https://github.com/conda-forge/staged-recipes/pull/8229
+    - Maybe form a working group?
+- Perl ecosystem? (ocefpaf:Ask bBjorn G.)
+    - move forward with plan to incorporate perl into CF
+        - Do we have an issue or something for this?
+- R 3.6 migration? (ocefpaf: Ask bBjorn G.)
+    - https://github.com/conda-forge/r-base-feedstock/pull/82
+


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

This just does an archival dump of all of the notes from Dropbox Paper exported to Markdown.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
