### PR TITLE
'Knowledge base' page heading capitalized.

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1,4 +1,4 @@
-Knowledge base
+Knowledge Base
 **************
 
 Using CMake


### PR DESCRIPTION
'Knowledge base' change to 'Knowledge Base' in the heading.

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs`
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
