### PR TITLE
simplify reccomended use and add pypy3.7

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1053,7 +1053,7 @@ To use the PyPy 3.6 or 3.7 builds you can do the following,
 .. code-block:: bash
 
    conda create -n pypy36  pypy python=3.6
-   conda create -n pypy37  pypy3.7 python=3.7
+   conda create -n pypy37  pypy python=3.7
 
 .. note::
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1048,27 +1048,16 @@ the requirement should be changed from ``run`` to ``run_constrained``. Note that
 PyPy builds
 ===========
 
-To use the PyPy builds you can do the following,
+To use the PyPy 3.6 or 3.7 builds you can do the following,
 
 .. code-block:: bash
 
-   conda install python=3.6.*=*_pypy
-
-or,
-
-.. code-block:: bash
-
-   conda install pypy python=3.6
-
-or,
-
-.. code-block:: bash
-
-   conda install pypy
+   conda create -n pypy36  pypy python=3.6
+   conda create -n pypy37  pypy3.7 python=3.7
 
 .. note::
 
-   As of March 8, if you are using defaults as a low priority channel,
+   As of March 8 2020, if you are using defaults as a low priority channel,
    then you need to use strict channel priority as the metadata in defaults
    has not been patched yet which allows cpython extension packages to be
    installed alongside pypy.


### PR DESCRIPTION
Show only one recommended way of using the pypy builds, and add pypy3.7. I tried the `conda install` variant but it more often that not caused a resolver conflict, so I think it is better to recommend creating a new environment.

It might be nice to explain the command. I know how to explain the `-n pypy` part, but what exactly is the next selector `pypy3.6` or `pypy3.7` called?