### PR TITLE
Fix version ordering broken link

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1387,7 +1387,7 @@ Pre-release version sorting
 ---------------------------
 
 If you wish to add numbers to your ``dev`` or ``rc`` build, you should follow the
-`guidelines <http://conda.pydata.org/docs/spec.html#build-version-spec>`_ put
+`guidelines <https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#version-ordering>`_ put
 forth by Continuum regarding version sorting in ``conda``. Also see the `source
 code for conda
 4.2.13 <https://github.com/conda/conda/blob/4.2.13/conda/version.py#L93-L119>`_.


### PR DESCRIPTION
PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below

The page <https://conda.io/en/latest/spec.html#build-version-spec> doesn't exist anymore.