### PR TITLE
Document macOS CMake options to skip system packages

### DIFF
--- a/src/maintainer/knowledge_base.rst
+++ b/src/maintainer/knowledge_base.rst
@@ -45,6 +45,7 @@ Some optional, but useful CMake options:
     - ``-DCMAKE_INSTALL_LIBDIR=lib`` Libraries will land in $PREFIX/lib, sometimes projects install
       into lib64 or similar but on conda-forge we keep shared libraries in simply lib.
     - ``-DBUILD_SHARED_LIBS=ON`` Instruct CMake to build shared libraries instead of static ones.
+    - ``-DCMAKE_FIND_FRAMEWORK=NEVER`` and ``-DCMAKE_FIND_APPBUNDLE=NEVER`` Prevent CMake from using system-wide macOS packages.
     - ``${CMAKE_ARGS}`` Add variables defined by conda-forge internally. This is required to enable various conda-forge enhancements, like `CUDA builds <https://conda-forge.org/docs/maintainer/knowledge_base.html#cuda-builds>`__.
 
 Here are some basic commands for you to get started. These are dependent on your source


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

[CMAKE_FIND_FRAMEWORK](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_FRAMEWORK.html) and [CMAKE_FIND_APPBUNDLE](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_APPBUNDLE.html) default to `FIRST` on darwin. The consequence is that if a library is installed in the system (e.g. `/Library/Frameworks/Mono.framework/Headers/jpeglib.h` on osx_64), CMake never uses the version installed in the build environment.

I hit this problem in [libjxl](https://github.com/conda-forge/staged-recipes/pull/21185) and it took me hours.
