### PR TITLE
DOC: Update feedstock channel selection docs

### DIFF
--- a/docs/maintainer/conda_forge_yml.md
+++ b/docs/maintainer/conda_forge_yml.md
@@ -241,22 +241,18 @@ allowed here.
 
 ### channels
 
-This represents the channels to grab packages from during builds and
-which channels/labels to push to on anaconda.org after a package
-has been built.  The `channels` variable is a mapping with
-`sources` and `targets`, as follows:
+:::warning
+This parameter has been deprecated. Instead, specify channels in `recipe/conda_build_config.yaml`
+using `channel_sources` and `channel_targets`. Note that all channels go on a single
+line because each line represents a build variant.
 
-```yaml
-channels:
-  # sources selects the channels to pull packages from, in order.
-  sources:
-    - conda-forge
-    - defaults
-  # targets is a list of 2-lists, where the first element is the
-  # channel to push to and the second element is the label on that channel
-  targets:
-    - ["conda-forge", "main"]
+```yaml title="recipe/conda_build_config.yaml"
+channel_sources:
+  - mysourcechannel1,mysourcechannel2,conda-forge,defaults
+channel_targets:
+  - target_channel target_label
 ```
+:::
 
 <a id="choco"></a>
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/2026

Documentation for channel sources and targets are out of date. This
setting is now managed in conda_build_config

Related
https://github.com/conda-forge/conda-smithy/issues/897
https://github.com/conda-forge/conda-smithy/blob/9f81a068e8f23f2aae670469b473da786d49d8ef/README.md

Prompted by
https://github.com/conda-forge/furo-feedstock/pull/27

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
~~- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)~~
~~- [ ] put any other relevant information below~~
