### PR TITLE
Fix the bullet points in Organisatin docs -> Language versions

### DIFF
--- a/src/orga/guidelines.rst
+++ b/src/orga/guidelines.rst
@@ -157,10 +157,12 @@ The guidance that we can provide here is two fold:
 1. We will move with the community. 
    When our core libraries stop supporting an old version, so too will conda forge.
    The (nonexhaustive) list of core libraries that we consider when making the decision to drop an older version are:
+
    * matplotlib
    * numpy
    * scipy
    * pypy
+
 2. The core team can decide to keep an old version around temporarily until some specific criteria is met.
    For example, we're holding off on turning off py36 until pypy comes out with pypy3.7.
 3. If there are lots of people in the community relying on older versions, core team can decide to keep an old version around.


### PR DESCRIPTION
There is some error here: 
<img width="767" alt="Screenshot 2022-03-28 at 7 45 39 PM" src="https://user-images.githubusercontent.com/51460047/160418228-99268353-0201-47b9-b323-628e916daa8d.png">

In the last line: ``The (nonexhaustive) list of core libraries that we consider when making the decision to drop an older version are: ...`` the list of libraries are not written properly in bullet points. This PR fixes this.

PR Checklist:
- [X] make all edits to the docs in the `src` directory, not in `docs` or in the html files

