### PR TITLE
Announce Python 3.7 will be dropped October 3rd

### DIFF
--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,6 +8,16 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2022
 ----
 
+2022-08-24: Dropping Python 3.7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conda-Forge has been providing support for Python 3.7 for 4 years now.
+Increasingly projects are moving off it (particularly in the PyData community).
+With Python 3.11's release coming around the corner (October 3rd), conda-forge
+plans to drop Python 3.7 support when Python 3.11 comes out. This will lighten
+the load on conda-forge infrastructure. Plus make room for the new versions the
+community would like to support.
+
 2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -18,7 +18,9 @@ plans to drop Python 3.7 support when Python 3.11 comes out. This will lighten
 the load on conda-forge infrastructure and make room for the new versions the
 community would like to support.
 
-More details can be found in issue [conda-forge-pinning-feedstock#2623]( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623 ). Feedback is welcome there.
+More details can be found in issue [conda-forge-pinning-feedstock#2623](
+https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623 ).
+Feedback is welcome there.
 
 2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -21,8 +21,7 @@ community would like to support.
 More details can be found in issue `conda-forge-pinning-feedstock#2623`_.
 Feedback is welcome there.
 
-.. _`conda-forge-pinning-feedstock#2623`:
-https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623
+.. _`conda-forge-pinning-feedstock#2623`: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623
 
 2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -18,6 +18,8 @@ plans to drop Python 3.7 support when Python 3.11 comes out. This will lighten
 the load on conda-forge infrastructure and make room for the new versions the
 community would like to support.
 
+More details can be found in issue [conda-forge-pinning-feedstock#2623]( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623 ). Feedback is welcome there.
+
 2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -15,7 +15,7 @@ Conda-Forge has been providing support for Python 3.7 for 4 years now.
 Increasingly projects are moving off it (particularly in the PyData community).
 With Python 3.11's release coming around the corner (October 3rd), conda-forge
 plans to drop Python 3.7 support when Python 3.11 comes out. This will lighten
-the load on conda-forge infrastructure. Plus make room for the new versions the
+the load on conda-forge infrastructure and make room for the new versions the
 community would like to support.
 
 2022-08-17: Dropping PyPy 3.7

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -18,9 +18,11 @@ plans to drop Python 3.7 support when Python 3.11 comes out. This will lighten
 the load on conda-forge infrastructure and make room for the new versions the
 community would like to support.
 
-More details can be found in issue [conda-forge-pinning-feedstock#2623](
-https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623 ).
+More details can be found in issue `conda-forge-pinning-feedstock#2623`_.
 Feedback is welcome there.
+
+`conda-forge-pinning-feedstock#2623`_:
+https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623
 
 2022-08-17: Dropping PyPy 3.7
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -21,7 +21,7 @@ community would like to support.
 More details can be found in issue `conda-forge-pinning-feedstock#2623`_.
 Feedback is welcome there.
 
-`conda-forge-pinning-feedstock#2623`_:
+.. _`conda-forge-pinning-feedstock#2623`:
 https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623
 
 2022-08-17: Dropping PyPy 3.7


### PR DESCRIPTION
Following up on comment ( https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/2623#issuecomment-1226073265 ), this announces that Python 3.7 will be dropped from conda-forge when [Python 3.11 comes out October 3rd]( https://peps.python.org/pep-0664/ ).

<hr>

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
