### PR TITLE
DOC strict is now the default on windows

### DIFF
--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -113,8 +113,7 @@ channel_priority
 ----------------
 
 This value sets the ``conda`` solver channel priority for feedstock builds. On
-OSX and Liunx, it defaults to ``strict``. On Windows, it defaults to the default in
-``conda`` (``flexible`` at the time of writing). Any valid value for the same setting
+OSX, Liunx, and Windows, it defaults to ``strict``. Any valid value for the same setting
 in the ``.condarc`` is allowed here.
 
 channels


### PR DESCRIPTION
<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
cc @wolfv @isuruf @ocefpaf 