### PR TITLE
knowledge_base: add missing cudnn key

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1113,6 +1113,8 @@ of your recipe and rerendering.
 
 .. code-block:: yaml
 
+   cudnn:                                    # [linux64]
+     - undefined                             # [linux64]
    cuda_compiler_version:                    # [linux64]
      - None                                  # [linux64]
    docker_image:                             # [linux64]


### PR DESCRIPTION
Add missing `cudnn` key in YAML block describing `conda_build_config.yaml` for CentOS 7

cc @chrisburr @beckermr

<!--
Thank you for pull request.
Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
