### PR TITLE
knowledge_base: To use vs2019 it is not necessary anymore to change azure image

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -210,25 +210,14 @@ In conda_build_config.yaml file:
 
 .. code-block:: yaml
 
-    c_compiler:
-    - vs2019
-    cxx_compiler:
-    - vs2019
+c_compiler:  # [win]
+- vs2019  # [win]
+cxx_compiler:  # [win]
+- vs2019  # [win]
 
 
-In conda-forge.yml file:
-
-.. code-block:: yaml
-
-    azure:
-      settings_win:
-          pool:
-              vmImage: windows-2019
-
-
-
-For example see the changes made in the ``conda_build_config.yaml`` and ``conda-forge.yml`` files in `this
-<https://github.com/conda-forge/libignition-physics-feedstock/commit/c586d765a2f5fd0ecf6da43c53315c898c9bf6bd>`__ PR.
+For example see the changes made in the ``conda_build_config.yaml`` files in `this
+<https://github.com/conda-forge/libignition-msgs1-feedstock/pull/73/commits/81b5ee0e1d23f7f20427dd80d04cf1f7321b441d>`__ commit.
 
 After making these changes don't forget to rerender with ``conda-smithy`` (to rerender manually use ``conda smithy rerender`` from the command line).
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -210,10 +210,10 @@ In conda_build_config.yaml file:
 
 .. code-block:: yaml
 
-c_compiler:  # [win]
-- vs2019  # [win]
-cxx_compiler:  # [win]
-- vs2019  # [win]
+    c_compiler:    # [win]
+    - vs2019       # [win]
+    cxx_compiler:  # [win]
+    - vs2019       # [win]
 
 
 For example see the changes made in the ``conda_build_config.yaml`` files in `this


### PR DESCRIPTION
See https://github.com/conda-forge/conda-smithy/pull/1552 that changed default `vmImage` to `windows-2019`.


PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
