### PR TITLE
Add Polys to linkcheck ignore list

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -126,6 +126,7 @@ linkcheck_ignore = [
     r'https://anaconda.org/?$',  # 403 forbidden
     r'https://cloudflare.com/learning/cdn/what-is-a-cdn/?$',  # 403 forbidden
     r'https://gitter.im/conda-forge/core$',  # private team
+    r'https://polys.me/?$',  # 403 forbidden
 ] + anchor_check_fps
 
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge.github.io/issues/1663

The Polys link has been a bit flaky (HTTP 403 error), which has caused `lintcheck` to fail sporadically. Usually this works after retrying. That said, this can confuse PR authors updating docs and can result in docs not getting updated. So skip `lintcheck` on the Polys link to avoid this issue.

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

cc @croth1