### PR TITLE
DOC: Add note about mpi compiler metapackages

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -680,6 +680,13 @@ Without a preferred ``nompi`` variant, recipes that require mpi are much simpler
     run:
       - {{ mpi }}
 
+MPI Compilers
+^^^^^^^^^^^^^
+
+Do not use the `[openmpi,mpich]-mpicc` metapackages in the `requirements/build` section
+of a recipe; the mpi compiler wrappers are included in the main openmpi/mpich packages.
+Add openmpi/mpich to the `requirements/host` section and use compiler directives for the 
+corresponding compilers in `requirements/build` as normal.
 
 
 OpenMP

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -680,10 +680,10 @@ Without a preferred ``nompi`` variant, recipes that require mpi are much simpler
     run:
       - {{ mpi }}
 
-MPI Compilers
-^^^^^^^^^^^^^
+MPI Compiler Packages
+^^^^^^^^^^^^^^^^^^^^^
 
-Do not use the ``[openmpi,mpich]-[mpicc, mpicxx, mpifort]`` metapackages in the ``requirements/build`` section
+Do not use the ``[openmpi,mpich]-[mpicc,mpicxx,mpifort]`` metapackages in the ``requirements/build`` section
 of a recipe; the MPI compiler wrappers are included in the main ``openmpi``/``mpich`` packages.
 As shown above, just add ``openmpi``/``mpich`` to the ``requirements/host`` section and use compiler directives for the 
 corresponding compilers in ``requirements/build`` as normal.

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -488,7 +488,7 @@ and apply the appropriate conditionals in your build:
 
 
 Preferring a provider (usually nompi)
-"""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Up to here, mpi providers have no explicit preference. When choosing an MPI provider, the mutual exclusivity of
 the ``mpi`` metapackage allows picking between mpi providers by installing an mpi provider, e.g.
@@ -580,7 +580,7 @@ Remove the ``if mpi...`` condition if all variants should create a strict runtim
 chosen at build time (i.e. if the nompi build cannot be run against the mpich build).
 
 Complete example
-""""""""""""""""
+^^^^^^^^^^^^^^^^
 
 Combining all of the above, here is a complete recipe, with:
 
@@ -660,7 +660,7 @@ mpi-metapackage exclusivity allows ``mpi_*`` to resolve the same as ``mpi_{{ mpi
 if ``{{ mpi }}`` is also a direct dependency, though it's probably nicer to be explicit.
 
 Just mpi example
-""""""""""""""""
+^^^^^^^^^^^^^^^^
 
 Without a preferred ``nompi`` variant, recipes that require mpi are much simpler. This is all that is needed:
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -683,10 +683,10 @@ Without a preferred ``nompi`` variant, recipes that require mpi are much simpler
 MPI Compilers
 ^^^^^^^^^^^^^
 
-Do not use the `[openmpi,mpich]-mpicc` metapackages in the `requirements/build` section
-of a recipe; the mpi compiler wrappers are included in the main openmpi/mpich packages.
-Add openmpi/mpich to the `requirements/host` section and use compiler directives for the 
-corresponding compilers in `requirements/build` as normal.
+Do not use the ``[openmpi,mpich]-[mpicc, mpicxx, mpifort]`` metapackages in the ``requirements/build`` section
+of a recipe; the MPI compiler wrappers are included in the main ``openmpi``/``mpich`` packages.
+As shown above, just add ``openmpi``/``mpich`` to the ``requirements/host`` section and use compiler directives for the 
+corresponding compilers in ``requirements/build`` as normal.
 
 
 OpenMP


### PR DESCRIPTION
Closes https://github.com/conda-forge/openmpi-feedstock/issues/91

<!--
Thank you for pull request!

Please note that the `docs` subdir is generated from the sphinx sources in `src`, changes 
to `.html` files will only be effective if applied to the respective `.rst`.
-->

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

Adds a paragraph clarifying the the mpi compiler meta-packages are for end-user convenience and not for use in conda-build recipes.