### PR TITLE
Under the hood docs improvements

### DIFF
--- a/.ci_scripts/environment.yml
+++ b/.ci_scripts/environment.yml
@@ -4,13 +4,12 @@ channels:
 dependencies:
   - python=3
   - conda-smithy
-  - sphinx<3
-  - docutils<0.18
+  - sphinx
   - cloud_sptheme
   - sphinxcontrib-fulltoc
   - make
   - xonsh
-  - recommonmark
+  - myst-parser
   - pyyaml
   - jinja2
   - requests

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -26,7 +26,10 @@ rm -rf docs/
 python .ci_scripts/generate_cfep_index.py
 
 pushd src
-make html
+
+# -W --keep-going: list all warnings but fail build in case there are any
+# -n: check validity of all links
+make html SPHINXOPTS="-W --keep-going -n"
 mv _build/html ../docs
 rm -rf _build
 popd

--- a/misc/DEV_MEETING_TEMPLATE.md
+++ b/misc/DEV_MEETING_TEMPLATE.md
@@ -1,6 +1,5 @@
 # YYYY-MM-DD conda-forge core meeting 
 
-****
 ## Attendees
 List the attendees for the meeting
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -17,7 +17,6 @@ import sys
 import datetime
 
 import cloud_sptheme as csp
-import recommonmark.parser
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -33,6 +32,7 @@ import recommonmark.parser
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'myst_parser',
     'sphinx.ext.todo',
     'sphinxcontrib.fulltoc',
     'sphinxcontrib.newsfeed',
@@ -41,10 +41,6 @@ extensions = [
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
-# Transpile markdown into rest
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -86,7 +82,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -754,10 +754,9 @@ Jinja expressions serve following purposes in the meta.yaml:
 
 - They allow defining variables to avoid code duplication. Using a variable for the ``version`` allows changing the version only once with every update.
 
-  .. code-block:: yaml
+  .. code-block:: yaml+jinja
 
       {% set version = "3.7.3" %}
-       [...]
 
       package:
         name: python
@@ -769,7 +768,7 @@ Jinja expressions serve following purposes in the meta.yaml:
 
 - They can call `conda-build functions <https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#conda-build-specific-jinja2-functions>`__ for automatic code generation. Examples are the compilers, cdt packages or the ``pin_compatible`` function.
 
-  .. code-block:: yaml
+  .. code-block:: yaml+jinja
 
     requirements:
       build:

--- a/src/maintainer/pinning_deps.rst
+++ b/src/maintainer/pinning_deps.rst
@@ -106,7 +106,7 @@ be added by hand. To do this, follow these steps:
 
 #. Create a new migration yaml by copying `example.exyaml <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/example.exyaml>`__ in the ``conda-forge/conda-forge-pinning`` repository.
 #. Change the migration yaml to reflect the package and version to be migrated
-#. Write a :ref:`migrator <pin_migrator>` for propagating the pin changes.
+#. Write a migrator for propagating the pin changes.
 #. Propose the changes as a :term:`PR` to `conda-forge/conda-forge-pinning-feedstock`_.
 #. Once accepted the migration will begin. The migration status can be monitored at https://conda-forge.org/status.
 #. After the migration is complete, a new PR can be issued to `conda-forge/conda-forge-pinning-feedstock`_ to:

--- a/src/orga/minutes/2016-04-22.md
+++ b/src/orga/minutes/2016-04-22.md
@@ -8,7 +8,7 @@ Subject: **How do we want to express recipes for particular VS versions.**
 
 *   New conda-build release - may be necessary for VS builds: [](https://github.com/conda/conda-build/releases/tag/1.20.1)[https://github.com/conda/conda-build/releases/tag/1.20.1](https://github.com/conda/conda-build/releases/tag/1.20.1)
 
-        *   Rebuild Eigen to test that the latest version works - if so we can drop [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)'s conda-smithy branch that tries to fix appveyor.
+        *   Rebuild Eigen to test that the latest version works - if so we can drop [John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)'s conda-smithy branch that tries to fix appveyor.
     *   This has all been done and works now. In some cases Python 3.4 64-bit  builds on Windows have issues. That is still not understood.
 
 *   Current guidance at [](https://github.com/conda-forge/staged-recipes/wiki/VC-features)[https://github.com/conda-forge/staged-recipes/wiki/VC-features](https://github.com/conda-forge/staged-recipes/wiki/VC-features) and [](https://github.com/conda/conda/wiki/VC-features)[https://github.com/conda/conda/wiki/VC-features](https://github.com/conda/conda/wiki/VC-features). 

--- a/src/orga/minutes/2016-04-29.md
+++ b/src/orga/minutes/2016-04-29.md
@@ -12,7 +12,7 @@ Agenda:
 
                 *   Question about conda-smithy/conda-build-all requirements. Please see reference to "Question 4.5" in [this comment](https://github.com/conda/conda-build/pull/848#issuecomment-215523101) 
 
-        *   Internal pinning mechanism. [Phil Elson](/ep/profile/AviM60TiesB) wrote some nice scripts here and they are very helpful.
+        *   Internal pinning mechanism. [Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB) wrote some nice scripts here and they are very helpful.
     *   Questions:
 
                 *   How can we figure out what things need pinning?
@@ -52,7 +52,7 @@ Notes:
 *   Let's give webex a shot
 *   Dependency tracking
 
-        *   Currently baking in versions into the recipe, automated with script from [Phil Elson](/ep/profile/AviM60TiesB)
+        *   Currently baking in versions into the recipe, automated with script from [Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
     *   Version choices are decided manually at the moment
     *   [](https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies)https://github.com/conda-forge/staged-recipes/wiki/Pinned-dependencies
     *   What if we want to change a pinned version, say zlib 1.2 to 1.3?
@@ -92,7 +92,7 @@ Notes:
         *   Helpful when resolving problems, detecting when system Python
         *   Put it in, not too hard and will help downstream organizations
 
-All of the contents below were discussed between [Phil Elson](/ep/profile/AviM60TiesB) and [John Kirkham](/ep/profile/wv6uvIZX6h0). Many of the items have already been planned before and just need the details ironed out. Anything that required large group discussion was not decided in anyway.
+All of the contents below were discussed between [Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB) and [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0). Many of the items have already been planned before and just need the details ironed out. Anything that required large group discussion was not decided in anyway.
 
 *   Yum requirements
 
@@ -107,13 +107,13 @@ All of the contents below were discussed between [Phil Elson](/ep/profile/AviM60
 *   Adding a devtoolset to the container (for now).
 
         *   This was already merged (adds devtoolset-2).
-    *   [Phil](/ep/profile/AviM60TiesB) has rebuilt this.
-    *   [John](/ep/profile/wv6uvIZX6h0) tested the image with a trivial C++11 [program](https://github.com/jakirkham/hello_tests/blob/5b2f6b0c5682ecd84bee3be9cb73d790265f6002/hello.cxx) and that worked fine.
+    *   [Phil](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB) has rebuilt this.
+    *   [John](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0) tested the image with a trivial C++11 [program](https://github.com/jakirkham/hello_tests/blob/5b2f6b0c5682ecd84bee3be9cb73d790265f6002/hello.cxx) and that worked fine.
     *   Automatic builds are not working. Will likely contact Docker to fix. However, this only matters if this problem still happens after moving the images.
 
 *   Movement of Docker images to common spaces (Docker Hub org, GitHub org).
 
-        *   [John](/ep/profile/wv6uvIZX6h0) will add the PRs to move Obvious-CI's Docker image to the org and from Obvious-CI.
+        *   [John](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0) will add the PRs to move Obvious-CI's Docker image to the org and from Obvious-CI.
     *   Docker Hub org is already setup
     *   Repo on GitHub is ready to go.
     *   Need to setup autobuilds for the image(s).

--- a/src/orga/minutes/2016-05-13.md
+++ b/src/orga/minutes/2016-05-13.md
@@ -8,7 +8,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 *   Jonathan Helmus
 *   Michael Sarahan
-*   [John Kirkham](/ep/profile/wv6uvIZX6h0)
+*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 *   Phil Elson
 *   Eric Dill
 *   Anthony Scopatz

--- a/src/orga/minutes/2016-06-03.md
+++ b/src/orga/minutes/2016-06-03.md
@@ -6,7 +6,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie) [
 
 **Attendees**
 
-Ray, Matt, Jonathan, Phil, Jonas, Michael, Philippe, John, [Bjorn Gruning](https://conda-forge.hackpad.com/ep/profile/DMmBLyb21HK), Jan
+Ray, Matt, Jonathan, Phil, Jonas, Michael, Philippe, John, [Bjorn Gruning](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/DMmBLyb21HK), Jan
 
 **Standing items**
 
@@ -52,7 +52,7 @@ Ray, Matt, Jonathan, Phil, Jonas, Michael, Philippe, John, [Bjorn Gruning](https
 
 *   Another   thing to consider here might be a new piece of metadata. For instance,   we could specify the primary language of a package. We could then   specify to `conda install`    that we want this language of a package. Possible syntax might include   something that looks like that of the above. Not sure how we want to   handled conflicts if we want to error, warn and install everything, or   something else.
 
-*   A simpler idea that we might consider that includes some of the ideas [Michael](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS) mentioned above, but could be implemented without changes to `conda` or package metadata would be to place packages in labeled channels. That way all Python packages would be in `conda-forge/label/python`. This way one could simply add this labeled channel and get all the `python`  packages one wants. It's still a little fragile when enabling multiple  labels, but maybe this can leverage the channel resolution stuff that  Michael Grant has worked on.
+*   A simpler idea that we might consider that includes some of the ideas [Michael](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS) mentioned above, but could be implemented without changes to `conda` or package metadata would be to place packages in labeled channels. That way all Python packages would be in `conda-forge/label/python`. This way one could simply add this labeled channel and get all the `python`  packages one wants. It's still a little fragile when enabling multiple  labels, but maybe this can leverage the channel resolution stuff that  Michael Grant has worked on.
 
 *   PR reviews
 

--- a/src/orga/minutes/2016-06-09.md
+++ b/src/orga/minutes/2016-06-09.md
@@ -7,10 +7,10 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 **Attendees**
 
 *   Jonathan Helmus
-*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
-*   [Johannes Koster](https://conda-forge.hackpad.com/ep/profile/vuQo2WAv29A) 
-*   [Bjorn Gruning](https://conda-forge.hackpad.com/ep/profile/DMmBLyb21HK) 
-*   [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+*   [John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+*   [Johannes Koster](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/vuQo2WAv29A) 
+*   [Bjorn Gruning](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/DMmBLyb21HK) 
+*   [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 *   Ray
 *   Phil Elson
 

--- a/src/orga/minutes/2016-06-24.md
+++ b/src/orga/minutes/2016-06-24.md
@@ -8,19 +8,19 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)ht
 
 **Attendees**
 
-[Bjˆrn Gr¸ning](/ep/profile/DMmBLyb21HK)
+[Bjˆrn Gr¸ning](https://conda-forge.hackpad.com/ep/profile/DMmBLyb21HK)
 
 Filipe 
 
-[John Kirkham](/ep/profile/wv6uvIZX6h0)
+[John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 
-[Michael Sarahan](/ep/profile/yHQTJXZ4gyS)
+[Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 
 Jonathan Helmus
 
 Matt Craig
 
-[Phil Elson](/ep/profile/AviM60TiesB)
+[Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
 
 **Standing items**
 

--- a/src/orga/minutes/2016-07-22.md
+++ b/src/orga/minutes/2016-07-22.md
@@ -6,15 +6,15 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-[John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+[John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 
 Jonathan Helmus
 
-[Matt Craig](https://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y)
+[Matt Craig](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y)
 
 Phil Elson
 
-[Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+[Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 
 Filipe 
 

--- a/src/orga/minutes/2016-08-12.md
+++ b/src/orga/minutes/2016-08-12.md
@@ -10,11 +10,11 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 Eric Dill
 
-[Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
+[Phil Elson](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
 
-[Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+[Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 
-[John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+[John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 
 **Standing items**
 

--- a/src/orga/minutes/2016-08-25.md
+++ b/src/orga/minutes/2016-08-25.md
@@ -6,7 +6,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-Jonathan Helmus, Filipe, [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS), [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0), Jake VanderPlas, Eric Dill, Ray Donnelly , [Phil Elson](https://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
+Jonathan Helmus, Filipe, [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS), [John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0), Jake VanderPlas, Eric Dill, Ray Donnelly , [Phil Elson](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/AviM60TiesB)
 
 **Standing items**
 

--- a/src/orga/minutes/2016-09-09.md
+++ b/src/orga/minutes/2016-09-09.md
@@ -6,7 +6,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-*    Jonathan Helmus, Filipe, Michael, Ray, [Eric Dill](https://conda-forge.hackpad.com/ep/profile/yJqDqpPqJyz), Björn Grüning, [Matt Craig](https://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y) (late)
+*    Jonathan Helmus, Filipe, Michael, Ray, [Eric Dill](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yJqDqpPqJyz), Björn Grüning, [Matt Craig](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y) (late)
 
 **Standing items**
 

--- a/src/orga/minutes/2016-10-07.md
+++ b/src/orga/minutes/2016-10-07.md
@@ -6,7 +6,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-*   Jonathan Helmus, Eric Dill, [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS), Phil Elson, [Filipe Fernandes](https://twitter.com/ocefpaf)**, **[John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0), Ray Donnelly
+*   Jonathan Helmus, Eric Dill, [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS), Phil Elson, [Filipe Fernandes](https://twitter.com/ocefpaf)**, **[John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0), Ray Donnelly
 
 **Standing Items**
 

--- a/src/orga/minutes/2016-11-17.md
+++ b/src/orga/minutes/2016-11-17.md
@@ -8,9 +8,9 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 *   Phil Elson
 *   [Filipe Fernandes](https://twitter.com/ocefpaf)
-*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+*   [John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 *   Ray Donnelly
-*   [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+*   [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 
 **Notes**
 

--- a/src/orga/minutes/2016-11-24.md
+++ b/src/orga/minutes/2016-11-24.md
@@ -25,7 +25,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
         *   Currently done with "low hanging fruit" or difficult packages
     *   CFEP would be helpful to give clear guidance
     *   What does it take to merge repackaging stuff?  At what point does it become painful enough to allow repackaging?  
-    *   MSYS2 - [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS) to ask Ray about build infrastructure for MSYS2 and perhaps unification with conda/conda-forge
+    *   MSYS2 - [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS) to ask Ray about build infrastructure for MSYS2 and perhaps unification with conda/conda-forge
     *   Git  for windows as example to avoid (Large agglomeration of individual  projects - prefer to build individual projects).  If MSYS2 were not  available, this would be an OK candidate for repackaging, because it is  such a huge pain.  Because MSYS2 is available, we should avoid  repackaging git for windows.
 
 *   conda-build 2

--- a/src/orga/minutes/2017-01-06.md
+++ b/src/orga/minutes/2017-01-06.md
@@ -6,12 +6,12 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-*   [John Kirkham](https://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
+*   [John Kirkham](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/wv6uvIZX6h0)
 *   Ray Donnelly
 *   Filipe Fernandes
-*   [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
-*   [Peter Williams](https://conda-forge.hackpad.com/ep/profile/Gxz5eDxqYrB)
-*   [Eric Dill](https://conda-forge.hackpad.com/ep/profile/yJqDqpPqJyz)
+*   [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+*   [Peter Williams](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/Gxz5eDxqYrB)
+*   [Eric Dill](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yJqDqpPqJyz)
 
 **Standing Items**
 

--- a/src/orga/minutes/2017-04-26.md
+++ b/src/orga/minutes/2017-04-26.md
@@ -6,7 +6,7 @@ Hangout link: [](https://hangouts.google.com/call/v5olhwzpfzgzpoq5i3wthjpqpie)[h
 
 **Attendees**
 
-Jonathan Helmus, Eric Dill,  Filipe, Peter Williams, John Kirkham, [Matt Craig](https://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y), [Michael Sarahan](https://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
+Jonathan Helmus, Eric Dill,  Filipe, Peter Williams, John Kirkham, [Matt Craig](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yBvjHx0Ad3Y), [Michael Sarahan](https://conda-forge.hackpad.comhttps://conda-forge.hackpad.com/ep/profile/yHQTJXZ4gyS)
 
 **Standing Items**
 

--- a/src/orga/minutes/2018-04-17.md
+++ b/src/orga/minutes/2018-04-17.md
@@ -29,7 +29,7 @@
         - John: Get a pygdf-feedstock on conda-forge and ping the Nvidia folks
 - Adding people to cf/staged-recipes
     - ~~Marius van Niekerk offered to help review on staged-recipes~~ Invited to staged recipes
-~~~~    - Igor T. Ghisi (igortg) was also interested in helping
+    - Igor T. Ghisi (igortg) was also interested in helping
 - Adding people to core
     - Invite one or more from bioconda. 
         - Bjorn (Filipe will invite)

--- a/src/orga/minutes/2018-05-29.md
+++ b/src/orga/minutes/2018-05-29.md
@@ -30,7 +30,6 @@
 
 **Existing Items**
 
-****
 - Making the agenda and notes public again.
     - John will see if we can make dropbox paper readable by the world
         - It’s easy to do this per doc with a link

--- a/src/orga/minutes/2018-10-30.md
+++ b/src/orga/minutes/2018-10-30.md
@@ -14,7 +14,7 @@
 - Compiler rebuild status
     - python done for both compiler stacks
     - ~~pending: openblas (numeric stack currently held up)~~
-~~~~    - Qt: try to build on Azure?
+    - Qt: try to build on Azure?
 - New approach to reducing CI load https://github.com/conda-forge/conda-forge.github.io/issues/647
     - Might be possible to not be totally insecure with work. But nobody is volunteering to do that work right now. :)
     - Pushing PR builds to a staging channel might be a nice UX improvement so you can test anyway.

--- a/src/orga/minutes/2019-05-29.md
+++ b/src/orga/minutes/2019-05-29.md
@@ -19,7 +19,7 @@
     - Coordinate more SciPy activities: lightning talks, lunch/dinner?
     - ~~TODO: Open an issue on github conda-forge.github.io to keep track of who is going to Scipy 2019~~
     - https://github.com/conda-forge/conda-forge.github.io/issues/791
-~~~~- Discuss a strategy to manage qt patches (23!) and new version builds in the CIs.
+- Discuss a strategy to manage qt patches (23!) and new version builds in the CIs.
 - ESIP update:
     - balance: 3827.78 USD
     - use part of the money to pay for Azure dedicated machines: Windows and Linux to build Qt.

--- a/src/orga/minutes/2019-06-26.md
+++ b/src/orga/minutes/2019-06-26.md
@@ -2,7 +2,6 @@
 
 Date: Jun 26, 2019
 
-****
 ## Attendees
 
 @mention yourself and add others

--- a/src/orga/minutes/2019-07-24.md
+++ b/src/orga/minutes/2019-07-24.md
@@ -2,7 +2,6 @@
 
 [HackMD link](https://hackmd.io/P8on5P8wR3q3WslwrJzOEg)
 [Zoom link]()
-****
 ## Attendees
 List the attendees for the meeting
 

--- a/src/orga/minutes/2019-07-24.md
+++ b/src/orga/minutes/2019-07-24.md
@@ -1,7 +1,6 @@
 # 2017-07-24 conda-forge core meeting 
 
 [HackMD link](https://hackmd.io/P8on5P8wR3q3WslwrJzOEg)
-[Zoom link]()
 ## Attendees
 List the attendees for the meeting
 

--- a/src/orga/minutes/2019-08-07.md
+++ b/src/orga/minutes/2019-08-07.md
@@ -2,7 +2,6 @@
 
 [HackMD link](https://hackmd.io/1VB13FnIQpiruA0lb04MKw?edit)
 
-****
 ## Attendees
 List the attendees for the meeting
 

--- a/src/orga/minutes/2019-09-04.md
+++ b/src/orga/minutes/2019-09-04.md
@@ -1,7 +1,5 @@
 # 2019-09-04 conda-forge core meeting 
 
-****
-
 ## Attendees
 
 List the attendees for the meeting

--- a/src/orga/minutes/2019-09-18.md
+++ b/src/orga/minutes/2019-09-18.md
@@ -1,6 +1,5 @@
 # 2019-09-18 conda-forge core meeting 
 
-****
 ## Attendees
 * CJ
 * Eric

--- a/src/orga/minutes/2019-10-02.md
+++ b/src/orga/minutes/2019-10-02.md
@@ -1,6 +1,5 @@
 # 2019-10-02 conda-forge core meeting
 
-****
 ## Attendees
 
 * Eric

--- a/src/orga/minutes/2019-10-16.md
+++ b/src/orga/minutes/2019-10-16.md
@@ -1,6 +1,5 @@
 # 2019-10-16 conda-forge core meeting 
 
-****
 ## Attendees
 
 ## Agenda

--- a/src/orga/minutes/2019-10-30.md
+++ b/src/orga/minutes/2019-10-30.md
@@ -1,6 +1,5 @@
 # 2019-10-30 conda-forge core meeting 
 
-****
 
 ## Attendees
 * Eric D.

--- a/src/orga/minutes/2019-11-12.md
+++ b/src/orga/minutes/2019-11-12.md
@@ -1,6 +1,5 @@
 # 2019-11-12 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-01-08.md
+++ b/src/orga/minutes/2020-01-08.md
@@ -1,6 +1,5 @@
 # 2020-01-08 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-01-22.md
+++ b/src/orga/minutes/2020-01-22.md
@@ -1,6 +1,5 @@
 # 2020-01-22 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-02-05.md
+++ b/src/orga/minutes/2020-02-05.md
@@ -1,6 +1,5 @@
 # 2020-02-05 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-02-19.md
+++ b/src/orga/minutes/2020-02-19.md
@@ -1,6 +1,5 @@
 # 2020-02-19 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-03-04.md
+++ b/src/orga/minutes/2020-03-04.md
@@ -1,6 +1,5 @@
 # 2020-03-04 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-03-18.md
+++ b/src/orga/minutes/2020-03-18.md
@@ -1,6 +1,5 @@
 # 2020-03-18 conda-forge core meeting 
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-04-01.md
+++ b/src/orga/minutes/2020-04-01.md
@@ -1,6 +1,5 @@
 # 2020-04-01 conda-forge core meeting 
 
-****
 
 ## Attendees
  - MS, ED, LB, CJ, AS, MB, Matt B, FF, JH, Uwe

--- a/src/orga/minutes/2020-04-15.md
+++ b/src/orga/minutes/2020-04-15.md
@@ -1,6 +1,5 @@
 # 2020-04-15 conda-forge core meeting 
 
-****
 
 ## Attendees
     * CJ Wright

--- a/src/orga/minutes/2020-04-29.md
+++ b/src/orga/minutes/2020-04-29.md
@@ -1,6 +1,5 @@
 # 2020-04-29 conda-forge core meeting 
 
-****
 
 ## Attendees
   * Marius van Niekerk

--- a/src/orga/minutes/2020-05-13.md
+++ b/src/orga/minutes/2020-05-13.md
@@ -1,6 +1,5 @@
 # 2020-05-13 conda-forge core meeting
 
-****
 
 ## Attendees
     * Jonathan Helmus

--- a/src/orga/minutes/2020-05-27.md
+++ b/src/orga/minutes/2020-05-27.md
@@ -1,6 +1,5 @@
 # 2020-05-27 conda-forge core meeting
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-06-22.md
+++ b/src/orga/minutes/2020-06-22.md
@@ -1,6 +1,5 @@
 # 2020-06-22 conda-forge core meeting
 
-****
 
 ## Attendees
 * Eric D

--- a/src/orga/minutes/2020-07-01.md
+++ b/src/orga/minutes/2020-07-01.md
@@ -1,6 +1,5 @@
 # 2020-07-01 conda-forge core meeting
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-07-08.md
+++ b/src/orga/minutes/2020-07-08.md
@@ -1,6 +1,5 @@
 # 2020-07-08 conda-forge core meeting
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-07-15.md
+++ b/src/orga/minutes/2020-07-15.md
@@ -1,6 +1,5 @@
 # 2020-07-15 conda-forge core meeting
 
-****
 
 ## Attendees
 

--- a/src/orga/minutes/2020-07.22.md
+++ b/src/orga/minutes/2020-07.22.md
@@ -1,6 +1,5 @@
 # 2020-07-22 conda-forge core meeting 
 
-****
 
 ## Attendees
 * Filipe Fernandes

--- a/src/orga/minutes/2020-07.29.md
+++ b/src/orga/minutes/2020-07.29.md
@@ -1,6 +1,5 @@
 # 2020-07-29 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-07-29/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-08-05.md
+++ b/src/orga/minutes/2020-08-05.md
@@ -1,6 +1,5 @@
 # 2020-08-05 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-05/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-08-12.md
+++ b/src/orga/minutes/2020-08-12.md
@@ -1,6 +1,5 @@
 # 2020-08-12 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-05/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-08-19.md
+++ b/src/orga/minutes/2020-08-19.md
@@ -1,6 +1,5 @@
 # 2020-08-19 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-05/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-08-26.md
+++ b/src/orga/minutes/2020-08-26.md
@@ -1,6 +1,5 @@
 # 2020-08-26 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-09-02.md
+++ b/src/orga/minutes/2020-09-02.md
@@ -1,6 +1,5 @@
 # 2020-09-02 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-09-09.md
+++ b/src/orga/minutes/2020-09-09.md
@@ -1,6 +1,5 @@
 # 2020-09-09 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-09-16.md
+++ b/src/orga/minutes/2020-09-16.md
@@ -1,6 +1,5 @@
 # 2020-09-16 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09 )
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-09-30.md
+++ b/src/orga/minutes/2020-09-30.md
@@ -1,6 +1,5 @@
 # 2020-09-30 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-09.09.md
+++ b/src/orga/minutes/2020-09.09.md
@@ -1,1 +1,0 @@
-  * Filipe Fernandes

--- a/src/orga/minutes/2020-10-07.md
+++ b/src/orga/minutes/2020-10-07.md
@@ -1,6 +1,5 @@
 # 2020-10-07 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-10-14.md
+++ b/src/orga/minutes/2020-10-14.md
@@ -1,6 +1,5 @@
 # 2020-10-14 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-10-21.md
+++ b/src/orga/minutes/2020-10-21.md
@@ -1,6 +1,5 @@
 # 2020-10-21 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-10-28.md
+++ b/src/orga/minutes/2020-10-28.md
@@ -1,6 +1,5 @@
 # 2020-10-28 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-11-03.md
+++ b/src/orga/minutes/2020-11-03.md
@@ -1,6 +1,5 @@
 # 2020-11-03 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-11-11.md
+++ b/src/orga/minutes/2020-11-11.md
@@ -1,6 +1,5 @@
 # 2020-11-11 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-11-18.md
+++ b/src/orga/minutes/2020-11-18.md
@@ -1,6 +1,5 @@
 # 2020-11-18 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-12-02.md
+++ b/src/orga/minutes/2020-12-02.md
@@ -2,7 +2,6 @@
 
 # 2020-12-02 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2020-12-16.md
+++ b/src/orga/minutes/2020-12-16.md
@@ -2,7 +2,6 @@
 
 # 2020-12-16 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-01-06.md
+++ b/src/orga/minutes/2021-01-06.md
@@ -2,7 +2,6 @@
 
 # 2021-01-06 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-01-27.md
+++ b/src/orga/minutes/2021-01-27.md
@@ -2,7 +2,6 @@
 
 # 2021-01-27 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-02-10.md
+++ b/src/orga/minutes/2021-02-10.md
@@ -2,7 +2,6 @@
 
 # 2021-02-10 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-02-24.md
+++ b/src/orga/minutes/2021-02-24.md
@@ -2,7 +2,6 @@
 
 # 2021-02-24 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-03-10.md
+++ b/src/orga/minutes/2021-03-10.md
@@ -2,7 +2,6 @@
 
 # 2021-03-10 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-03-24.md
+++ b/src/orga/minutes/2021-03-24.md
@@ -2,7 +2,6 @@
 
 # 2021-03-24 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-04-07.md
+++ b/src/orga/minutes/2021-04-07.md
@@ -1,6 +1,5 @@
 # 2021-04-07 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-04-21.md
+++ b/src/orga/minutes/2021-04-21.md
@@ -2,7 +2,6 @@
 
 # 2021-04-21 conda-forge core meeting
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-05-05.md
+++ b/src/orga/minutes/2021-05-05.md
@@ -2,7 +2,6 @@
 
 # 2021-05-05 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-05-19.md
+++ b/src/orga/minutes/2021-05-19.md
@@ -2,7 +2,6 @@
 
 # 2021-05-19 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-06-02.md
+++ b/src/orga/minutes/2021-06-02.md
@@ -2,7 +2,6 @@
 
 # 2021-06-02 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-06-16.md
+++ b/src/orga/minutes/2021-06-16.md
@@ -1,6 +1,5 @@
 # 2021-06-16 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-07-14.md
+++ b/src/orga/minutes/2021-07-14.md
@@ -2,7 +2,6 @@
 
 # 2021-07-14 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-07-28.md
+++ b/src/orga/minutes/2021-07-28.md
@@ -2,7 +2,6 @@
 
 # 2021-07-28 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-08-11.md
+++ b/src/orga/minutes/2021-08-11.md
@@ -1,6 +1,5 @@
 # 2021-08-11 conda-forge core meeting 
 
-****
 
 [Zoom link](https://flatiron.zoom.us/j/93242638216?pwd=bjRCWmVJRW1oTGJhN09VUmxtTTJOUT09)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-08-25.md
+++ b/src/orga/minutes/2021-08-25.md
@@ -2,7 +2,6 @@
 
 # 2021-08-25 conda-forge core meeting 
 
-****
 
 [last weeks meeting](https://hackmd.io/rKi3Rh-mTMKNBGtwQjwDcg)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-09-08.md
+++ b/src/orga/minutes/2021-09-08.md
@@ -2,7 +2,6 @@
 
 # 2021-09-08 conda-forge core meeting 
 
-****
 
 [last weeks meeting](https://hackmd.io/3INm0EGoS5uS_S2ZxJNzaA)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-09-22.md
+++ b/src/orga/minutes/2021-09-22.md
@@ -2,7 +2,6 @@
 
 # 2021-09-22 conda-forge core meeting 
 
-****
 
 [last weeks meeting](https://hackmd.io/D0A8IiUARbeZTKxq_F9vuA)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/orga/minutes/2021-10-06.md
+++ b/src/orga/minutes/2021-10-06.md
@@ -1,6 +1,5 @@
 # 2021-10-06 conda-forge core meeting 
 
-****
 
 [last weeks meeting](https://hackmd.io/BWH1Su-pSSG3gAqmWQXiCQ)
 [What time is the meeting in my time zone](https://arewemeetingyet.com/UTC/2020-08-26/17:00/w/Conda-forge%20dev%20meeting#eyJ1cmwiOiJodHRwczovL2hhY2ttZC5pby9wUk15dFVKV1FmU3NJM2xvMGlqQzJRP2VkaXQifQ==)

--- a/src/user/ci-skeleton.rst
+++ b/src/user/ci-skeleton.rst
@@ -68,7 +68,7 @@ you can use the ``-r`` option to supply an alternative.
 
 The **meta.yaml** looks like:
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
     {% set name = "myproj" %}
     {% set version = environ.get('GIT_DESCRIBE_TAG', 'untagged')|string|replace('-','_') %}


### PR DESCRIPTION
Things that happened:

- move from recommonmark to myst and lift sphinx version restrictions
- fix all remaining sphinx compiler warnings
- changed the sphinx compile flags such that the build errors out when there are warnings.
- check validity of links automatically on build.

Fingers crossed that this will work 😅 