### PR TITLE
Add note on jpeg/libjpeg-turbo in Knowledge Base

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1271,6 +1271,13 @@ which has `openblas` as a dependency and has a symlink from `libblas.so.3` to `l
 BLAS `3.8.0` API.  This means that, at install time, the user can select what BLAS implementation
 they like without any knowledge of the version of the BLAS implementation needed.
 
+### Linking `jpeg`
+
+If you mantain a feedstock that depends on jpeg, please make it depend on the `jpeg` package, not
+on the `libjpeg-turbo` package. `jpeg` and `libjpeg-turbo` have common symbols and loading both into 
+the same process can be problematic. It is possible that in the future conda-forge will switch to 
+use libjpeg-turbo, but at the moment depending on libjpeg-turbo is not supported and discouraged.
+
 <a id="knowledge-mpl"></a>
 
 <a id="matplotlib"></a>

--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1274,9 +1274,10 @@ they like without any knowledge of the version of the BLAS implementation needed
 ### Linking `jpeg`
 
 If you mantain a feedstock that depends on jpeg, please make it depend on the `jpeg` package, not
-on the `libjpeg-turbo` package. `jpeg` and `libjpeg-turbo` have common symbols and loading both into 
-the same process can be problematic. It is possible that in the future conda-forge will switch to 
-use libjpeg-turbo, but at the moment depending on libjpeg-turbo is not supported and discouraged.
+on the `libjpeg-turbo` package. `jpeg` and `libjpeg-turbo` have common symbols and loading both into
+the same process can be problematic. It is possible that in the future conda-forge will [switch to
+use `libjpeg-turbo`](https://github.com/conda-forge/conda-forge.github.io/issues/673),
+but at the moment depending on `libjpeg-turbo` is not supported and discouraged.
 
 <a id="knowledge-mpl"></a>
 


### PR DESCRIPTION
PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs`
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below


I have added some feedstock that depend on libjpeg-turbo, but it turned out that this is not currently supported, see https://github.com/conda-forge/qt-main-feedstock/issues/124 and https://github.com/conda-forge/conda-forge.github.io/issues/673 . Adding a note in the Knowledge Base should help avoiding that future maintainers also do the same error. 