### PR TITLE
Updated 'using grayskull to generate recipes' information

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -28,12 +28,9 @@ There are multiple ways to get started:
 #. If it is an R package from `CRAN <https://cran.r-project.org/>`_, kindly
    start by using the `conda-forge helper script for R recipes <https://github.com/bgruening/conda_r_skeleton_helper>`_ instead.
    Then if necessary, you can make manual edits to the recipe.
-#. If it is a python package, you can generate the recipe as a starting point with
-   ``grayskull pypi your_package_name``. To install it you can use ``conda install -c conda-forge grayskull``. You do *not* have to use ``grayskull``, and the
-   recipes produced by ``grayskull`` will need to be reviewed and edited.
-   In particular, you'll at least need to check the build line to :ref:`use pip <use-pip>`,
-   add yourself as a maintainer,
-   and specify a ``license_file``.
+#. If it is a python package, you can generate the recipe as a starting point with ``grayskull``.
+   Use ``conda install -c conda-forge grayskull`` to install ``grayskull``, followed by ``grayskull pypi your_package_name`` to generate the recipe. Note that you do *not* necessarily have to use ``grayskull``, and the
+   recipes produced by ``grayskull`` might need to be reviewed and edited. Read more about ``grayskull`` and how to use it `here <https://github.com/conda-incubator/grayskull#introduction>`_.
 
 Your final recipe should have no comments (unless they're actually relevant to the recipe, and not generic instruction comments), and follow the order in the example.
 


### PR DESCRIPTION
Updated the information about 'using grayskull to generate recipes' .
Also added a link to the grayskull github repo readme.

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
