### PR TITLE
Formatting corrected in FAQ

### DIFF
--- a/src/maintainer/maintainer_faq.rst
+++ b/src/maintainer/maintainer_faq.rst
@@ -89,9 +89,12 @@ FAQ
     
     .. _mfaq_conda_verify:
 
-:ref:`(Q) <mfaq_conda_verify>` **I am seeing** ``Importing conda-verify failed.`` **error message during build. What do I do?**
+:ref:`(Q) <mfaq_conda_verify>` **I am seeing** ``Importing conda-verify failed`` **error message during build. What do I do?**
 
-   ``Importing conda-verify failed. Please be sure to test your packages. conda install conda-verify to make this message go away.``
+  ::
+    
+    Importing conda-verify failed. Please be sure to test your packages. conda install conda-verify to make this message go away.
+    
 You are seeing this error message because by default, conda-build uses conda-verify to ensure that your recipe and package meet some minimum sanity checks. 
 This message can be safely ignored as conda-forge doesn't use conda-verify. 
 


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

This corrects the formatting error introduced due to  #1402 .
The error message was a single long line and disrupted the formatting of the page. 
This PR adds a scroll bar and fixes the formatting mistake. 

@viniciusdc 

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
