### PR TITLE
Improve build_platform and providers documentation

### DIFF
--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -129,14 +129,26 @@ automatic version updates/migrations for feedstocks. The current options are
 build_platform
 --------------
 This is a mapping from the build platform to the host platform of the package
-to be built. For eg: following builds a ``osx-64`` platform from ``linux-64``
+to be built. e.g. the following builds a ``osx-64`` package on the ``linux-64``
 build platform using cross-compiling.
 
 .. code-block:: yaml
 
     build_platform:
       osx_64: linux_64
-      
+
+Leaving this field empty implicitly requests to build a package natively. i.e. 
+
+.. code-block:: yaml
+
+    build_platform:
+      linux_64: linux_64
+      linux_ppc64le: linux_ppc64le
+      linux_aarch64: linux_aarch64
+      osx_64: osx_64
+      osx_arm64: osx_arm64
+      win_64: win_64
+
 .. _build_with_mambabuild:
 
 build_with_mambabuild
@@ -339,6 +351,7 @@ arches:
 * ``win``
 * ``linux_aarch64``
 * ``linux_ppc64le``
+* ``osx_arm64``
 
 The following CI services are available:
 
@@ -369,6 +382,7 @@ provider entry is equivalent to the following:
       win: azure
       linux_ppc64le: None
       linux_aarch64: None
+      osx_arm64: None
 
 To enable ``linux_ppc64le`` and ``linux_aarch64`` and the following:
 
@@ -377,6 +391,8 @@ To enable ``linux_ppc64le`` and ``linux_aarch64`` and the following:
     provider:
       linux_ppc64le: default
       linux_aarch64: default
+
+If the ``build_platform`` for an arch is not available with the selected provider, the build will be disabled; cross-compilation must be specified manually.
 
 .. _recipe_dir:
 

--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -392,7 +392,9 @@ To enable ``linux_ppc64le`` and ``linux_aarch64`` and the following:
       linux_ppc64le: default
       linux_aarch64: default
 
-If the ``build_platform`` for an arch is not available with the selected provider, the build will be disabled; cross-compilation must be specified manually.
+If the ``build_platform`` for an arch is not available with the selected provider
+(either natively or with emulation), the build will be disabled; cross-compilation
+must be specified manually.
 
 .. _recipe_dir:
 


### PR DESCRIPTION
Clarify that build_platforms are native when unspecified and that cross-compilation must be manually specified if (as in the case of osx_arm64 right now), there is no native provider available.

Closes conda-forge/conda-smithy#1546
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
