### PR TITLE
Defined maintainers and linked it with the role of maintainers.

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -4,7 +4,7 @@ Contributing packages
 *********************
 
 
-A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have the push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
+A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
 Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for the permission from the current maintainers of it and get youself added in the list of maintainers. 
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -6,7 +6,9 @@ Contributing packages
 
 A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of only the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
-Once you create a package, as a code owner you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. `Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
+The list of maintainers of a feedstock package is recorded in the recipe of that package itself. Once you create a package, as a code owner, you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you should ask for permission from its current maintainers and
+get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. 
+`Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
 
 
 .. _creating_recipes:

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -6,7 +6,7 @@ Contributing packages
 
 A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have the push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
-Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer a certain package, you can ask for the permission from the current maintainers of it and get youself added in the list of maintainers. 
+Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for the permission from the current maintainers of it and get youself added in the list of maintainers. 
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
 For more details on this, check `Updating the maintainers list. <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__
 

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -8,7 +8,7 @@ A maintainer is an individual who is responsible for maintaining and updating on
 
 Once you create a package, as a code owner you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. `Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
-For more details on this, check `Updating the maintainers list. <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__
+
 
 .. _creating_recipes:
 

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -6,7 +6,7 @@ Contributing packages
 
 A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
-Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get yourself added to the list of maintainers. 
+Once you create a package, as a code owner you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. `Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
 For more details on this, check `Updating the maintainers list. <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__
 

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -6,7 +6,7 @@ Contributing packages
 
 A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
-Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for the permission from the current maintainers of it and get youself added in the list of maintainers. 
+Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get yourself added to the list of maintainers. 
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
 For more details on this, check `Updating the maintainers list. <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__
 

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -3,6 +3,13 @@
 Contributing packages
 *********************
 
+
+A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have the push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
+
+Once you create a package, you automatically become the maintainer of it. In case you wish to be a maintainer a certain package, you can ask for the permission from the current maintainers of it and get youself added in the list of maintainers. 
+The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
+For more details on this, check `Updating the maintainers list. <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__
+
 .. _creating_recipes:
 
 The staging process

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -4,7 +4,7 @@ Contributing packages
 *********************
 
 
-A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
+A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of only the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
 Once you create a package, as a code owner you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. `Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
 The list of maintainers of the feedstock package is recorded in the recipe of that package itself.

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -7,7 +7,6 @@ Contributing packages
 A maintainer is an individual who is responsible for maintaining and updating one or more feedstock repositories and packages as well as their future versions. They have push access to the feedstock repositories of only the packages they maintain and can merge `PR <https://conda-forge.org/docs/misc/00_intro.html#glossary>`__ into it. See `Maintainers Role. <https://conda-forge.org/docs/maintainer/adding_pkgs.html#maintainer-role>`__
 
 Once you create a package, as a code owner you automatically become a maintainer of it. In case you wish to be a maintainer of a certain package, you can ask for permission from the current maintainers of it and get your `gitub-id` added to the `recipe-maintainers` section in the recipe’s `meta.yaml`. `Please refer to Updating the maintainer list <https://conda-forge.org/docs/maintainer/updating_pkgs.html#updating-the-maintainer-list>`__ for detailed instructions.
-The list of maintainers of the feedstock package is recorded in the recipe of that package itself.
 
 
 .. _creating_recipes:


### PR DESCRIPTION
When we search for maintainers in the search bar, we don't get proper results which can define what  a maintainer is. The information is there in the docs but it seemed scattered. I have added the definition and linked it to maintainers role and how to get yourself added in maintainers list. 

Linked issue : #1331 

(I am little wary of putting this in 'Contributing packages' section. It seems a bit out of place)

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
