### PR TITLE
DOC add info on os version

### DIFF
--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -252,7 +252,7 @@ Currently only:
 os_version
 ----------
 This key is used to set the OS versions for ``linux_*`` platforms. Valid entries map a linux platform and arch to either ``cos6``
-or ``cos7``. Currently ``cos6`` is the default. Here is an example that enables CentOS 7 on ``linux-64`` builds
+or ``cos7``. Currently ``cos6`` is the default for ``linux-64``. All other linux architectures use CentOS 7. Here is an example that enables CentOS 7 on ``linux-64`` builds
 
 .. code-block:: yaml
 

--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -36,6 +36,7 @@ Top-level fields
 * linux
 * linux_aarch64
 * linux_ppc64le
+* os_version
 * osx
 * provider
 * recipe_dir
@@ -247,6 +248,16 @@ Currently only:
 
     linux_ppc64le:
       enabled: False
+
+os_version
+----------
+This key is used to set the OS versions for ``linux_*`` platforms. Valid entries map a linux platform and arch to either ``cos6``
+or ``cos7``. Currently ``cos6`` is the default. Here is an example that enables CentOS 7 on ``linux-64`` builds
+
+.. code-block:: yaml
+
+    os_version:
+      linux_64: cos7
 
 osx
 ---

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1065,23 +1065,13 @@ put the following in your build section.
        - {{ compiler('c') }}
        - sysroot_linux-64 2.17  # [linux64]
 
-You also need to use a newer docker image by setting the following in the ``conda_build_config.yaml``
+You also need to use a newer docker image by setting the following in the ``conda-forge.yml``
 of your recipe and rerendering.
 
 .. code-block:: yaml
 
-   cudnn:                                    # [linux64]
-     - undefined                             # [linux64]
-   cuda_compiler_version:                    # [linux64]
-     - None                                  # [linux64]
-   docker_image:                             # [linux64]
-     - condaforge/linux-anvil-cos7-x86_64    # [linux64]
-   cdt_name:                                 # [linux64]
-     - cos7                                  # [linux64]
-
-The extra ``cuda_compiler_version`` key is needed because we currently zip that
-key with ``docker_image``. Also ``cdt_name`` ensures the CDTs match the CentOS
-version. If this changes in the future, then this extra key may not be needed.
+   os_version:
+     linux_64: cos7
 
 Finally, note that the ``aarch64`` and ``ppc64le`` platforms already use CentOS 7.
 


### PR DESCRIPTION
This PR adds docs for easier cos7 switching. Merge after the smithy PR (https://github.com/conda-forge/conda-smithy/pull/1453) is done and a new version of smithy has been released.