### PR TITLE
Add docs for extended CUDA build matrices

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1183,8 +1183,11 @@ My feedstock is not building old CUDA versions anymore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 With the `addition of CUDA 11.1 and 11.2 <https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1162>`_,
-the default build matrix for CUDA versions was trimmed down to versions 10.2, 11.0, 11.1, 11.2. If you want to
-re-add support for 9.2, 10.0 and 10.1, you need to follow these steps below:
+the default build matrix for CUDA versions was trimmed down to versions 10.2, 11.0, 11.1, 11.2.
+
+If you really need it, you can re-add support for 9.2, 10.0 and 10.1. However, this is not recommended.
+Adding more CUDA versions to the build matrix will dramatically increase the number of jobs and will place a large
+burden on our CI resources. Only proceed if there's a known use case for the extra packages.
 
 1. Download this `migration file <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/cuda92_100_101.yaml>`_.
 2. In your feedstock fork, create a new branch and place the migration file under ``.ci_support/migrations``.

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -467,7 +467,7 @@ shouldn't be, because some packages built with mpi don't preclude other packages
 from using the no-mpi variant of the library (e.g. for a long time, fenics used mpi with no-mpi hdf5 since there was no
 parallel hdf5 yet. This works fine, though some features may not be available).
 
-Typically, if there is a preference it will be for the serial build, such that installers/requirers of the package 
+Typically, if there is a preference it will be for the serial build, such that installers/requirers of the package
 only get the mpi build if explicitly requested. We use a higher build number for the ``nompi`` variant in this case.
 
 Here is an example build section:
@@ -1177,6 +1177,24 @@ For now, you will have to add ``nvcuda.dll`` to the ``missing_dso_whitelist``::
     ...
     missing_dso_whitelist:
       - "*/nvcuda.dll"   # [win]
+
+
+My feedstock is not building old CUDA versions anymore
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the `addition of CUDA 11.1 and 11.2 <https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1162>`_,
+the default build matrix for CUDA versions was trimmed down to versions 10.2, 11.0, 11.1, 11.2. If you want to
+re-add support for 9.2, 10.0 and 10.1, you need to follow these steps below:
+
+1. Rename the file ``.ci_support/migrations/cuda111_112.yaml`` to ``.ci_support/migrations/cuda111_112.disabled``.
+2. Add the contents of `this file <https://github.com/conda-forge/nvcc-feedstock/blob/master/recipe/conda_build_config.yaml>`_
+   to your ``recipe/conda_build_config.yaml``. Create it if it didn't exist yet.
+3. Re-render the feedstock.
+
+Note that by following this procedure you are opting out of the migration process for CUDA builds and you will have to
+update the contents of ``conda_build_config.yaml`` by hand. If you experience re-rendering errors, check that the contents
+of this file match the one present in the `nvcc-feedstock <https://github.com/conda-forge/nvcc-feedstock>`_. When in doubt,
+remove ``conda_build_config.yaml``, rename back the migrator file (step 1) and re-render.
 
 
 Adding support for a new CUDA version

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1186,15 +1186,9 @@ With the `addition of CUDA 11.1 and 11.2 <https://github.com/conda-forge/conda-f
 the default build matrix for CUDA versions was trimmed down to versions 10.2, 11.0, 11.1, 11.2. If you want to
 re-add support for 9.2, 10.0 and 10.1, you need to follow these steps below:
 
-1. Rename the file ``.ci_support/migrations/cuda111_112.yaml`` to ``.ci_support/migrations/cuda111_112.disabled``.
-2. Add the contents of `this file <https://github.com/conda-forge/nvcc-feedstock/blob/master/recipe/conda_build_config.yaml>`_
-   to your ``recipe/conda_build_config.yaml``. Create it if it didn't exist yet.
-3. Re-render the feedstock.
-
-Note that by following this procedure you are opting out of the migration process for CUDA builds and you will have to
-update the contents of ``conda_build_config.yaml`` by hand. If you experience re-rendering errors, check that the contents
-of this file match the one present in the `nvcc-feedstock <https://github.com/conda-forge/nvcc-feedstock>`_. When in doubt,
-remove ``conda_build_config.yaml``, rename back the migrator file (step 1) and re-render.
+1. Download this `migration file <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/cuda92_100_101.yaml>`_.
+2. In your feedstock fork, create a new branch and place the migration file under ``.ci_support/migrations``.
+3. Open a PR and re-render. CUDA 9.2, 10.0 and 10.1 will appear in the CI checks now. Merge when ready!
 
 
 Adding support for a new CUDA version


### PR DESCRIPTION
Document process followed in https://github.com/conda-forge/nvcc-feedstock/pull/64

* Instead of deleting the migrator I suggest renaming to a non-yaml extension so it's easier to undo, but happy to change that if needed!