### PR TITLE
main branch, not master branch

### DIFF
--- a/index.html.tmpl
+++ b/index.html.tmpl
@@ -249,7 +249,7 @@
                           Fork the feedstock you wish to update.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-branch"></i>
-                          Create a new branch from the feedstock master branch.
+                          Create a new branch from the feedstock main branch.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-pencil"></i>
                           Edit the recipe as desired. You may even consider adding yourself as a recipe maintainer.
@@ -274,7 +274,7 @@
                           Fork <a href="https://github.com/conda-forge/staged-recipes">conda-forge/staged-recipes</a>
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-git-branch"></i>
-                          Create a new branch from the staged-recipes master branch.
+                          Create a new branch from the staged-recipes main branch.
                       </li>
                       <li><i class="mega-octicon fa-3x octicon-pencil"></i>
                           Add a new conda recipe in a new "recipes/[your-package-name]" directory. Please make sure to follow these


### PR DESCRIPTION
Not sure if all feedstocks already use "main", but its likely clear on what is meant if we use the new name here.

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
