### PR TITLE
Dependencies of conda can be noarch now

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -983,7 +983,6 @@ In order to qualify as a noarch python package, all of the following criteria mu
   - If ``console_scripts`` ``entry_points`` are defined in ``setup.py`` or ``setup.cfg``, they are also listed in
     the ``build`` section of ``meta.yaml``
   - No activate scripts
-  - Not a dependency of conda
 
 .. note::
 


### PR DESCRIPTION
Since we already have colorama, charset-normalizer as noarch, I see no reason to not allow this