### PR TITLE
updating 'updating the maintainer list' section

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -223,24 +223,20 @@ If you believe a feedstock should be archived, please contact `@conda-forge/core
 Updating the maintainer list
 ============================
 
-The list of maintainers of a feedstock is recorded in the recipe itself. The list of maintainers can be updated with following steps:
+The list of maintainers of a feedstock is recorded in the recipe itself. A new maintainer can be added by opening
+an issue in the feedstock repository with the following title: 
 
-1. Add your github-id to the ``recipe-maintainers`` section at the bottom of the ``recipe/meta.yaml`` file in the feedstock:
+``@conda-forge-admin, please add <@user>``
 
-  .. code-block:: yaml
+where ``<@user>`` is the new maintainer to be added.
+A PR will be automatically created and a maintainer or a member of the ``core`` can then merge this PR to add the user. 
 
-    extra:
-      recipe-maintainers:
-        - current-maintainer
-        - your-github-id
+.. note::
 
-2. Commit and push the change to your fork and open a :term:`PR` against the feedstock you want to become a maintainer of.
 
-3. :ref:`Rerender<dev_update_rerender>` the feedstock by posting ``@conda-forge-admin, please rerender`` as a new comment in the :term:`PR`.
+   This PR is designed to skip building the package. Please do **not** modify it or adjust the commit message.
 
-4. Wait until the :term:`PR` is merged. If the current maintainer is no longer active, you can ping ``@conda-forge/core`` and ask for a merge.
-
-Once the PR is merged, our infrastructure will grant and revoke maintainer permissions.
+For example see `this <https://github.com/conda-forge/cudnn-feedstock/issues/20>`__ issue. 
 
 
 Maintaining several versions


### PR DESCRIPTION
Fixes #1467 

Added information about the new
``@conda-forge-admin, please add <@user>`` command to update maintainer list

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below


Updated the 'updating the maintainer list' section based on the new AWS command ``@conda-forge-admin, please add <@user>``. 

![image](https://user-images.githubusercontent.com/65779580/123538026-40d52c80-d750-11eb-9f00-dfc0c0ce8095.png)

