### PR TITLE
Correct compiler stack name in docs

### DIFF
--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -361,7 +361,7 @@ We do use some unofficial names for our compiler stack internally. Note however 
 the existence of these names does not imply any level of support or stability for the compilers
 that form the given stack.
 
-* Our current compiler stack is referred to internally as ``comp7``.
+* Our current compiler stack is referred to internally as ``cos7``.
 * The previous compiler stack based in part on the various ``toolchain_*`` packages
   was sometimes referred to as ``comp4``. On linux the ``toolchain_*`` compilers were
   GCC 4.8.2 as packaged in the devtoolset-2 software collection. On osx, we use clang from


### PR DESCRIPTION
The compiler stack is now cos7, see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2241

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [ ] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
