### PR TITLE
minor fix in build-locally.py documentation for osx SDKs

### DIFF
--- a/src/maintainer/adding_pkgs.rst
+++ b/src/maintainer/adding_pkgs.rst
@@ -637,7 +637,7 @@ If you want to run and build packages in the staged-recipes repository locally,
 go to the root repository directory and run the
 ``build-locally.py`` script (you need Python 3). And then you could follow the prompt to select the variant you'd like to build. This requires that you have Docker
 installed on your machine if you are building a package for Linux.
-For MacOS, it will prompt you to select a location for the SDK (e.g. ``export OSX_SDK_DIR=/opt``) to be downloaded.
+For MacOS, it will prompt you to select a location for the SDK (e.g. ``export OSX_SDK_DIR=SDKs``) to be downloaded.
 
 .. code-block:: bash
         


### PR DESCRIPTION
Minor followup to PR #1590
Fixes #1623

This PR only updates the location of the SDK

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
