### PR TITLE
Add empty packages to docs

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -853,10 +853,10 @@ Empty Python packages
 For some features introduced in later Python versions, the Python community creates backports, which makes these
 features available for earlier versions of Python as well.
 One example here is `dataclasses <https://www.python.org/dev/peps/pep-0557/>`__ which was introduced with
-Python3.7 but is available as a `backport <https://github.com/ericvsmith/dataclasses>`__ for Python3.6 as well.
+Python3.7 but is available as a `backport <https://github.com/ericvsmith/dataclasses>`__ for Python3.6 too.
 Therefore, most upstream packages make those backports only mandatory for specific versions of Python and exclude them otherwise.
 
-Implementing this restriction in conda-forge is currently only possible through the usage of ``skips``
+Implementing this restriction in conda-forge is currently only possible through the use of ``skips``
 which restricts the corresponding conda-forge recipes from becoming ``noarch``.
 
 Therefore, some conda-forge recipes only create an actual package on specific Python versions and are otherwise an

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -846,6 +846,31 @@ To use this package in a build, put it in the host environment like so
         - pybind11-abi
 
 
+.. _knowledge:empty:
+
+Empty Python packages
+----------
+For some features introduced in later Python versions, the Python community creates backports, which makes these
+features available for earlier versions of Python as well.
+One example here is `dataclasses <https://www.python.org/dev/peps/pep-0557/>`__ which was introduced with
+Python3.7 but is available as a `backport <https://github.com/ericvsmith/dataclasses>`__ for Python3.6 as well.
+Therefore, most upstream packages make those backports only mandatory for specific versions of Python and exclude them otherwise.
+
+Implementing this restriction in conda-forge is currently only possible through the usage of ``skips``
+which restricts the corresponding conda-forge recipes from becoming ``noarch``.
+
+Therefore, some conda-forge recipes only create an actual package on specific Python versions and are otherwise an
+empty placeholder. This allows them to be safely installed under all Python versions and makes using ``skips`` unnecessary.
+
+Currently available packages:
+
++-------------+-------------------+--------------+
+| Name        | Available on:     | Empty on:    |
++=============+===================+==============+
+| dataclasses | python >=3.6,<3.7 | python >=3.7 |
++-------------+-------------------+--------------+
+
+
 Noarch builds
 =============
 


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs`
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

Closes #1270 

I was unable to build the docs locally using the `conda-forge-docs` environment, as that failed with the following error: 

```zsh
(conda-forge-docs) user@iMac src % make html                                               
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v3.5.2

Extension error:
Could not import extension sphinxcontrib.newsfeed (exception: No module named 'sphinxcontrib.newsfeed')
make: *** [Makefile:58: html] Error 2
```