### PR TITLE
Fixing typos: conda-forge.yaml -> conda-forge.yml

### DIFF
--- a/scripts/regenerate_feedstock.py
+++ b/scripts/regenerate_feedstock.py
@@ -207,7 +207,7 @@ Hi! This is the friendly conda-forge-admin automated user.
 
 I've re-rendered this feedstock with the latest version of conda-smithy ({}) and noticed some changes.
 If the changes look good, then please go ahead and merge this PR.
-If you have any questions about the changes though, please feel free to ping the 'conda-forge/core' team (using the @ notation in a comment). 
+If you have any questions about the changes though, please feel free to ping the 'conda-forge/core' team (using the @ notation in a comment).
 
 Remember, for any changes to the recipe you would normally need to increment the version or the build number of the package.
 Since this is an infrastructural change, we don't actually need/want a new version to be uploaded to anaconda.org/conda-forge, so the version and build/number are left unchanged and the CI has been skipped.
@@ -264,7 +264,7 @@ for feedstock, git_ref, meta_content, recipe in feedstock_gen:
 
             # Technically, we can do whatever we like to the feedstock now. Let's just
             # update the feedstock though. For examples of other things that *have* been
-            # done here - once upon a time @pelson modified the conda-forge.yaml config
+            # done here - once upon a time @pelson modified the conda-forge.yml config
             # item for every single feedstock, and submitted PRs for every project.
             conda_smithy.configure_feedstock.main(feedstock.directory)
         if pr:

--- a/src/maintainer/maintainer_faq.rst
+++ b/src/maintainer/maintainer_faq.rst
@@ -77,11 +77,11 @@ FAQ
 
   You can configure the conda-forge CI to run a debug build using the mamba solver with the following changes:
 
-  - Set ``build_with_mambabuild: True`` in ``conda-forge.yaml`` file
+  - Set ``build_with_mambabuild: True`` in ``conda-forge.yml`` file
   - Rerender with ``conda-smithy`` (to rerender manually use ``conda smithy rerender`` from the command line)
-  
+
   .. note::
-  
+
     Builds made with ``mambabuild`` won't be uploaded to ``conda-forge``. These builds are purely for debugging purposes.
 
   You can also do this locally by using:


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
