### PR TITLE
Document OS-specific approaches for noarch packages

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1051,7 +1051,7 @@ relies on three concepts:
     which are only present when the running platform is Linux, Windows, or MacOS, respectively.
     ``__unix`` is present in both Linux and MacOS. Note that this feature is **only fully available
     on conda 4.10 or above**.
-2.  ``conda-forge.ymls``'s :ref:`noarch_platforms` option.
+2.  ``conda-forge.yml``'s :ref:`noarch_platforms` option.
 
 The idea is to generate different noarch packages for each OS needing different dependencies.
 Let's say you have a pure Python package, perfectly eligible for ``noarch: python``, but on Windows

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1114,8 +1114,8 @@ would never be true). Fortunately, we can change the default behaviour in ``cond
     - win-64
 
 This will provide two runners per package! But since we are using selectors in ``conda_build_config.yaml``,
-only one is true at a time. Perfect! All these changes require a feedstock rerender to be applied:
-:ref:`_dev_update_rerender`.
+only one is true at a time. Perfect! All these changes require a feedstock rerender to be applied. See
+:ref:`dev_update_rerender`.
 
 Last but not least, what if you need conditional dependencies on all three operating systems? Do it like this:
 
@@ -1158,7 +1158,8 @@ Last but not least, what if you need conditional dependencies on all three opera
     - osx-64
     - win-64
 
-Again, d
+Again, remember to rerender after adding / modifying these files so the changes are applied.
+
 Noarch generic
 --------------
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1073,7 +1073,7 @@ have something like:
 
 We can replace it with:
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
   :caption: recipe/meta.yaml (modified)
 
   name: package
@@ -1121,7 +1121,7 @@ only one is true at a time. Perfect! All these changes require a feedstock reren
 
 Last but not least, what if you need conditional dependencies on all three operating systems? Do it like this:
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
   :caption: recipe/meta.yaml
 
   name: package

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1089,9 +1089,11 @@ to two outputs if replace it with this other approach!
     string: "win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"   # [win]
     noarch: python
   requirements:
-    # ...
+    host:
+      - python >=3.7
+      # ...
     run:
-      - python
+      - python >=3.7
       - numpy
       - __unix  # [unix]
       - __win   # [win]

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1052,6 +1052,7 @@ relies on three concepts:
     ``__unix`` is present in both Linux and MacOS. Note that this feature is **only fully available
     on conda 4.10 or above**.
 2.  ``conda-forge.yml``'s :ref:`noarch_platforms` option.
+3. **conda-build 3.25.0 or above** changing the build hash depending on virtual packages used.
 
 The idea is to generate different noarch packages for each OS needing different dependencies.
 Let's say you have a pure Python package, perfectly eligible for ``noarch: python``, but on Windows
@@ -1073,10 +1074,10 @@ it requires ``windows-only-dependency``. You might have something like:
       - windows-only-dependency  # [win]
 
 Being non-noarch, this means that the build matrix will include at least 12 outputs: three platforms,
-times four Python versions. This gets worse with arm64, aarch64 and ppc64le in the mix. We can get it down
-to two outputs if replace it with this other approach!
+times four Python versions. This gets worse with ``arm64``, ``aarch64`` and ``ppc64le`` in the mix.
+We can get it down to two outputs if replace it with this other approach!
 
-.. code-block:: yaml+jinja
+.. code-block:: yaml
   :caption: recipe/meta.yaml (modified)
 
   name: package
@@ -1084,9 +1085,6 @@ to two outputs if replace it with this other approach!
     # ...
   build:
     number: 0
-    # You NEED to include the platform in the build string to avoid hash collisions
-    string: "unix_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [unix]
-    string: "win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"   # [win]
     noarch: python
   requirements:
     host:
@@ -1126,10 +1124,6 @@ If you need conditional dependencies on all three operating systems, this is how
     # ...
   build:
     number: 0
-    # You NEED to include the platform in the build string to avoid hash collisions
-    string: "linux_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [linux]
-    string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [osx]
-    string: "win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [win]
     noarch: python
   requirements:
     # ...

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1081,6 +1081,8 @@ We can replace it with:
     # ...
   build:
     number: 0
+    # You can include target_os in the build string for easier identification of builds
+    string: "{{ target_os }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"
     noarch: python
   requirements:
     # ...

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1119,8 +1119,8 @@ would never be true). Fortunately, we can change the default behaviour in ``cond
   :caption: conda-forge.yml
 
   noarch_platforms:
-    - linux-64
-    - win-64
+    - linux_64
+    - win_64
 
 This will provide two runners per package! But since we are using selectors in
 ``conda_build_config.yaml``, only one is true at a time. Perfect! All these changes require a
@@ -1164,9 +1164,9 @@ like this:
   :caption: conda-forge.yml
 
   noarch_platforms:
-    - linux-64
-    - osx-64
-    - win-64
+    - linux_64
+    - osx_64
+    - win_64
 
 Again, remember to rerender after adding / modifying these files so the changes are applied.
 

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1125,7 +1125,9 @@ If you need conditional dependencies on all three operating systems, this is how
   build:
     number: 0
     # You NEED to include the platform in the build string to avoid hash collisions
-    string: "{{ SUBDIR.split('-')[0] }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"
+    string: "linux_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"  # [linux]
+    string: "osx_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [osx]
+    string: "win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}"    # [win]
     noarch: python
   requirements:
     # ...

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1057,15 +1057,15 @@ Python package, perfectly eligible for ``noarch: python``, but on Windows it req
 have something like:
 
 .. code-block:: yaml
+  :caption: recipe/meta.yaml (original)
 
-  # recipe/meta.yaml
   name: package
   source:
-   ...
+    # ...
   build:
     number: 0
   requirements:
-    ...
+    # ...
     run:
       - python
       - numpy
@@ -1074,16 +1074,16 @@ have something like:
 We can replace it with:
 
 .. code-block:: yaml
+  :caption: recipe/meta.yaml (modified)
 
-  # recipe/meta.yaml
   name: package
   source:
-   ...
+    # ...
   build:
     number: 0
     noarch: python
   requirements:
-    ...
+    # ...
     run:
       - python
       - numpy
@@ -1096,8 +1096,8 @@ Cool! Where does ``target_os`` come from? We need to define it in ``conda_build_
 Note how the values have been chosen carefully so they match the virtual packages names:
 
 .. code-block:: yaml
+  :caption: recipe/conda_build_config.yaml
 
-  # recipe/conda_build_config.yaml
   target_os:
     - unix  # [unix]
     - win   # [win]
@@ -1107,8 +1107,8 @@ the ``target_os`` matrix would only provide the ``unix`` value (because the ``# 
 would never be true). Fortunately, we can change the default behaviour in ``conda-forge.yml``:
 
 .. code-block:: yaml
+  :caption: conda-forge.yml
 
-  # conda-forge.yml
   noarch_platforms:
     - linux-64
     - win-64
@@ -1120,16 +1120,16 @@ only one is true at a time. Perfect! All these changes require a feedstock reren
 Last but not least, what if you need conditional dependencies on all three operating systems? Do it like this:
 
 .. code-block:: yaml
+  :caption: recipe/meta.yaml
 
-  # recipe/meta.yaml
   name: package
   source:
-   ...
+    # ...
   build:
     number: 0
     noarch: python
   requirements:
-    ...
+    # ...
     run:
       - python
       - numpy
@@ -1143,16 +1143,16 @@ Last but not least, what if you need conditional dependencies on all three opera
       {% endif %}
 
 .. code-block:: yaml
+  :caption: recipe/conda_build_config.yaml
 
-  # recipe/conda_build_config.yaml
   target_os:
     - linux  # [linux]
     - osx    # [osx]
     - win    # [win]
 
 .. code-block:: yaml
+  :caption: conda-forge.yml
 
-  # conda-forge.yml
   noarch_platforms:
     - linux-64
     - osx-64

--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -1052,7 +1052,7 @@ relies on three concepts:
     ``__unix`` is present in both Linux and MacOS. Note that this feature is **only fully available
     on conda 4.10 or above**.
 2.  ``conda-forge.yml``'s :ref:`noarch_platforms` option.
-3. **conda-build 3.25.0 or above** changing the build hash depending on virtual packages used.
+3.  **conda-build 3.25.0 or above** changing the build hash depending on virtual packages used.
 
 The idea is to generate different noarch packages for each OS needing different dependencies.
 Let's say you have a pure Python package, perfectly eligible for ``noarch: python``, but on Windows


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

This creative approach is used by several feedstocks (10 or so, according to [this Github CodeSearch query](https://cs.github.com/?scopeName=All+repos&scope=&q=org%3Aconda-forge+path%3Aconda-forge.yml+noarch_platforms)) now but wasn't documented. This approach alleviates the number of builds needed for platform-specific dependencies in noarch-eligible packages.