### PR TITLE
Added 'can I contribute packaged to conda-forge?' to brief intro of user docs

### DIFF
--- a/src/user/introduction.rst
+++ b/src/user/introduction.rst
@@ -94,7 +94,15 @@ From now on using ``conda install <package-name>`` will also find packages in ou
   Please refer to :ref:`multiple_channels` for pitfalls and more information.
 
 
-How can I give credit to ``conda-forge``?
+Can I contribute packages to conda-forge?
+-----------------------------------------
+
+Anyone can contribute packages to the ``conda-forge`` channel. 
+You don't have to be the upstream maintainer of a package in order to contribute it to ``conda-forge``. 
+To learn how to contribute your first package read `the staging process <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-staging-process>`_.
+
+
+How can I give credit to conda-forge?
 -----------------------------------------
 
 If you'd like to credit ``conda-forge`` in your work, please cite our `Zenodo entry <https://doi.org/10.5281/zenodo.4774216>`_. This citation is


### PR DESCRIPTION
**Added a 'can I contribute packages to conda-forge?' section in the brief intro of user docs.**

![can_i_contri](https://user-images.githubusercontent.com/65779580/125391342-f693b280-e3c1-11eb-8b25-cacc9cd0e3e3.png)

This section acts as a link between user docs and maintainer docs. It introduces users (those who do not maintain packages at conda-forge, and only use the conda-forge channel for package installation) to 'contributing packages'. 



**Also removed back ticks from section title.** 
The section title 'How can I give credit to conda-forge' wrongly had 'conda-forge' written within backticks. This PR removes those backticks, in consistency with the style followed in the rest of the docs.

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] put any other relevant information below
