### PR TITLE
Add section describing autotick-bot behavior in updating_pkgs.rst

### DIFF
--- a/src/maintainer/updating_pkgs.rst
+++ b/src/maintainer/updating_pkgs.rst
@@ -67,6 +67,10 @@ When a new version of a package is released on PyPI/CRAN/.., we have a bot that 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 The `regro-cf-autotick-bot <https://github.com/regro/autotick-bot>`__ continuously searches on a loop for any PyPI releases, GitHub releases, and any other sources of versions when any updates are released. The source code that gets executed in the loop comes from the `cf-scripts repository <https://github.com/regro/cf-scripts>`__, which contains the code to detect versions and submit PRs. Visit `cf-scripts <https://regro.github.io/cf-scripts/index.html>`__ to read more about it.
 
+The bot creates updates via inspection of the upstream release and will always update the ``source`` section and build version in the `recipe metadata <https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#>`_.
+For `Grayskull <https://github.com/conda-incubator/grayskull>`_-compatible recipes, the bot can also be configured to update the recipe's requirements, which may significantly assist in maintaining packages with specific dependency pins.
+(See the :ref:`_bot` section in ``conda-forge.yml``)
+
 Sometimes the bot may take several hours to search for these updates. You can also check `status of version updates <https://conda-forge.org/status/#version_updates>`__ for all the pending version updates. These version updates are pending either because an updated version was found, but a PR wasn't opened yet, or because the bot might have had an error while making the PR.
 If you can't find a version here, then the chances are that the bot couldn't find it either.
 


### PR DESCRIPTION


The autotick bot has recently gained the ability to perform grayskull based dependency analysis to update recipe requirements, however this is not described in the conda forge docs.
This is quite useful in maintaining packages as they update dependency pins, but isn't widely known by maintainers.

https://github.com/conda-forge/itables-feedstock/pull/23
https://github.com/conda-forge/flytekit-feedstock/pull/30

This is a first-pass stab at adding a reference in the "roughly correct" section of the conda forge docs to make this feature more discoverable.

Related to https://github.com/conda-forge/conda-forge.github.io/pull/1500, which is now a little aged in duplicates information from other sections of the docs.

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
