### PR TITLE
Minor 'How to get help' Modification

### DIFF
--- a/src/user/how_to_get_help.rst
+++ b/src/user/how_to_get_help.rst
@@ -1,4 +1,4 @@
-How to reach out to us
+How to get help in conda-forge
 ==============================
 
 You could connect with us via **Gitter, GitHub Issues or Mailing List**. 

--- a/src/user/how_to_get_help.rst
+++ b/src/user/how_to_get_help.rst
@@ -1,32 +1,29 @@
-How to get help in conda-forge
+How to reach out to us
 ==============================
 
-We have three options for communication,
-live `chat on gitter <https://gitter.im/conda-forge/conda-forge.github.io>`__,
-GitHub issues,
-and a `mailing list <https://groups.google.com/forum/#!forum/conda-forge>`__.
-Depending on the kind of problem one or the other may be more adequate.
+You could connect with us via **Gitter, GitHub Issues or Mailing List**. 
+We would be happy to hear from you!
 
-Live chat on gitter
+Gitter
 -------------------
 
-If you don't know the first thing about conda-forge and/or is completely
-lost we recommend to get in touch via the chat and our community members will direct
+If you are just starting out with conda-forge and/or are completely lost, we recommend to get in touch through `Gitter <https://gitter.im/conda-forge/conda-forge.github.io>`__ and our community members will direct
 you to the proper documentation and/or help you via the chat.
 
 GitHub issues
 -------------
+
 You can open issues at `staged-recipes <https://github.com/conda-forge/staged-recipes/issues>`__
 to request a new package or to report a problem with staged-recipes itself (our port of entry to conda-forge).
 
 Or you can open an issue about a specific package at the package feedstock via
 ``https://github.com/conda-forge/<PACKAGE-NAME>-feedstock/issues``
 
-When opening issues be sure to:
+When opening issues, be sure to:
 
-1. Try a new environment first following conda-forge `install instructions <https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge>`__.
-2. Always open a new one when an issue is closed. In the packaging world symptoms may be similar but the causes are usually very different.
-3. Fill in the required information. Without the output of `conda list` and `conda info -a` the team cannot debug the problem.
+* Try a new environment first following conda-forge `install instructions <https://conda-forge.org/docs/user/introduction.html#how-can-i-install-packages-from-conda-forge>`__.
+* Always open a new one when an issue is closed. In the packaging world symptoms may be similar but the causes are usually very different.
+* Fill in the required information. Without the output of `conda list` and `conda info -a` the team cannot debug the problem.
 
 
 You can open issues at `conda-forge.github.io <https://github.com/conda-forge/conda-forge.github.io/issues>`__
@@ -36,7 +33,6 @@ Please note that some of these discussions will be turned into policy via the `C
 Mailing list
 ------------
 
-The mailing list is a secondary home for long threads about the ecosystem.
+You can subscribe to our `Mailing List <https://groups.google.com/forum/#!forum/conda-forge>`__ and post your queries there. The mailing list is a secondary home for long threads about the ecosystem.
 
-TL:DR Don't be shy! Get in touch!
-----------------------------------
+


### PR DESCRIPTION
Made some changes in the How to get help section under User docs.

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs`
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
