### PR TITLE
Improve anchors for each year in Announcements section.

### DIFF
--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -5,6 +5,8 @@ Announcements
 
 Our announcements are published to an RSS feed `here <https://conda-forge.org/docs/news.rss>`_.
 
+.. _year_2022:
+
 2022
 ----
 
@@ -51,6 +53,8 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 
     If you encounter any problems, please comment on this Github 
     `issue <https://github.com/conda-forge/conda-forge.github.io/issues/1162>`_. 
+
+.. _year_2021:
 
 2021
 ----
@@ -106,6 +110,8 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
     You can now cite ``conda-forge`` using our `Zenodo entry <https://doi.org/10.5281/zenodo.4774216>`_!
     This entry credits the entire ``conda-forge`` community for its hard work in building our
     amazing ecosystem.
+
+.. _year_2020:
 
 2020
 ----
@@ -340,6 +346,8 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
      generated with this admin command. Further, this admin command will only work on
      ``osx-64`` and ``linux-64`` platforms.
 
+.. _year_2019:
+
 2019
 ----
 
@@ -364,6 +372,8 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
     If you:
       * maintain a compiled feedstock, it will likely need to be rerender
       * need to roll back to the old compilers, you can use the "cf201901" label
+
+.. _year_2018:
 
 2018
 ----


### PR DESCRIPTION
Towards #1611 

This fixes the links for each year from ``...#id1`` to ``...#year-2022``. 

PR Checklist:

- [x] make all edits to the docs in the `src` directory, not in `docs` or in the html files
- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below
