### PR TITLE
add url for lab49 logo

### DIFF
--- a/src/inst_partners.yaml
+++ b/src/inst_partners.yaml
@@ -10,11 +10,11 @@
 
 # Places that employ core
 Lab49:
-  Description:
+  Description: Lab49 provides developer time
   Developers:
     - cj-wright
   Logo URL:
-    - imgs/lab49.png
+    - https://www.lab49.com/wp-content/uploads/2020/06/logo.svg
   Site URL:
     - https://www.lab49.com
   contribution type:


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->