### PR TITLE
Fix dead url

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -488,7 +488,7 @@ Testing python packages
 .......................
 
 For the best information about testing, see the conda build docs
-`test section. <https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#test-section>`_
+`test section. <https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#test-section>`_
 
 
 Testing importing


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
