### PR TITLE
Added logotarget for logo links to direct back to homepage

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -135,6 +135,7 @@ html_theme_options = {
     'sidebarlinkcolor': 'rgb(31, 158, 111)',
     'codebgcolor': '#F2F2F2',
     'sidebarbgcolor': '#F2F2F2',
+    'logotarget': '../../../index',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->
Fixes: #1292 
Old PR: #1311 
PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs`
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
