### PR TITLE
Fixed the link in 'pinned dependencies' page.

### DIFF
--- a/src/maintainer/pinning_deps.rst
+++ b/src/maintainer/pinning_deps.rst
@@ -64,7 +64,7 @@ If a package is not pinned in `conda-forge-pinning <https://github.com/conda-for
       ignore_run_exports:
         - gmp
 
-There is additional documentation on this pinning scheme in `the conda docs <https://docs.conda.io/projects/conda-build/en/latest/source/variants.html#build-variants>`_.
+There is additional documentation on this pinning scheme in `the conda docs <https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#build-variants>`_.
 
 
 Specifying run_exports


### PR DESCRIPTION
>There is additional documentation on this pinning scheme in [the conda docs](https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#build-variants)

'the conda docs' now point to : https://docs.conda.io/projects/conda-build/en/latest/resources/variants.html#build-variants

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs`
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
