### PR TITLE
Specify GCC 11's default C++ version behavior

### DIFF
--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -39,9 +39,9 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
     These compilers will become the default for building packages in conda-forge.
     One notable change in gcc 10 is that the -fopenmp flag in FFLAGS is dropped.
     In clang 12, -std=c++14 explicit flag has been dropped from CXXFLAGS,
-    as it is the default compilation mode for clang 12. In clang>=12 and gcc>=11,
-    we will not provide an explicit C++ standard, and will defer to the compiler
-    default.
+    as it is the default compilation mode for clang 12. In gcc 11, the default
+    is -std=gnu++17. In clang>=12 and gcc>=11, we will not provide an explicit
+    C++ standard, and will defer to the compiler default.
 
 :2021-10-04: python 3.6 is now dropped when building conda-forge packages
 


### PR DESCRIPTION
Found this detail about GCC's C++ version support useful to include since we include it for Clang and was wondering what it did.

Under "Caveats" it says...

> The default mode for C++ is now -std=gnu++17 instead of -std=gnu++14.

https://www.gnu.org/software/gcc/gcc-11/changes.html

cc @isuruf

<hr>

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [ ] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
