### PR TITLE
documenting adding a package locally CONFIG= ./.scripts/run_docker_build.sh call

### DIFF
--- a/docs/maintainer/adding_pkgs.html
+++ b/docs/maintainer/adding_pkgs.html
@@ -595,7 +595,7 @@ installed on your machine.</p>
 <p>You need to define an environment variable named <code class="docutils literal notranslate"><span class="pre">CONFIG</span></code>. Its value must be
 the name of one of the three YAML configuration files in the <code class="docutils literal notranslate"><span class="pre">.ci_support</span></code>
 directory (either <code class="docutils literal notranslate"><span class="pre">linux64</span></code>, <code class="docutils literal notranslate"><span class="pre">osx64</span></code>, or <code class="docutils literal notranslate"><span class="pre">win64</span></code>). As an example, you can
-invoke the command as follows (noting that you must have shyaml installed for this to work correctly).</p>
+invoke the command as follows.</p>
 <div class="highlight-sh notranslate"><div class="highlight"><pre><span></span>$ <span class="nb">cd</span> staged-recipes
 $ <span class="nv">CONFIG</span><span class="o">=</span>linux64 ./.scripts/run_docker_build.sh
 </pre></div>

--- a/docs/maintainer/adding_pkgs.html
+++ b/docs/maintainer/adding_pkgs.html
@@ -595,7 +595,7 @@ installed on your machine.</p>
 <p>You need to define an environment variable named <code class="docutils literal notranslate"><span class="pre">CONFIG</span></code>. Its value must be
 the name of one of the three YAML configuration files in the <code class="docutils literal notranslate"><span class="pre">.ci_support</span></code>
 directory (either <code class="docutils literal notranslate"><span class="pre">linux64</span></code>, <code class="docutils literal notranslate"><span class="pre">osx64</span></code>, or <code class="docutils literal notranslate"><span class="pre">win64</span></code>). As an example, you can
-invoke the command as follows.</p>
+invoke the command as follows (noting that you must have shyaml installed for this to work correctly).</p>
 <div class="highlight-sh notranslate"><div class="highlight"><pre><span></span>$ <span class="nb">cd</span> staged-recipes
 $ <span class="nv">CONFIG</span><span class="o">=</span>linux64 ./.scripts/run_docker_build.sh
 </pre></div>

--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -641,7 +641,7 @@ installed on your machine.
 You need to define an environment variable named ``CONFIG``. Its value must be
 the name of one of the three YAML configuration files in the ``.ci_support``
 directory (either ``linux64``, ``osx64``, or ``win64``). As an example, you can
-invoke the command as follows.
+invoke the command as follows. For this to work correctly, you must have ``shyaml`` installed on your machine, for example ``conda install -c conda-forge shyaml``.
 
 .. code-block:: sh
 


### PR DESCRIPTION
Essentially run_docker_build will default to linux-anvil-comp7 if shyaml isn't installed. Noting that in the docs.

```
./.scripts/run_docker_build.sh: line 24: shyaml: command not found
WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to quay.io/condaforge/linux-anvil-comp7
latest: Pulling from condaforge/linux-anvil-comp7

```

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [ ] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
