### PR TITLE
Add announcement for dropping PyPy 3.7

### DIFF
--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,7 +8,7 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2022
 ----
 
-2022-08-11: Dropping PyPy 3.7
+2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Conda-forge has supported PyPy since almost 2.5 years now, and the initial

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -13,9 +13,7 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 
 Conda-forge has supported PyPy since almost 2.5 years now, and the initial
 PyPy 3.7 builds have been superseded in almost all aspects by the newer builds
-for 3.8 & 3.9. Dropping PyPy 3.7 has the consequence that we are currently
-unable to keep supporting the miniforge installer with PyPy in the base
-environment, but you can keep using PyPy for any other environment!
+for 3.8 & 3.9.
 
 2022-08-11: Moving to Visual Studio toolchain vc142
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,6 +8,14 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2022
 ----
 
+2022-08-11: Dropping PyPy 3.7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conda-forge has supported PyPy since almost 2.5 years now, and the initial
+PyPy 3.7 builds have been superseded in almost all aspects by the newer builds
+for 3.8 & 3.9. Dropping PyPy 3.7 has the consequence that we are currently
+unable to keep supporting the miniforge installer with PyPy in the base
+environment, but you can keep using PyPy for any other environment!
 
 2022-08-11: Moving to Visual Studio toolchain vc142
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -13,7 +13,8 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 
 Conda-forge has supported PyPy since almost 2.5 years now, and the initial
 PyPy 3.7 builds have been superseded in almost all aspects by the newer builds
-for 3.8 & 3.9.
+for 3.8 & 3.9. We are therefore dropping PyPy 3.7 as a supported python version,
+and will keep focussing on the more contemporary PyPy builds.
 
 2022-08-11: Moving to Visual Studio toolchain vc142
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -14,7 +14,7 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 Conda-forge has supported PyPy since almost 2.5 years now, and the initial
 PyPy 3.7 builds have been superseded in almost all aspects by the newer builds
 for 3.8 & 3.9. We are therefore dropping PyPy 3.7 as a supported python version,
-and will keep focussing on the more contemporary PyPy builds.
+and will keep focusing on the more contemporary PyPy builds.
 
 2022-08-11: Moving to Visual Studio toolchain vc142
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

As discussed in the dev meeting, announcing the drop of pypy 3.7, see #1800 & https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3227

Note that to avoid rebasing issue, this currently includes #1810.

CC @conda-forge/help-pypy