### PR TITLE
Change Google Groups links to Discourse group

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -20,7 +20,8 @@ Chances are we have already packaged it for you. You can `search <https://anacon
 
   - `GitHub issues <https://github.com/conda-forge/conda-forge.github.io/issues>`_
   - `Gitter channel <https://gitter.im/conda-forge/conda-forge.github.io>`_
-  - `Mailing list <https://groups.google.com/forum/#!forum/conda-forge>`_
+  - `Discourse group <https://conda.discourse.group>`_
+  - `Mailing list (archived) <https://groups.google.com/forum/#!forum/conda-forge>`_
 
 
 Table of Contents

--- a/src/user/how_to_get_help.rst
+++ b/src/user/how_to_get_help.rst
@@ -1,14 +1,14 @@
 How to get help at conda-forge
 ==============================
 
-You could connect with us via **Gitter, GitHub Issues or Mailing List**. 
+You could connect with us via **Gitter, GitHub Issues or Discourse Group**.
 We would be happy to hear from you!
 
 Gitter
 -------------------
 
 If you are just starting out with conda-forge and/or feel completely lost, we recommend getting in touch through `Gitter <https://gitter.im/conda-forge/conda-forge.github.io>`__. Our community members will direct
-you to the proper documentation and/or help you via the chat. 
+you to the proper documentation and/or help you via the chat.
 
 GitHub issues
 -------------
@@ -30,9 +30,7 @@ You can open issues at `conda-forge.github.io <https://github.com/conda-forge/co
 for long threads involving infrastructural, architectural or ecosystem wide discussions.
 Please note that some of these discussions will be turned into policy via the `CFEP process <https://github.com/conda-forge/conda-forge-enhancement-proposals>`__.
 
-Mailing list
-------------
+Discourse Group
+---------------
 
-You can subscribe to our `Mailing List <https://groups.google.com/forum/#!forum/conda-forge>`__ and post your queries there. The mailing list is a secondary home for long threads about the ecosystem.
-
-
+You can subscribe to our `Discourse group <https://conda.discourse.group>`__ and post your queries there. The Discourse group is a secondary home for long threads about the ecosystem.


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

I did not see any issues or PR about adding the Discourse group link in the documentation, so I made this PR. The Google Groups link is kept and marked as "archived".

I also see references to "conda-forge@googlegroups.com". If there is a newer email, I can add it to this PR as well.

Let me know if any changes are needed. Thanks!