### PR TITLE
Improved Getting-In-Touch in Org sec.

### DIFF
--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -3,14 +3,19 @@
 Getting in Touch
 ================
 
-There are many ways to get in touch with the conda-forge community, primarily
-through issue trackers, mailing lists, and real-time chat.
+The community at conda-forge would be happy to connect with you. We have got several ways for you to communicate with us, primarily through issue trackers, mailing lists, and real-time chat.
+
+Issue Trackers
+-----------------
 
 The main issue trackers that you will interact with are
 
 * `staged-recipes <https://github.com/conda-forge/staged-recipes/issues>`_: You'll use staged-recipes to create a new conda package on conda-forge
-* `our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`_: You'll use this repo as a catch-all for issues where you're not sure where else to put them
-* `our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`_: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
+* `Our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`_: You'll use this repo as a catch-all for issues where you're not sure where else to put them
+* `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`_: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
+
+Gitter
+-----------------
 
 The main chat rooms that you'll interact with are
 
@@ -22,12 +27,14 @@ The main chat rooms that you'll interact with are
   Our automation infrastructure is colloquially referred to as "the bot".
 * `gitter: compilers <https://gitter.im/conda-forge/conda-forge-compilers>`_: Public chat room focused on the conda-forge compiler stack.
 
-Mailing lists
+Mailing List
+-----------------
 
 * `google group: conda-forge <https://groups.google.com/g/conda-forge>`_: The general mailing list for conda-forge.
   Sees a moderate amount of traffic, though substantially lower than the public gitter room.
 
-Other communication methods
+Other Communication Methods
+-----------------------------
 
 * The core team is also on Keybase for security related stuff. If you're part of the core team and don't have
   access, ping someone on the core team for access.
@@ -38,5 +45,5 @@ Staying Up-to-date
 
 There are several sources that have the latest conda-forge information.
 
-* `blog <https://conda-forge.org/blog>`_: We blog about big feature enhancements and other items. Our blog has an Atom `feed <https://conda-forge.org/blog/atom.xml>`_.
-* `news <https://conda-forge.org/docs/user/announcements.html#announcements>`_: Our :ref:`announcements <news>` page has periodic notices about technical changes to our infrastructure. It is also served as an RSS `feed <https://conda-forge.org/docs/news.rss>`_.
+* `Blog <https://conda-forge.org/blog>`_: We blog about big feature enhancements and other items. Our blog has an Atom `feed <https://conda-forge.org/blog/atom.xml>`_.
+* `News <https://conda-forge.org/docs/user/announcements.html#announcements>`_: Our :ref:`announcements <news>` page has periodic notices about technical changes to our infrastructure. It is also served as an RSS `feed <https://conda-forge.org/docs/news.rss>`_.


### PR DESCRIPTION
I have tried to modify the Getting in Touch section under Organization Docs to make it look even with Getting in touch section under User Docs.
![Screenshot from 2021-04-05 13-36-51](https://user-images.githubusercontent.com/51945896/113552627-03ab4380-9614-11eb-8a4b-5ec478e6f0d3.png)




PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs`
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
