### PR TITLE
Recipe definition added 

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -113,11 +113,10 @@
             <div class="col-lg-8 col-lg-offset-2 padded">
                 <h2 class="text-center">About conda-forge</h2>
                 <p>
-                  <a href="https://github.com/conda-forge">conda-forge</a> is a GitHub organization containing repositories of conda recipes.
-
+                  <a href="https://github.com/conda-forge">conda-forge</a> is a GitHub organization containing repositories of conda <a href="https://conda-forge.org/docs/misc/00_intro.html#glossary">recipes</a>.
                   Thanks to some awesome continuous integration providers (AppVeyor, Azure Pipelines, CircleCI and TravisCI),
                   each repository, also known as a feedstock, automatically
-                  builds its own recipe in a clean and repeatable way on Windows, Linux and OSX.
+                  builds its own <a href="https://conda-forge.org/docs/misc/00_intro.html#glossary">recipe</a> in a clean and repeatable way on Windows, Linux and OSX.
                 </p>
                 <p>
                   The built distributions are uploaded to <a href="http://anaconda.org/conda-forge">anaconda.org/conda-forge</a>

--- a/src/misc/00_intro.rst
+++ b/src/misc/00_intro.rst
@@ -6,6 +6,9 @@ Glossary
 
 .. glossary::
 
+  Recipe
+    **R**\ ecipe is the collection of files required to build the conda package. This includes at minimum the `meta.yaml <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml>`_, but can also include license files, patches, build scripts, test scripts etc.
+  
   CI
     **C**\ ontinuous **I**\ ntegration.
 

--- a/src/misc/00_intro.rst
+++ b/src/misc/00_intro.rst
@@ -7,7 +7,8 @@ Glossary
 .. glossary::
 
   Recipe
-    **R**\ ecipe is the collection of files required to build the conda package. This includes at minimum the `meta.yaml <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml>`_, but can also include license files, patches, build scripts, test scripts etc.
+    **R**\ ecipe is a collection of files required to build the conda package. This includes, at minimum, the `meta.yaml <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml>`_, but can also include license files, patches, build scripts, test scripts etc. `Learn More <https://github.com/conda-forge/staged-recipes/tree/master/recipes/example>`_.
+
   
   CI
     **C**\ ontinuous **I**\ ntegration.


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->
Recipe definition added to glossary and links in homepage added


PR Checklist:

![image](https://user-images.githubusercontent.com/66299533/115390292-b4603800-a1fb-11eb-99d5-b9cb77c8f9ed.png)

Fixes: #1389 

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
