### PR TITLE
Improved the 'becoming involved'  page

### DIFF
--- a/src/user/contributing.rst
+++ b/src/user/contributing.rst
@@ -3,14 +3,14 @@
 Becoming involved
 *****************
 
-Conda-forge is a community-driven effort of cross-platform packaging and relies on volunteers to sustain and improve.
+conda-forge is a community-driven effort of cross-platform packaging and relies on volunteers to sustain and improve.
 
 We encourage you to contribute to conda-forge. You can do so in several ways:
 
- - Contribute new packages (:ref:`dev_contribute_pkgs`)
- - Help update and maintain packages (:ref:`maintaining_pkgs`)
- - Suggest or implement improvements for our :ref:`infrastructure`
- - Help :ref:`improve_docs`
+ - `Contribute new packages <https://conda-forge.org/docs/maintainer/adding_pkgs.html>`_.
+ - Help update and `maintain packages <https://conda-forge.org/docs/maintainer/updating_pkgs.html#maintaining-pkgs>`_.
+ - Suggest or implement improvements for our `infrastructure <https://conda-forge.org/docs/maintainer/infrastructure.html#infrastructure>`_.
+ - Help `improve the documentation <https://conda-forge.org/docs/user/contributing.html#improve-docs>`_.
 
 
 .. _improve_docs:
@@ -18,11 +18,11 @@ We encourage you to contribute to conda-forge. You can do so in several ways:
 Improve the documentation
 ===========================
 
-You can help improve the conda-forge documentation. It is version-controlled in the
+The ``conda-forge`` documentation is version-controlled in the
 `conda-forge.github.io repository
 <https://github.com/conda-forge/conda-forge.github.io>`_ on GitHub. The source
-text is stored there in `the src/ subdirectory
-<https://github.com/conda-forge/conda-forge.github.io/tree/master/src>`_ and
+text is stored in `the src/ subdirectory
+<https://github.com/conda-forge/conda-forge.github.io/tree/master/src>`_ of this repository and
 is formatted using Python’s `reStructuredText
 <http://docutils.sourceforge.net/rst.html>`_ system.
 
@@ -33,11 +33,11 @@ will take you directly to a web-based editor for this very webpage. In
 general, the file corresponding to each page in the GitHub browser has a
 little pencil icon in its top-right corner that lets you open it up for editing.
 
-We are glad to know that you would like to contribute to the conda-forge documentation. If you are new to the conda-forge community, follow the steps below to make your first contribution:
+We are glad to know that you would like to contribute to the ``conda-forge`` documentation. If you are new to the conda-forge community, follow the steps below to make your first contribution:
 
 1. `Fork <https://help.github.com/articles/fork-a-repo/>`_ the
    `conda-forge.github.io repository
-   <https://github.com/conda-forge/conda-forge.github.io>`_ to your own GitHub user account.
+   <https://github.com/conda-forge/conda-forge.github.io>`_.
 2. `Clone <https://help.github.com/articles/cloning-a-repository/>`_ this fork onto your computer.
 3. `Check out
    <https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging>`_
@@ -48,4 +48,4 @@ We are glad to know that you would like to contribute to the conda-forge documen
 5. Submit a `pull request
    <https://help.github.com/articles/about-pull-requests/>`_ to the main repository proposing your changes.
 
-Happy editing!
+Happy contributing!

--- a/src/user/contributing.rst
+++ b/src/user/contributing.rst
@@ -3,14 +3,14 @@
 Becoming involved
 *****************
 
-Conda-forge is a community-driven effort of cross-platform packaging and as such relies on volunteers to sustain and improve.
+Conda-forge is a community-driven effort of cross-platform packaging and relies on volunteers to sustain and improve.
 
-We encourage you to contribute in any way you can and would like! You can contribute in many categories such as:
+We encourage you to contribute to conda-forge. You can do so in several ways:
 
- - Contributing new packages (:ref:`dev_contribute_pkgs`)
- - Helping in updating and maintaining packages (:ref:`maintaining_pkgs`)
- - Suggesting and implementing improvements for our :ref:`infrastructure`
- - Helping to :ref:`improve_docs`
+ - Contribute new packages (:ref:`dev_contribute_pkgs`)
+ - Help update and maintain packages (:ref:`maintaining_pkgs`)
+ - Suggest or implement improvements for our :ref:`infrastructure`
+ - Help :ref:`improve_docs`
 
 
 .. _improve_docs:
@@ -18,7 +18,7 @@ We encourage you to contribute in any way you can and would like! You can contri
 Improve the documentation
 ===========================
 
-You can help to improve the documentation! It is version-controlled in the
+You can help improve the conda-forge documentation. It is version-controlled in the
 `conda-forge.github.io repository
 <https://github.com/conda-forge/conda-forge.github.io>`_ on GitHub. The source
 text is stored there in `the src/ subdirectory
@@ -27,13 +27,13 @@ is formatted using Python’s `reStructuredText
 <http://docutils.sourceforge.net/rst.html>`_ system.
 
 You can propose quick edits directly through the GitHub website if you have
-an account there — for instance, `this link
+a GitHub account — for instance, `this link
 <https://github.com/conda-forge/conda-forge.github.io/edit/master/src/user/contributing.rst>`_
 will take you directly to a web-based editor for this very webpage. In
 general, the file corresponding to each page in the GitHub browser has a
-little pencil icon in its top-right that lets you open it up for editing.
+little pencil icon in its top-right corner that lets you open it up for editing.
 
-We are glad to know that you would like to contribute. If you are new to our community, follow the steps below to make your first contribution:
+We are glad to know that you would like to contribute to the conda-forge documentation. If you are new to the conda-forge community, follow the steps below to make your first contribution:
 
 1. `Fork <https://help.github.com/articles/fork-a-repo/>`_ the
    `conda-forge.github.io repository


### PR DESCRIPTION
Make grammatical improvements in the 'becoming involved' page of user docs

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
