### PR TITLE
add NVIDIA to institutional partners

### DIFF
--- a/src/inst_partners.yaml
+++ b/src/inst_partners.yaml
@@ -66,6 +66,18 @@ QuantStack:
    contribution type:
      - dev support
 
+NVIDIA:
+   Description: NVIDIA provides developer time
+   Developers:
+     - jakirkham
+     - kkraus14
+   Logo URL:
+     - https://s3.amazonaws.com/cms.ipressroom.com/219/files/20149/544a0d86f6091d6699000060_NVLogo_2D/NVLogo_2D_362acb00-8e1b-476b-9662-9fe138a4a920-prv.jpg
+   Site URL:
+     - https://www.nvidia.com
+   contribution type:
+     - dev support
+
 # Places that give us stuff
 Microsoft Azure:
   Description: Azure provides build systems for Windows, OSX, and Linux

--- a/src/inst_partners.yaml
+++ b/src/inst_partners.yaml
@@ -72,7 +72,7 @@ NVIDIA:
      - jakirkham
      - kkraus14
    Logo URL:
-     - https://s3.amazonaws.com/cms.ipressroom.com/219/files/20149/544a0d86f6091d6699000060_NVLogo_2D/NVLogo_2D_362acb00-8e1b-476b-9662-9fe138a4a920-prv.jpg
+     - https://cdn-assets-cloud.frontify.com/s3/frontify-cloud-files-us/eyJwYXRoIjoiZnJvbnRpZnlcL2FjY291bnRzXC84MVwvOTYxNTJcL3Byb2plY3RzXC8xNzY2NDRcL2Fzc2V0c1wvOWRcLzI0NzM4MTdcLzY0ZmRkOTc3MGY4Zjg0YjMxM2E3NDQ5NGY3NTc0MzZiLTE1MzE1MTU3MjkucG5nIn0:cloud:hhu8wqybRLydq7ZhAqVEYy66lpq61SJurz-rRPPEX2s
    Site URL:
      - https://www.nvidia.com
    contribution type:

--- a/src/inst_partners.yaml
+++ b/src/inst_partners.yaml
@@ -77,6 +77,7 @@ NVIDIA:
      - https://www.nvidia.com
    contribution type:
      - dev support
+     - fiscal support
 
 # Places that give us stuff
 Microsoft Azure:


### PR DESCRIPTION
Related to https://github.com/conda-forge/conda-forge.github.io/pull/1200

I believe NVIDIA has also provided monetary funding to conda-forge. Unsure if that should be captured here or not, but given I'm an inherently biased source 😅 would defer to others thoughts.