### PR TITLE
add the kw 'broken' to linkcheck help newbies debug errors

### DIFF
--- a/newsfeed/demo/Makefile
+++ b/newsfeed/demo/Makefile
@@ -158,8 +158,8 @@ changes:
 linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
+	@echo "Link check complete; look for any errors (like 'broken') in the " \
+		  "above output or in $(BUILDDIR)/linkcheck/output.txt."
 
 doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest


### PR DESCRIPTION
<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [ ] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below


Make sure the message seen in CI includes the word "broken" so newbies like me know what to look for. Related to a recent PR build failure.