### PR TITLE
Add favicon

### DIFF
--- a/feedstocks.html.tmpl
+++ b/feedstocks.html.tmpl
@@ -9,6 +9,8 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
+    <link rel="shortcut icon" href="img/favicon.ico">
+
     <title>conda-forge feedstocks | community driven packaging for conda</title>
 
     <!-- Bootstrap Core CSS -->


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [ ] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

Followup to https://github.com/conda-forge/conda-forge.github.io/pull/1549

Copying my comment from there:

> Everything's working except https://conda-forge.org/feedstock-outputs/ which is (I think) because feedstock_outputs.html.tmpl is actually not used anymore: https://github.com/conda-forge/conda-forge.github.io/search?q=feedstock_outputs.html.tmpl
>
> Only feedstocks.html.tmpl is used (Which I didn't change because the link is feedstock-outputs/).
>
> Is this assumption correct?

If yes, might make sense to delete that.