### PR TITLE
fixed formatting problems to keep sphinx compiler happy

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -29,7 +29,7 @@ There are multiple ways to get started:
    Then if necessary, you can make manual edits to the recipe.
 #. If it is a python package, you can generate the recipe as a starting point with ``grayskull``.
    Use ``conda install -c conda-forge grayskull`` to install ``grayskull``, followed by ``grayskull pypi your_package_name`` to generate the recipe. Note that you do *not* necessarily have to use ``grayskull``, and the
-   recipes produced by ``grayskull`` might need to be reviewed and edited. Read more about ``grayskull`` and how to use it `here <https://github.com/conda-incubator/grayskull#introduction>`_.
+   recipes produced by ``grayskull`` might need to be reviewed and edited. Read more about ``grayskull`` and how to use it `here <https://github.com/conda-incubator/grayskull#introduction>`__.
 
 Your final recipe should have no comments (unless they're actually relevant to the recipe, and not generic instruction comments), and follow the order in the example.
 

--- a/src/maintainer/conda_forge_yml.rst
+++ b/src/maintainer/conda_forge_yml.rst
@@ -152,7 +152,7 @@ Leaving this field empty implicitly requests to build a package natively. i.e.
 .. _build_with_mambabuild:
 
 build_with_mambabuild
---------------
+---------------------
 This option, when enabled, configures the conda-forge CI to run a debug build using the ``mamba`` solver. Check `this <https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-mamba-local>`__ to know more.  
 
 .. code-block:: yaml
@@ -457,17 +457,19 @@ This is used for disabling testing for cross compiling. Default is ``false``
 .. _test:
 
 test
--------------------
+----
 This is used to configure on which platforms a recipe is tested. Default is ``all``.
 
 .. code-block:: yaml
 
     test: native_and_emulated
+
 Will do testing only if the platform is native or if there is an emulator.
 
 .. code-block:: yaml
 
     test: native
+
 Will do testing only if the platform is native.
 
 .. _travis:

--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -9,7 +9,7 @@ Repositories
 Staging area for recipes
 ------------------------
 
-`conda-forge/staged-recipes <https://github.com/conda-forge/staged-recipes>`_ is the entry point for new packages to join the conda-forge package collection.
+`conda-forge/staged-recipes <https://github.com/conda-forge/staged-recipes>`__ is the entry point for new packages to join the conda-forge package collection.
 You can find the detailed guide for submitting new package recipes in :ref:`creating_recipes`.
 
 Smithy
@@ -25,7 +25,7 @@ Smithy contains maintenance code for conda-forge, which is used by the ``conda-s
 
 ``conda-smithy`` also contains the command line tool that you should use if you rerender manually from the command line (see :ref:`dev_update_rerender`).
 
-Smithy can be used beyond Conda-Forge's purposes. For example, it can be used to `set up self-hosted Azure agents <self-hosted_azure-config>`_ for non-Conda-Forge infrastructures.
+Smithy can be used beyond Conda-Forge's purposes. For example, it can be used to `set up self-hosted Azure agents <self-hosted_azure-config>`__ for non-Conda-Forge infrastructures.
 (You could also consider using `Azure virtual machine scale set agents <https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops>`_,
 which could be less expensive to run than permanently active agents.)
 
@@ -33,15 +33,15 @@ which could be less expensive to run than permanently active agents.)
 Web services
 ------------
 
-The Heroku app providing the conda-forge web services lives in `conda-forge/conda-forge-webservices <https://github.com/conda-forge/conda-forge-webservices>`_.
+The Heroku app providing the conda-forge web services lives in `conda-forge/conda-forge-webservices <https://github.com/conda-forge/conda-forge-webservices>`__.
 Please note that the code logic provided by the app is in the ``Smithy`` repository.
 
-Bugs or suggestions regarding the service functionality should therefore be opened in ``conda-forge/conda-smithy``'s `bug tracker <https://github.com/conda-forge/conda-smithy/issues>`_.
+Bugs or suggestions regarding the service functionality should therefore be opened in ``conda-forge/conda-smithy``'s `bug tracker <https://github.com/conda-forge/conda-smithy/issues>`__.
 
 conda-forge pinning
 -------------------
 
-Package-wide dependency pins are defined in `conda_build_config.yaml <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml>`_  in the `conda-forge/conda-forge-pinning-feedstock <https://github.com/conda-forge/conda-forge-pinning-feedstock>`_.
+Package-wide dependency pins are defined in `conda_build_config.yaml <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml>`__ in the `conda-forge/conda-forge-pinning-feedstock <https://github.com/conda-forge/conda-forge-pinning-feedstock>`_.
 
 For more information on conda-forge wide package pins, please refer to :ref:`globally_pinned_packages`.
 
@@ -129,7 +129,7 @@ associated with the repo. This command can be useful for people who are not yet 
 so cannot @-mention the ``staged-recipes`` team for PR reviews.
 
 @conda-forge-admin, please ping conda-forge/<team>
-------------------------------------
+--------------------------------------------------
 
 Entering this command in the PR of a feedstock or staged-recipes will have the admin bot @-mention the respective team.
 This command can be useful for people who are not yet members of conda-forge and
@@ -148,7 +148,7 @@ Adding this label to non-bot issued PRs will have no effect.
 Entering this command in the title or comment of an issue will instruct the admin bot to
 open a PR enabling the automatic merging of passing PRs from the ``auto-tick``
 bot. This functionality is currently experimental. You can find more details
-`here <https://regro.github.io/cf-scripts/github_actions_infrastructure.html#automerging-prs>`_.
+`here <https://regro.github.io/cf-scripts/github_actions_infrastructure.html#automerging-prs>`__.
 Please open issue on ``regro/cf-scripts`` for any feedback, bugs, and/or questions!
 
 @conda-forge-admin, please add python 2.7
@@ -162,7 +162,7 @@ other builds. **Python 2.7 support is deprecated and any feedstocks on Python 2.
 not be properly handled by our bots.**
 
 @conda-forge-admin, please add user @username
---------------------------------------
+---------------------------------------------
 
 Entering the above phrase in the title of an issue on a feedstock will make a PR
 that adds the given user to the feedstock. A maintainer or member of ``core`` can then merge
@@ -181,7 +181,7 @@ Azure is used to build packages for OSX, Linux (x86_64, native), Linux (ARMv8, e
 The build queue on Azure is substantially larger than on all the other providers.
 Azure builds have a maximum duration of 6 hours.
 
-To see all builds on Azure, visit `<https://dev.azure.com/conda-forge/feedstock-builds/_build>`_.
+To see all builds on Azure, visit `<https://dev.azure.com/conda-forge/feedstock-builds/_build>`__.
 
 Restarting builds
 .................
@@ -226,7 +226,7 @@ Enable a build by adding the following to ``conda-forge.yml`` in the root of the
       osx: travis
 
 For IBM Power 8+ builds, add the name of your feedstock to the list `here
-<https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/arch_rebuild.txt>`_
+<https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/arch_rebuild.txt>`__
 via a pull request.
 
 
@@ -259,8 +259,8 @@ Enabling Circle on your Fork
 
 If for some reason CircleCI is not triggering build from forks,
 Circle can be manually added for each fork. Circle calls this "Adding a Project" and
-`the official CircleCI documentation is available here <https://circleci.com/docs/getting-started/#add-and-follow-more-projects>`_.
-This effectively amounts to going to the `Add Projects <https://circleci.com/add-projects>`_
+`the official CircleCI documentation is available here <https://circleci.com/docs/getting-started/#add-and-follow-more-projects>`__.
+This effectively amounts to going to the `Add Projects <https://circleci.com/add-projects>`__
 page, finding the fork that you wish to enable, and clicking the "Build Project" button.
 This is not normally needed.
 
@@ -271,7 +271,7 @@ If CircleCI lacks permissions to checkout the source code, it will produce an er
     Permission denied (publickey).
     fatal: Could not read from remote repository.
 
-When this happens for a feedstock, it can be fixed using the `webservice <https://conda-forge.org/docs/webservice.html#conda-forge-admin-please-update-circle>`_, by posting the following comment::
+When this happens for a feedstock, it can be fixed using the `webservice <https://conda-forge.org/docs/webservice.html#conda-forge-admin-please-update-circle>`__, by posting the following comment::
 
   @conda-forge-admin, please update circle
 
@@ -285,7 +285,7 @@ Otherwise (e.g. in a PR to staged-recipes), here are some things you can try:
 Drone.io
 --------
 
-We use `Drone.io <https://drone.io>`_ for Linux ARMv8 builds. To enable these builds on your feedstock, make a pull request to add your feedstock to the list
+We use `Drone.io <https://drone.io>`__ for Linux ARMv8 builds. To enable these builds on your feedstock, make a pull request to add your feedstock to the list
 here `<https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/arch_rebuild.txt>`_.
 
 
@@ -298,9 +298,9 @@ GitHub Actions.
 Automerge
 .........
 
-The automerge service uses the GitHub action in this `repo <https://github.com/conda-forge/automerge-action>`_. This action runs out of a
-Docker `container <https://hub.docker.com/repository/docker/condaforge/automerge-action>`_ on the ``prod`` tag. See the
-repo `README.md <https://github.com/conda-forge/automerge-action#readme>`_ for more details. PRs are automatically merged if they satisfy either
+The automerge service uses the GitHub action in this `repo <https://github.com/conda-forge/automerge-action>`__. This action runs out of a
+Docker `container <https://hub.docker.com/repository/docker/condaforge/automerge-action>`__ on the ``prod`` tag. See the
+repo `README.md <https://github.com/conda-forge/automerge-action#readme>`__ for more details. PRs are automatically merged if they satisfy either
 of the two following sets of conditions:
 
 1. are from the ``regro-cf-autotick-bot``, have ``[bot-automerge]`` in the title, all statuses are passing, and the feedstock allows automerge
@@ -312,9 +312,9 @@ edits to the PR.
 Rerendering
 ...........
 
-The rerendering service is triggered by the Heroku app. It uses the GitHub action in this `repo <https://github.com/conda-forge/webservices-dispatch-action>`_.
-This action runs out of a Docker `container <https://hub.docker.com/repository/docker/condaforge/webservices-dispatch-action>`_ on the ``prod`` tag. See the
-repo `README.md <https://github.com/conda-forge/webservices-dispatch-action#readme>`_ for more details.
+The rerendering service is triggered by the Heroku app. It uses the GitHub action in this `repo <https://github.com/conda-forge/webservices-dispatch-action>`__.
+This action runs out of a Docker `container <https://hub.docker.com/repository/docker/condaforge/webservices-dispatch-action>`__ on the ``prod`` tag. See the
+repo `README.md <https://github.com/conda-forge/webservices-dispatch-action#readme>`__ for more details.
 
 
 Skipping CI builds

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -111,7 +111,7 @@ Local testing
 The first thing that you should know is that you can locally test Windows
 builds of your packages even if you don’t own a Windows machine. Microsoft
 makes available free, official Windows virtual machines (VMs) `at this website
-<https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`_. If you
+<https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`__. If you
 are unfamiliar with VM systems or have trouble installing Microsoft’s VMs, please
 use a general web search to explore — while these topics are beyond the
 scope of this documentation, there are ample discussions on them on the broader
@@ -121,24 +121,24 @@ In order to compile native code (C, C++, etc.) on Windows, you will need to
 install Microsoft’s Visual C++ build tools on your VM. You must install
 particular versions of these tools — this is to maintain compatibility between
 compiled libraries used in Python, `as described on this Python wiki page
-<https://wiki.python.org/moin/WindowsCompilers>`_. The current relevant
+<https://wiki.python.org/moin/WindowsCompilers>`__. The current relevant
 versions are:
 
 * For Python 2.7: Visual C++ 9.0
 * For Python 3.5–3.7: Visual C++ 14.0
 
 While you can obtain these tools by installing the right version of the full
-`Visual Studio <https://visualstudio.microsoft.com/>`_ development
+`Visual Studio <https://visualstudio.microsoft.com/>`__ development
 environment, you can save a lot of time and bandwidth by installing standalone
 “build tools” packages. The links are as follows:
 
 * For Python 2.7: `Microsoft Visual C++ Compiler for Python 2.7
-  <https://www.microsoft.com/download/details.aspx?id=44266>`_.
+  <https://www.microsoft.com/download/details.aspx?id=44266>`__.
 * For Python 3.5–3.7: `Microsoft Build Tools for Visual Studio 2017
-  <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`_.
+  <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017>`__.
 
 If you need more information. Please refer `the Python wiki page on Windows compilers
-<https://wiki.python.org/moin/WindowsCompilers>`_.
+<https://wiki.python.org/moin/WindowsCompilers>`__.
 
 Simple CMake-Based ``bld.bat``
 ------------------------------
@@ -231,7 +231,7 @@ In conda-forge.yml file:
 
 
 For example see the changes made in the ``conda_build_config.yaml`` and ``conda-forge.yml`` files in `this
-<https://github.com/conda-forge/libignition-physics-feedstock/commit/c586d765a2f5fd0ecf6da43c53315c898c9bf6bd>`_ PR.
+<https://github.com/conda-forge/libignition-physics-feedstock/commit/c586d765a2f5fd0ecf6da43c53315c898c9bf6bd>`__ PR.
 
 After making these changes don't forget to rerender with ``conda-smithy`` (to rerender manually use ``conda smithy rerender`` from the command line).
 
@@ -265,7 +265,7 @@ A package that needs all three compilers would define
 
   Appropriate compiler runtime packages will be automatically added to the package's runtime requirements and therefore
   there's no need to specify ``libgcc`` or ``libgfortran``. There are additional informations about how conda-build 3 treats
-  compilers in the `conda docs <https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html>`_.
+  compilers in the `conda docs <https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html>`__.
 
 .. _cdt_packages:
 
@@ -283,7 +283,7 @@ either 6 or 7 depending on user choice and platform. We manage the build of CDT
 packages using a centralized repo, `conda-forge/cdt-builds <https://github.com/conda-forge/cdt-builds>`_,
 as opposed to generating feedstocks for them. (Note that historically we did use feedstocks but this
 practice has been deprecated.) To add a new CDT, make a PR on the
-`conda-forge/cdt-builds <https://github.com/conda-forge/cdt-builds>`_ repo.
+`conda-forge/cdt-builds <https://github.com/conda-forge/cdt-builds>`__ repo.
 
 In ``conda-forge`` the primary usages of CDTs is currently for packages that link against libGL.
 
@@ -894,7 +894,7 @@ To use this package in a build, put it in the host environment like so
 .. _knowledge:empty:
 
 Empty Python packages
-----------
+---------------------
 For some features introduced in later Python versions, the Python community creates backports, which makes these
 features available for earlier versions of Python as well.
 One example here is `dataclasses <https://www.python.org/dev/peps/pep-0557/>`__ which was introduced with
@@ -1181,7 +1181,7 @@ There are two options for how to proceed:
             set SETUPTOOLS_SCM_PRETEND_VERSION=%PKG_VERSION%
 
         Whereby you use that ``PKG_VERSION`` has been set with the version string,
-        see `Environment variables <https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#env-vars>`_.
+        see `Environment variables <https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#env-vars>`__.
 
     -   Otherwise, if you are directly building from ``meta.yaml``, use for example:
 
@@ -1250,10 +1250,10 @@ On Linux, CMake users are required to use ``${CMAKE_ARGS}`` so CMake can find CU
   **How is CUDA provided at the system level?**
 
   * On Linux, Nvidia provides official Docker images, which we then
-    `adapt <https://github.com/conda-forge/docker-images>`_ to Conda-Forge's needs.
+    `adapt <https://github.com/conda-forge/docker-images>`__ to Conda-Forge's needs.
 
   * On Windows, the compilers need to be installed for every CI run. This is done through the
-    `conda-forge-ci-setup <https://github.com/conda-forge/conda-forge-ci-setup-feedstock/>`_ scripts.
+    `conda-forge-ci-setup <https://github.com/conda-forge/conda-forge-ci-setup-feedstock/>`__ scripts.
     Do note that the Nvidia executable won't install the drivers because no GPU is present in the machine.
 
   **How is cudatoolkit selected at install time?**
@@ -1262,7 +1262,7 @@ On Linux, CMake users are required to use ``${CMAKE_ARGS}`` so CMake can find CU
   named ``__cuda``. By default, ``conda`` will install the highest version available
   for the packages involved. To override this behaviour, you can define a ``CONDA_OVERRIDE_CUDA`` environment
   variable. More details in the
-  `Conda docs <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages>`_.
+  `Conda docs <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#overriding-detected-packages>`__.
 
   Note that prior to v4.8.4, ``__cuda`` versions would not be part of the constraints, so you would always
   get the latest one, regardless the supported CUDA version.
@@ -1279,10 +1279,10 @@ of the conda recipe. That does not mean you can't test your package locally. To 
 
 1. Enable the Azure artifacts for your feedstock (see :ref:`here <azure-config>`).
 2. Include the test files and requirements in the recipe
-   `like this <https://github.com/conda-forge/cupy-feedstock/blob/a1e9cdf47775f90d3153a26913068c6df942d54b/recipe/meta.yaml#L51-L61>`_.
+   `like this <https://github.com/conda-forge/cupy-feedstock/blob/a1e9cdf47775f90d3153a26913068c6df942d54b/recipe/meta.yaml#L51-L61>`__.
 3. Provide the test instructions. Take into account that the GPU tests will fail in the CI run,
    so you need to ignore them to get the package built and uploaded as an artifact.
-   `Example <https://github.com/conda-forge/cupy-feedstock/blob/a1e9cdf47775f90d3153a26913068c6df942d54b/recipe/run_test.py>`_.
+   `Example <https://github.com/conda-forge/cupy-feedstock/blob/a1e9cdf47775f90d3153a26913068c6df942d54b/recipe/run_test.py>`__.
 4. Once you have downloaded the artifacts, you will be able to run::
 
     conda build --test <pkg file>.tar.bz2
@@ -1322,7 +1322,7 @@ If you really need it, you can re-add support for 9.2, 10.0 and 10.1. However, t
 Adding more CUDA versions to the build matrix will dramatically increase the number of jobs and will place a large
 burden on our CI resources. Only proceed if there's a known use case for the extra packages.
 
-1. Download this `migration file <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/cuda92_100_101.yaml>`_.
+1. Download this `migration file <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/cuda92_100_101.yaml>`__.
 2. In your feedstock fork, create a new branch and place the migration file under ``.ci_support/migrations``.
 3. Open a PR and re-render. CUDA 9.2, 10.0 and 10.1 will appear in the CI checks now. Merge when ready!
 
@@ -1335,8 +1335,8 @@ Providing a new CUDA version involves five repositores:
 * `cudatoolkit-feedstock <https://github.com/conda-forge/cudatoolkit-feedstock>`_
 * `nvcc-feedstock <https://github.com/conda-forge/nvcc-feedstock>`_
 * `conda-forge-pinning-feedstock <https://github.com/conda-forge/conda-forge-pinning-feedstock>`_
-* `docker-images <https://github.com/conda-forge/docker-images>`_ (Linux only)
-* `conda-forge-ci-setup-feedstock <https://github.com/conda-forge/conda-forge-ci-setup-feedstock>`_ (Windows only)
+* `docker-images <https://github.com/conda-forge/docker-images>`__ (Linux only)
+* `conda-forge-ci-setup-feedstock <https://github.com/conda-forge/conda-forge-ci-setup-feedstock>`__ (Windows only)
 
 The steps involved are, roughly:
 
@@ -1347,7 +1347,7 @@ The steps involved are, roughly:
    Copy the migration file manually to ``.ci_support/migrations``.
    This copy should not specify a timestamp. Comment it out and rerender.
 4. For Windows, add the installer URLs and hashes to the ``conda-forge-ci-setup``
-   `script <https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/install_cuda.bat>`_.
+   `script <https://github.com/conda-forge/conda-forge-ci-setup-feedstock/blob/master/recipe/install_cuda.bat>`__.
    The migration file must also be manually copied here. Rerender.
 5. Create the new ``nvcc`` packages for the new version. Again, manual
    migration must be added. Rerender.
@@ -1361,7 +1361,7 @@ Apple Silicon builds
 ====================
 
 The new Apple M1 processor is the first Apple Silicon supported by conda-forge
-`osx-arm64 <https://github.com/conda-forge/conda-forge.github.io/issues/1126>`_ builds.
+`osx-arm64 <https://github.com/conda-forge/conda-forge.github.io/issues/1126>`__ builds.
 For new builds to be available, via cross-compilation, a migration is required for
 the package and its dependencies. These builds are experimental as many of them are untested.
 
@@ -1370,7 +1370,7 @@ To request a migration for a particular package and all its dependencies:
 1. Check the feedstock in question to see if there is already an issue or pull request.
    Opening an issue here is fine, as it might take a couple iterations of the below,
    especially if many dependencies need to be built as well.
-2. If nothing is under way, look at the current `conda-forge-pinning <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/osx_arm64.txt>`_.
+2. If nothing is under way, look at the current `conda-forge-pinning <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/osx_arm64.txt>`__.
 3. If the package is not listed there, make a PR, adding the package
    name to the end of ``osx_arm64.txt``. The migration bot should start making automated
    pull requests to the repo and its dependencies.
@@ -1391,15 +1391,15 @@ Recipe maintainers can make pre-release builds available on
 conda-forge by adding them to the ``dev`` or ``rc`` label.
 
 The semantics of these labels should generally follow the
-`guidelines <https://docs.python.org/devguide/devcycle.html#stages>`_ that Python
+`guidelines <https://docs.python.org/devguide/devcycle.html#stages>`__ that Python
 itself follows.
 
-- ``rc``: `Beta <https://docs.python.org/devguide/devcycle.html#beta>`_ and `Release
+- ``rc``: `Beta <https://docs.python.org/devguide/devcycle.html#beta>`__ and `Release
   Candidate <https://docs.python.org/devguide/devcycle.html#release-candidate-rc>`_
   (RC). No new features. Bugfix only.
 
 - ``dev``: `Pre-Alpha <https://docs.python.org/devguide/devcycle.html#pre-alpha>`_
-  and `Alpha <https://docs.python.org/devguide/devcycle.html#alpha>`_. These are
+  and `Alpha <https://docs.python.org/devguide/devcycle.html#alpha>`__. These are
   still packages that could see substantial changes
   between the dev version and the final release.
 
@@ -1472,10 +1472,10 @@ Pre-release version sorting
 ---------------------------
 
 If you wish to add numbers to your ``dev`` or ``rc`` build, you should follow the
-`guidelines <https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#version-ordering>`_ put
+`guidelines <https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#version-ordering>`__ put
 forth by Continuum regarding version sorting in ``conda``. Also see the `source
 code for conda
-4.2.13 <https://github.com/conda/conda/blob/4.2.13/conda/version.py#L93-L119>`_.
+4.2.13 <https://github.com/conda/conda/blob/4.2.13/conda/version.py#L93-L119>`__.
 The tl;dr here is that conda sorts as follows:
 
 .. code-block::

--- a/src/maintainer/maintainer_faq.rst
+++ b/src/maintainer/maintainer_faq.rst
@@ -67,7 +67,7 @@ FAQ
 
 :ref:`(Q) <mfaq_anaconda_delay>` **Why does my new version appear on Anaconda Cloud, but is not installable with conda?**
 
-  For certain, high-traffic channels (main & conda-forge), Anaconda uses a `CDN <https://cloudflare.com/learning/cdn/what-is-a-cdn/>`_ to decrease costs. The CDN is only reindexed every 20 minutes, however `Anaconda.org <https://anaconda.org>`_ uses the original channel that the CDN mirrors.  Therefore, packages will show up on the `Anaconda Cloud <https://anaconda.org>`_ about 20 to 40 minutes before they are downloadable via conda.  You can use ``conda search <pkg>``  to see if the package is installable, because this command reads from the CDN.
+  For certain, high-traffic channels (main & conda-forge), Anaconda uses a `CDN <https://cloudflare.com/learning/cdn/what-is-a-cdn/>`__ to decrease costs. The CDN is only reindexed every 20 minutes, however `Anaconda.org <https://anaconda.org>`__ uses the original channel that the CDN mirrors.  Therefore, packages will show up on the `Anaconda Cloud <https://anaconda.org>`__ about 20 to 40 minutes before they are downloadable via conda.  You can use ``conda search <pkg>``  to see if the package is installable, because this command reads from the CDN.
 
 .. _mfaq_mamba_local:
 
@@ -88,7 +88,8 @@ FAQ
 
   - ``conda install boa -c conda-forge``
   - ``conda mambabuild myrecipe``
-  For more details visit `this <https://boa-build.readthedocs.io/en/latest/mambabuild.html>`_ page.
+  
+  For more details visit `this <https://boa-build.readthedocs.io/en/latest/mambabuild.html>`__ page.
 
 .. _mfaq_conda_verify:
 
@@ -136,7 +137,7 @@ FAQ
     ImportError: libGL.so.1: cannot open shared object file: No such file or directory
 
 
-  To fix the error, create a `yum_requirements.txt <https://conda-forge.org/docs/maintainer/knowledge_base.html#yum-deps>`_ file and add *mesa-libGL*.
+  To fix the error, create a `yum_requirements.txt <https://conda-forge.org/docs/maintainer/knowledge_base.html#yum-deps>`__ file and add *mesa-libGL*.
 
 
 .. _mfaq_qt_load_xcb:
@@ -157,7 +158,7 @@ FAQ
 
 
   This comes from the CI environment being headless and can be fixed by adding the ``QT_QPA_PLATFORM=offscreen`` `environment variable <https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html#inherited-environment-variabless>`_.
-  The variable can either be added directly to the test command or provided in the `meta.yaml <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml>`_ like so:
+  The variable can either be added directly to the test command or provided in the `meta.yaml <https://conda-forge.org/docs/maintainer/adding_pkgs.html#the-recipe-meta-yaml>`__ like so:
 
   .. code-block:: yaml
 
@@ -170,8 +171,8 @@ FAQ
 
 :ref:`(Q) <mfaq_contact_core>` **How can I contact conda-forge/core?**
 
-  When in an issue or PR, you can contact `conda-forge/core <https://conda-forge.org/docs/orga/governance.html#teams-roles>`_ by simply mentioning ``@conda-forge/core`` in a comment.
-  If you don't receive an an answer after a couple of days, feel free to reach out to us via the public `gitter <https://gitter.im/conda-forge/conda-forge.github.io>`_ channel.
+  When in an issue or PR, you can contact `conda-forge/core <https://conda-forge.org/docs/orga/governance.html#teams-roles>`__ by simply mentioning ``@conda-forge/core`` in a comment.
+  If you don't receive an an answer after a couple of days, feel free to reach out to us via the public `gitter <https://gitter.im/conda-forge/conda-forge.github.io>`__ channel.
 
   .. note::
 
@@ -184,7 +185,7 @@ FAQ
 
 :ref:`(Q) <mfaq_abandoned_feedstock>` **A feedstock has been abandoned and I would like to take over maintenance.**
 
-  A  feedstock is generally considered abandoned when the maintainer isn't around anymore and doesn't merge new PRs or answer any issues. If that is the case, you can add yourself to the team by using the `@conda-forge-admin, please add user @username <https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-add-user-username>`_ command. If the maintainer doesn't merge it after roughly a week, :ref:`contact conda-forge/core<mfaq_contact_core>` to have it merged. Once added, you have full rights to the feedstock and can continue its maintenance.
+  A  feedstock is generally considered abandoned when the maintainer isn't around anymore and doesn't merge new PRs or answer any issues. If that is the case, you can add yourself to the team by using the `@conda-forge-admin, please add user @username <https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-add-user-username>`__ command. If the maintainer doesn't merge it after roughly a week, :ref:`contact conda-forge/core<mfaq_contact_core>` to have it merged. Once added, you have full rights to the feedstock and can continue its maintenance.
 
   .. note::
 

--- a/src/misc/00_intro.rst
+++ b/src/misc/00_intro.rst
@@ -7,29 +7,29 @@ Glossary
 .. glossary::
 
   CI
-    **C**\ ontinuous **I**\ ntegration. Continuous integration is the practice of automating the integration of code changes from multiple contributors into a single software project. `Learn More <https://en.wikipedia.org/wiki/Continuous_integration/>`_.
+    **C**\ ontinuous **I**\ ntegration. Continuous integration is the practice of automating the integration of code changes from multiple contributors into a single software project. `Learn More <https://en.wikipedia.org/wiki/Continuous_integration/>`__.
 
   PR
-    **P**\ ull **R**\ equest. Pull Request is a workflow method to submit contributions to an open development project in which the developer asks for changes committed to an external repository to be considered for inclusion in a project's main repository. `Learn More <https://help.github.com/articles/about-pull-requests/>`_.
+    **P**\ ull **R**\ equest. Pull Request is a workflow method to submit contributions to an open development project in which the developer asks for changes committed to an external repository to be considered for inclusion in a project's main repository. `Learn More <https://help.github.com/articles/about-pull-requests/>`__.
 
   CDT
-    **C**\ ore **D**\ ependency **T**\ ree. Core Dependency Tree packages take care of the dependencies which are so close to the system that they are not packaged with ``conda-forge``. A CDT package consists of repackaged CentOS binaries from the appropriate version, either 6 or 7 depending on user choice and platform. `Learn More <https://conda-forge.org/docs/maintainer/knowledge_base.html#core-dependency-tree-packages-cdts/>`_.
+    **C**\ ore **D**\ ependency **T**\ ree. Core Dependency Tree packages take care of the dependencies which are so close to the system that they are not packaged with ``conda-forge``. A CDT package consists of repackaged CentOS binaries from the appropriate version, either 6 or 7 depending on user choice and platform. `Learn More <https://conda-forge.org/docs/maintainer/knowledge_base.html#core-dependency-tree-packages-cdts/>`__.
 
   ABI
-    **A**\ pplication **B**\ inary **I**\ nterface. ABI is a document that comprehensively defines the binary system interface between applications and the operating system on which they run. `Learn More <https://en.wikipedia.org/wiki/Application_binary_interface>`_.
+    **A**\ pplication **B**\ inary **I**\ nterface. ABI is a document that comprehensively defines the binary system interface between applications and the operating system on which they run. `Learn More <https://en.wikipedia.org/wiki/Application_binary_interface>`__.
 
   ICU
-    **I**\ nternational **C**\ omponents for **U**\ nicode. ICU is an open-source project of mature C/C++ and Java libraries for Unicode support, software internationalization, and software globalization. `Learn More <http://site.icu-project.org/>`_.
+    **I**\ nternational **C**\ omponents for **U**\ nicode. ICU is an open-source project of mature C/C++ and Java libraries for Unicode support, software internationalization, and software globalization. `Learn More <http://site.icu-project.org/>`__.
 
   CRAN
-    **C**\ omprehensive **R** **A**\ rchive **N**\ etwork. CRAN is a network of FTP and web servers around the world that store identical, up-to-date, versions of code and documentation for R. `Learn More <https://cran.r-project.org/>`_.
+    **C**\ omprehensive **R** **A**\ rchive **N**\ etwork. CRAN is a network of FTP and web servers around the world that store identical, up-to-date, versions of code and documentation for R. `Learn More <https://cran.r-project.org/>`__.
 
   CFEP
-    **C**\ onda **F**\ orge **E**\ nhancement **P**\ roposal. A CFEP is a document which outlines a suggested change to how the conda-forge project operates, from a technical standpoint as well as to address social topics such as governance and expected conduct. `Learn More <https://github.com/conda-forge/cfep/blob/main/cfep-01.md/>`_.
+    **C**\ onda **F**\ orge **E**\ nhancement **P**\ roposal. A CFEP is a document which outlines a suggested change to how the conda-forge project operates, from a technical standpoint as well as to address social topics such as governance and expected conduct. `Learn More <https://github.com/conda-forge/cfep/blob/main/cfep-01.md/>`__.
 
 TODO list
 *********
 
 .. todolist::
 
-The original entry is located in ``.src`` file of `/home/runner/work/conda-forge.github.io/conda-forge.github.io/src/maintainer/knowledge_base.rst, line 952. <https://github.com/conda-forge/conda-forge.github.io/blob/main/src/maintainer/knowledge_base.rst#noarch-generic/>`_.
+The original entry is located in ``.src`` file of `/home/runner/work/conda-forge.github.io/conda-forge.github.io/src/maintainer/knowledge_base.rst, line 952. <https://github.com/conda-forge/conda-forge.github.io/blob/main/src/maintainer/knowledge_base.rst#noarch-generic/>`__.

--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -10,27 +10,27 @@ Issue Trackers
 
 The main issue trackers that you will interact with are
 
-* `staged-recipes <https://github.com/conda-forge/staged-recipes/issues>`_: You'll use staged-recipes to create a new conda package on conda-forge
-* `Our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`_: You'll use this repo as a catch-all for issues where you're not sure where else to put them
-* `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`_: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
+* `staged-recipes <https://github.com/conda-forge/staged-recipes/issues>`__: You'll use staged-recipes to create a new conda package on conda-forge
+* `Our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`__: You'll use this repo as a catch-all for issues where you're not sure where else to put them
+* `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`__: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
 
 Gitter
 -----------------
 
 The main chat rooms that you'll interact with are
 
-* `gitter: general <https://gitter.im/conda-forge/conda-forge.github.io>`_: Our general chat room for all things conda-forge. Pretty much any question can be asked here and others in the community may be able to help.
+* `gitter: general <https://gitter.im/conda-forge/conda-forge.github.io>`__: Our general chat room for all things conda-forge. Pretty much any question can be asked here and others in the community may be able to help.
   Move stuff to an issue tracker if your question isn't getting resolved.
-* `gitter: core/private <https://gitter.im/conda-forge/core>`_: Private chat for the @conda-forge/core team to discuss continued operations and improvements to conda-forge.
-* `gitter: power pc <https://gitter.im/conda-forge-ppc64le/Lobby>`_: Public chat room for all things related to building for power pc (IBM) systems.
-* `gitter: bot subteam <https://gitter.im/conda-forge/regro-cf-autotick-bot>`_: Public chat room for all things related to the conda-forge automation infrastructure.
+* `gitter: core/private <https://gitter.im/conda-forge/core>`__: Private chat for the @conda-forge/core team to discuss continued operations and improvements to conda-forge.
+* `gitter: power pc <https://gitter.im/conda-forge-ppc64le/Lobby>`__: Public chat room for all things related to building for power pc (IBM) systems.
+* `gitter: bot subteam <https://gitter.im/conda-forge/regro-cf-autotick-bot>`__: Public chat room for all things related to the conda-forge automation infrastructure.
   Our automation infrastructure is colloquially referred to as "the bot".
-* `gitter: compilers <https://gitter.im/conda-forge/conda-forge-compilers>`_: Public chat room focused on the conda-forge compiler stack.
+* `gitter: compilers <https://gitter.im/conda-forge/conda-forge-compilers>`__: Public chat room focused on the conda-forge compiler stack.
 
 Mailing List
 -----------------
 
-* `google group: conda-forge <https://groups.google.com/g/conda-forge>`_: The general mailing list for conda-forge.
+* `google group: conda-forge <https://groups.google.com/g/conda-forge>`__: The general mailing list for conda-forge.
   Sees a moderate amount of traffic, though substantially lower than the public gitter room.
 
 Other Communication Methods
@@ -45,5 +45,5 @@ Staying Up-to-date
 
 There are several sources that have the latest conda-forge information.
 
-* `Blog <https://conda-forge.org/blog>`_: We blog about big feature enhancements and other items. Our blog has an Atom `feed <https://conda-forge.org/blog/atom.xml>`_.
-* `News <https://conda-forge.org/docs/user/announcements.html#announcements>`_: Our :ref:`announcements <news>` page has periodic notices about technical changes to our infrastructure. It is also served as an RSS `feed <https://conda-forge.org/docs/news.rss>`_.
+* `Blog <https://conda-forge.org/blog>`__: We blog about big feature enhancements and other items. Our blog has an Atom `feed <https://conda-forge.org/blog/atom.xml>`__.
+* `News <https://conda-forge.org/docs/user/announcements.html#announcements>`__: Our :ref:`announcements <news>` page has periodic notices about technical changes to our infrastructure. It is also served as an RSS `feed <https://conda-forge.org/docs/news.rss>`__.


### PR DESCRIPTION
Just a bunch of minor formatting fixes. We should maybe check more carefully that link targets are generally included as anonymous (with two underscores instead of one) - just to make the compiler happy :-)

