### PR TITLE
Reordered sections within user docs

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -223,24 +223,20 @@ If you believe a feedstock should be archived, please contact `@conda-forge/core
 Updating the maintainer list
 ============================
 
-The list of maintainers of a feedstock is recorded in the recipe itself. The list of maintainers can be updated with following steps:
+The list of maintainers of a feedstock is recorded in the recipe itself. A new maintainer can be added by opening
+an issue in the feedstock repository with the following title: 
 
-1. Add your github-id to the ``recipe-maintainers`` section at the bottom of the ``recipe/meta.yaml`` file in the feedstock:
+``@conda-forge-admin, please add <@user>``
 
-  .. code-block:: yaml
+where ``<@user>`` is the new maintainer to be added.
+A PR will be automatically created and a maintainer or a member of the ``core`` can then merge this PR to add the user. 
 
-    extra:
-      recipe-maintainers:
-        - current-maintainer
-        - your-github-id
+.. note::
 
-2. Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
 
-3. :ref:`Rerender<dev_update_rerender>` the feedstock by posting ``@conda-forge-admin, please rerender`` as a new comment in the :term:`PR`.
+   This PR is designed to skip building the package. Please do **not** modify it or adjust the commit message.
 
-4. Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
-
-Once the PR is merged, our infrastructure will grant and revoke maintainer permissions.
+For example see `this <https://github.com/conda-forge/cudnn-feedstock/issues/20>`__ issue. 
 
 
 Maintaining several versions

--- a/src/user/00_intro.rst
+++ b/src/user/00_intro.rst
@@ -9,5 +9,6 @@ User Documentation
   how_to_get_help
   tipsandtricks
   ci-skeleton
+  announcements
   faq
   announcements

--- a/src/user/00_intro.rst
+++ b/src/user/00_intro.rst
@@ -5,9 +5,9 @@ User Documentation
 .. toctree::
 
   introduction
-  announcements
+  contributing
+  how_to_get_help
   tipsandtricks
   ci-skeleton
   faq
-  contributing
-  how_to_get_help
+  announcements

--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -99,7 +99,7 @@ Becoming Involved: How to contribute packages to conda-forge?
 
 Anyone can contribute packages to the ``conda-forge`` channel. 
 You don't have to be the upstream maintainer of a package in order to contribute it to ``conda-forge``. 
-To learn how you can contribute your first package read `the staging process <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-staging-process>`_.
+If you are interested in submitting a package to conda-forge, read `the staging process <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-staging-process>`_. for a better description of the process.
 
 
 How can I give credit to conda-forge?

--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -94,7 +94,15 @@ From now on using ``conda install <package-name>`` will also find packages in ou
   Please refer to :ref:`multiple_channels` for pitfalls and more information.
 
 
-How can I give credit to ``conda-forge``?
+Can I contribute packages to conda-forge?
+-----------------------------------------
+
+Yes, anyone can contribute packages to the ``conda-forge`` channel. 
+You don't have to be the upstream maintainer of a package in order to contribute it to ``conda-forge``. 
+To learn how you can contribute your first package read `the staging process <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-staging-process>`_.
+
+
+How can I give credit to conda-forge?
 -----------------------------------------
 
 If you'd like to credit ``conda-forge`` in your work, please cite our `Zenodo entry <https://doi.org/10.5281/zenodo.4774216>`_. This citation is

--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -97,7 +97,7 @@ From now on using ``conda install <package-name>`` will also find packages in ou
 Becoming Involved: How to contribute packages to conda-forge?
 -----------------------------------------
 
-Yes, anyone can contribute packages to the ``conda-forge`` channel. 
+Anyone can contribute packages to the ``conda-forge`` channel. 
 You don't have to be the upstream maintainer of a package in order to contribute it to ``conda-forge``. 
 To learn how you can contribute your first package read `the staging process <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-staging-process>`_.
 

--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -94,7 +94,7 @@ From now on using ``conda install <package-name>`` will also find packages in ou
   Please refer to :ref:`multiple_channels` for pitfalls and more information.
 
 
-Can I contribute packages to conda-forge?
+Becoming Involved: How to contribute packages to conda-forge?
 -----------------------------------------
 
 Yes, anyone can contribute packages to the ``conda-forge`` channel. 


### PR DESCRIPTION
**The user documentation contains 7 subsections. The subsections are reordered, so that there is a better ‘flow of information’ and  the most frequently required information is at the top.** 

Fixes part of #1454 


![userdoc1](https://user-images.githubusercontent.com/65779580/122068543-1f9c4400-ce12-11eb-9cf7-f6a316558441.png)

