### PR TITLE
Fix linkcheck 403 with custom user_agent

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -112,6 +112,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # ---- Options for link validation --------
+user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'
 
 anchor_check_fps = [
     r'https://conda-forge.org/status/#armosxaddition$',


### PR DESCRIPTION
Fixes a linkcheck 403 error that we are seeing on CI. (thanks @croth1 for figuring this out! 🙏)

xref: https://github.com/sphinx-doc/sphinx/issues/7369
xref: https://github.com/conda-forge/conda-forge.github.io/pull/1710

<hr>

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
