### PR TITLE
Update build number in MPI example

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -605,7 +605,7 @@ This matches what is done in `hdf5 <https://github.com/conda-forge/hdf5-feedstoc
 
   # meta.yaml
   {% set name = 'pkg' %}
-  {% set build = 1000 %}
+  {% set build = 0 %}
 
   # ensure mpi is defined (needed for conda-smithy recipe-lint)
   {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
I don't think the 1000 build number is needed any more unless there is a quirk on MPI which I'm missing?