### PR TITLE
ci: ensure validity of external links

### DIFF
--- a/.ci_scripts/environment.yml
+++ b/.ci_scripts/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3
   - conda-smithy
-  - sphinx
+  - sphinx >=4.4
   - cloud_sptheme
   - sphinxcontrib-fulltoc
   - make

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -30,6 +30,7 @@ pushd src
 # -W --keep-going: list all warnings but fail build in case there are any
 # -n: check validity of all links
 make html SPHINXOPTS="-W --keep-going -n"
+make linkcheck
 mv _build/html ../docs
 rm -rf _build
 popd

--- a/src/conf.py
+++ b/src/conf.py
@@ -111,6 +111,23 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+# ---- Options for link validation --------
+
+anchor_check_fps = [
+    r'https://conda-forge.org/status/#armosxaddition$',
+    r'https://github.com/conda-forge/conda-smithy/blob/main/CHANGELOG.rst#v3130$',
+    r'https://github.com/.*#L\d+-L\d+$',
+    r'https://github.com/conda-forge/miniforge/#download$',
+    r'https://github.com/conda-incubator/grayskull#introduction$',
+]
+
+linkcheck_exclude_documents = [r'.*/minutes/.*']
+linkcheck_ignore = [
+    r'https://anaconda.org/?$',  # 403 forbidden
+    r'https://cloudflare.com/learning/cdn/what-is-a-cdn/?$',  # 403 forbidden
+    r'https://gitter.im/conda-forge/core$',  # private team
+] + anchor_check_fps
+
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This PR aims to prevent link decay by verifying external links in the CI. Dev meeting minutes are considered historical documents and are excluded from link validation.

The [exclude feature](https://github.com/sphinx-doc/sphinx/pull/9894) will land with sphinx-4.4, so we will have to wait a bit before can get merged :-)
