### PR TITLE
Fix broken link to docs about automerge

### DIFF
--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -148,7 +148,7 @@ Adding this label to non-bot issued PRs will have no effect.
 Entering this command in the title or comment of an issue will instruct the admin bot to
 open a PR enabling the automatic merging of passing PRs from the ``auto-tick``
 bot. This functionality is currently experimental. You can find more details
-`here <https://regro.github.io/cf-scripts/github_actions_infrastructure.html#automerging-prs>`__.
+:ref:`here<Automerge>`.
 Please open issue on ``regro/cf-scripts`` for any feedback, bugs, and/or questions!
 
 @conda-forge-admin, please add python 2.7
@@ -294,6 +294,8 @@ GitHub Actions
 
 We use GitHub actions to rerender feedstocks and also run our pull request automerge service. We do not currently support builds on
 GitHub Actions.
+
+.. _Automerge:
 
 Automerge
 .........


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->
There is a broken link in the maintainer docs in a note about the automerge functionality. I am not quite sure that I replaced the broken link with the appropriate link because I don't know what the original link pointed to! 🤷🏼 However, I guess that it is supposed to point to what is now a blurb about how automerging works with GitHub Actions. This is further down the page, so I have used a text anchor so that the link will be robust to any future url changes.

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
