### PR TITLE
pin docutils for older sphinx compatibility

### DIFF
--- a/.ci_scripts/environment.yml
+++ b/.ci_scripts/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3
   - conda-smithy
   - sphinx<3
+  - docutils<0.18
   - cloud_sptheme
   - sphinxcontrib-fulltoc
   - make


### PR DESCRIPTION
This pins `docutils` to a version range compatible with the aging `sphinx 2.x`, the only non-controversial thing from #1540...

# observed

From [a build of 1540](https://github.com/conda-forge/conda-forge.github.io/runs/4037956258?check_suite_focus=true#step:4:34):

```bash
sphinx-build -b html -d _build/doctrees   . _build/html
Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/conda-forge-docs/bin/sphinx-build", line 6, in <module>
    from sphinx.cmd.build import main
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/cmd/build.py", line 23, in <module>
    from sphinx.application import Sphinx
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/application.py", line 42, in <module>
    from sphinx.highlighting import lexer_classes, lexers
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/highlighting.py", line 30, in <module>
    from sphinx.ext import doctest
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/ext/doctest.py", line 28, in <module>
    from sphinx.builders import Builder
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/builders/__init__.py", line 24, in <module>
    from sphinx.io import read_doc
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/io.py", line 35, in <module>
    from sphinx.transforms.i18n import (
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/transforms/i18n.py", line 22, in <module>
    from sphinx.domains.std import make_glossary_term, split_term_classifiers
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/domains/std.py", line 26, in <module>
    from sphinx.directives import ObjectDescription
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/directives/__init__.py", line 261, in <module>
    from sphinx.directives.patches import (  # noqa
  File "/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/sphinx/directives/patches.py", line 15, in <module>
    from docutils.parsers.rst.directives import images, html, tables
ImportError: cannot import name 'html' from 'docutils.parsers.rst.directives' (/usr/share/miniconda3/envs/conda-forge-docs/lib/python3.8/site-packages/docutils/parsers/rst/directives/__init__.py)
make: *** [Makefile:58: html] Error 1
```

With this env:

<details>
<summary>with this env...</summary>
<pre>
  Prefix: /usr/share/miniconda3/envs/conda-forge-docs
  
    Updating specs:
  
     - python=3
     - conda-smithy
     - sphinx[version='<3']
     - cloud_sptheme
     - sphinxcontrib-fulltoc
     - make
     - xonsh
     - recommonmark
     - pyyaml
     - jinja2
     - requests
     - python-dateutil
     - pip
     - python-rapidjson
     - python=3.8
  
  
    Package                                            Version  Build               Channel                    Size
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    Install:
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
    + _libgcc_mutex                                        0.1  conda_forge         conda-forge/linux-64       3 KB
    + _openmp_mutex                                        4.5  1_gnu               conda-forge/linux-64      22 KB
    + alabaster                                         0.7.12  py_0                conda-forge/noarch        15 KB
    + babel                                              2.9.1  pyh44b312d_0        conda-forge/noarch         6 MB
    + backports                                            1.0  py_2                conda-forge/noarch         4 KB
    + backports.functools_lru_cache                      1.6.4  pyhd8ed1ab_0        conda-forge/noarch         9 KB
    + beautifulsoup4                                    4.10.0  pyha770c72_0        conda-forge/noarch        77 KB
    + blinker                                              1.4  py_1                conda-forge/noarch        13 KB
    + boolean.py                                           3.7  py_0                conda-forge/noarch        22 KB
    + brotlipy                                           0.7.0  py38h497a2fe_1001   conda-forge/linux-64     341 KB
    + bzip2                                              1.0.8  h7f98852_4          conda-forge/linux-64     484 KB
    + c-ares                                            1.18.1  h7f98852_0          conda-forge/linux-64     113 KB
    + ca-certificates                                2021.10.8  ha878542_0          conda-forge/linux-64     139 KB
    + certifi                                        2021.10.8  py38h578d9bd_0      conda-forge/linux-64     145 KB
    + cffi                                              1.14.6  py38h3931269_1      conda-forge/linux-64     226 KB
    + chardet                                            4.0.0  py38h578d9bd_1      conda-forge/linux-64     199 KB
    + charset-normalizer                                 2.0.0  pyhd8ed1ab_0        conda-forge/noarch        32 KB
    + cloud_sptheme                  1.10.1.post20200504175005  pyhd8ed1ab_1        conda-forge/noarch        74 KB
    + colorama                                           0.4.4  pyh9f0ad1d_0        conda-forge/noarch        18 KB
    + commonmark                                         0.9.1  py_0                conda-forge/noarch        46 KB
    + conda                                             4.10.3  py38h578d9bd_2      conda-forge/linux-64       3 MB
    + conda-build                                       3.21.4  py38h578d9bd_0      conda-forge/linux-64     553 KB
    + conda-forge-pinning                  2021.10.28.15.03.29  hd8ed1ab_0          conda-forge/noarch        18 KB
    + conda-package-handling                             1.7.3  py38h497a2fe_0      conda-forge/linux-64     927 KB
    + conda-smithy                                      3.14.1  pyhd8ed1ab_0        conda-forge/noarch        78 KB
    + conda-suggest                                      0.1.1  pyh9f0ad1d_0        conda-forge/noarch        11 KB
    + conda-suggest-conda-forge                      2021.8.24  ha770c72_0          conda-forge/linux-64     120 KB
    + cryptography                                      35.0.0  py38h3e25421_1      conda-forge/linux-64       2 MB
    + curl                                              7.79.1  h2574ce0_1          conda-forge/linux-64     153 KB
    + psutil                                             5.8.0  py38h497a2fe_1      conda-forge/linux-64     342 KB
    + py-lief                                           0.11.5  py38h709712a_0      conda-forge/linux-64       1 MB
    + pycosat                                            0.6.3  py38h497a2fe_1006   conda-forge/linux-64     107 KB
    + pycparser                                           2.20  pyh9f0ad1d_2        conda-forge/noarch        94 KB
    + pycrypto                                           2.6.1  py38h8df0ef7_1005   conda-forge/linux-64     495 KB
    + pygithub                                            1.55  pyh6c4a22f_0        conda-forge/noarch       120 KB
    + pygments                                          2.10.0  pyhd8ed1ab_0        conda-forge/noarch       760 KB
    + pyjwt                                              2.3.0  pyhd8ed1ab_0        conda-forge/noarch        18 KB
    + pynacl                                             1.4.0  py38h497a2fe_2      conda-forge/linux-64       1 MB
    + pyopenssl                                         21.0.0  pyhd8ed1ab_0        conda-forge/noarch        48 KB
    + pyparsing                                          3.0.3  pyhd8ed1ab_0        conda-forge/noarch        78 KB
    + pysocks                                            1.7.1  py38h578d9bd_3      conda-forge/linux-64      27 KB
    + python                                            3.8.12  hb7a2778_2_cpython  conda-forge/linux-64      26 MB
    + python-dateutil                                    2.8.2  pyhd8ed1ab_0        conda-forge/noarch       240 KB
    + python-libarchive-c                                  3.1  py38h578d9bd_0      conda-forge/linux-64      56 KB
    + python-rapidjson                                     1.5  py38h709712a_0      conda-forge/linux-64     248 KB
    + python_abi                                           3.8  2_cp38              conda-forge/linux-64       4 KB
    + pytz                                              2021.3  pyhd8ed1ab_0        conda-forge/noarch       242 KB
    + pyyaml                                               6.0  py38h497a2fe_0      conda-forge/linux-64     191 KB
    + readline                                             8.1  h46c0cb4_0          conda-forge/linux-64     295 KB
    + recommonmark                                       0.7.1  pyhd8ed1ab_0        conda-forge/noarch        13 KB
    + requests                                          2.26.0  pyhd8ed1ab_0        conda-forge/noarch        52 KB
    + requests-oauthlib                                  1.3.0  pyh9f0ad1d_0        conda-forge/noarch        21 KB
    + ripgrep                                           13.0.0  habb4d0f_1          conda-forge/linux-64       2 MB
    + ruamel.yaml                                      0.17.16  py38h497a2fe_0      conda-forge/linux-64     171 KB
    + ruamel.yaml.clib                                   0.2.2  py38h497a2fe_2      conda-forge/linux-64     174 KB
    + ruamel_yaml                                      0.15.80  py38h497a2fe_1004   conda-forge/linux-64     272 KB
    + scrypt                                            0.8.18  py38h2b97feb_0      conda-forge/linux-64      44 KB
    + setproctitle                                       1.2.2  py38h497a2fe_0      conda-forge/linux-64      16 KB
    + setuptools                                        58.2.0  py38h578d9bd_0      conda-forge/linux-64       1 MB
    + six                                               1.16.0  pyh6c4a22f_0        conda-forge/noarch        14 KB
    + smmap                                              3.0.5  pyh44b312d_0        conda-forge/noarch        22 KB
    + snowballstemmer                                    2.1.0  pyhd8ed1ab_0        conda-forge/noarch        57 KB
    + soupsieve                                          2.0.1  py38h32f6830_0      conda-forge/linux-64      57 KB
    + sphinx                                             2.4.4  py_0                conda-forge/noarch         1 MB
    + sphinxcontrib-applehelp                            1.0.2  py_0                conda-forge/noarch        28 KB
    + sphinxcontrib-devhelp                              1.0.2  py_0                conda-forge/noarch        22 KB
    + sphinxcontrib-fulltoc                              1.2.0  py_0                conda-forge/noarch        11 KB
    + sphinxcontrib-htmlhelp                             2.0.0  pyhd8ed1ab_0        conda-forge/noarch        31 KB
    + sphinxcontrib-jsmath                               1.0.1  py_0                conda-forge/noarch         7 KB
    + sphinxcontrib-qthelp                               1.0.3  py_0                conda-forge/noarch        25 KB
    + sphinxcontrib-serializinghtml                      1.1.5  pyhd8ed1ab_0        conda-forge/noarch        27 KB
    + sqlite                                            3.36.0  h9cd32fc_2          conda-forge/linux-64       1 MB
    + tk                                                8.6.11  h27826a3_1          conda-forge/linux-64       3 MB
    + toolz                                             0.11.1  py_0                conda-forge/noarch        46 KB
    + tqdm                                              4.62.3  pyhd8ed1ab_0        conda-forge/noarch        80 KB
    + typing_extensions                               3.10.0.2  pyha770c72_0        conda-forge/noarch        28 KB
    + urllib3                                           1.26.7  pyhd8ed1ab_0        conda-forge/noarch       100 KB
    + vsts-python-api                                   0.1.22  py_0                conda-forge/noarch       544 KB
    + wcwidth                                            0.2.5  pyh9f0ad1d_2        conda-forge/noarch        33 KB
    + wheel                                             0.37.0  pyhd8ed1ab_1        conda-forge/noarch        31 KB
    + wrapt                                             1.13.2  py38h497a2fe_0      conda-forge/linux-64      48 KB
    + xonsh                                             0.10.1  py38h578d9bd_1      conda-forge/linux-64       1 MB
    + xz                                                 5.2.5  h516909a_1          conda-forge/linux-64     343 KB
    + yaml                                               0.2.5  h516909a_0          conda-forge/linux-64      82 KB
    + zlib                                              1.2.11  h36c2ea0_1013       conda-forge/linux-64      86 KB
    + zstd                                               1.5.0  ha95c52a_0          conda-forge/linux-64     490 KB
  
    Summary:
  
    Install: 136 packages
  
    Total download: 129 MB
</pre>
</details>