### PR TITLE
Add missing backticks to `ppc64le`

### DIFF
--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -373,7 +373,7 @@ with our compilers. These ``sysroot`` files are available in the ``sysroot_linux
 These packages have version numbers that match the version of ``glibc`` they package. These
 versions are ``2.12`` for CentOS 6 and ``2.17`` for CentOS 7.
 
-For ``gcc``/``gxx``/``gfortran`` versions prior to ``8.4.0`` on ``ppc64le and ``7.5.0``
+For ``gcc``/``gxx``/``gfortran`` versions prior to ``8.4.0`` on ``ppc64le`` and ``7.5.0``
 on ``aarch64``/``x86_64``, we had been building our own versions of ``glibc``. This practice
 is now deprecated in favor of the CentOS-based ``sysroots``. Additionally, as of the same
 compiler versions above, we have removed the ``cos*`` part of the ``sysroot`` path. The new


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
