### PR TITLE
Removed Python 2.7 command from Infrastructure page.

### DIFF
--- a/src/maintainer/infrastructure.rst
+++ b/src/maintainer/infrastructure.rst
@@ -157,16 +157,6 @@ Please open issue on ``regro/cf-scripts`` for any feedback, bugs, and/or questio
 Entering this command in the title or comment of an issue will instruct the admin bot to
 open a PR to disable automerge, undoing the ``please add bot automerge`` command.
 
-@conda-forge-admin, please add python 2.7
------------------------------------------
-
-Entering this command in the title of an issue will instruct the admin bot to
-add Python 2.7 back to a feedstock. Note that this command will remove any other
-Python versions and any ``win``, ``aarch64`` or ``ppc64le`` builds. Thus you should
-merge the PR into a separate branch on your feedstock if you want to keep these
-other builds. **Python 2.7 support is deprecated and any feedstocks on Python 2.7 will
-not be properly handled by our bots.**
-
 @conda-forge-admin, please add user @username
 ---------------------------------------------
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-forge.github.io/issues/1773. Removed 2.7 command from https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-add-python-2-7, as it is no longer supported.
