### PR TITLE
Added Element rooms' links 

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -130,7 +130,7 @@ linkcheck_ignore = [
     r'https://polys.me/?$',  # 403 forbidden
     r'https://app.element.io/#/room/#conda-forge-space:matrix.org',  # needs login
     r'https://anacondacon.io/.*$',  # website is gone
-    r'https://matrix.io/#.*$',  # anchors are generated dynamically
+    r'https://matrix.to/#.*$',  # anchors are generated dynamically
     r'https://app.element.io/#.*$',  # anchors are generated dynamically
     r'https://wave.webaim.org/report#.*$',  # anchors are generated dynamically
 ] + anchor_check_fps

--- a/src/conf.py
+++ b/src/conf.py
@@ -130,7 +130,8 @@ linkcheck_ignore = [
     r'https://polys.me/?$',  # 403 forbidden
     r'https://app.element.io/#/room/#conda-forge-space:matrix.org',  # needs login
     r'https://anacondacon.io/.*$',  # website is gone
-    r'https://matrix.to/#.*$',  # anchors are generated dynamically
+    r'https://matrix.io/#.*$',  # anchors are generated dynamically
+    r'https://app.element.io/#.*$',  # anchors are generated dynamically
     r'https://wave.webaim.org/report#.*$',  # anchors are generated dynamically
 ] + anchor_check_fps
 

--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -30,6 +30,8 @@ The main chat rooms that you'll interact with are
 * `element: interns <https://app.element.io/#/room/#conda-forge_conda-forge-interns:gitter.im>`__: Public chat room for conda-forge interns to discuss projects and seek guidance from the community.
 * `element: general <https://app.element.io/#/room/#conda-forge:matrix.org>`__: Public chat room for the conda-forge community to discuss anything related to conda-forge.
 
+Note: All Gitter room links forward to Element
+
 Mailing List
 -----------------
 

--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -14,7 +14,7 @@ The main issue trackers that you will interact with are
 * `Our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`__: You'll use this repo as a catch-all for issues where you're not sure where else to put them
 * `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`__: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
 
-Gitter
+Gitter and Element
 -----------------
 
 The main chat rooms that you'll interact with are
@@ -26,6 +26,9 @@ The main chat rooms that you'll interact with are
 * `gitter: bot subteam <https://gitter.im/conda-forge/regro-cf-autotick-bot>`__: Public chat room for all things related to the conda-forge automation infrastructure.
   Our automation infrastructure is colloquially referred to as "the bot".
 * `gitter: compilers <https://gitter.im/conda-forge/conda-forge-compilers>`__: Public chat room focused on the conda-forge compiler stack.
+* `element: general <https://app.element.io/#/room/#conda-forge-space:matrix.org>`__: A general chat room for all things conda-forge on Element.
+* `element: interns <https://app.element.io/#/room/#conda-forge_conda-forge-interns:gitter.im>`__: Public chat room for conda-forge interns to discuss projects and seek guidance from the community.
+* `element: community <https://app.element.io/#/room/#conda-forge:matrix.org>`__: Public chat room for the conda-forge community to discuss anything related to conda-forge.
 
 Mailing List
 -----------------

--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -15,7 +15,7 @@ The main issue trackers that you will interact with are
 * `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`__: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
 
 Gitter and Element
------------------
+-------------------------
 
 The main chat rooms that you'll interact with are
 

--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -26,9 +26,9 @@ The main chat rooms that you'll interact with are
 * `gitter: bot subteam <https://gitter.im/conda-forge/regro-cf-autotick-bot>`__: Public chat room for all things related to the conda-forge automation infrastructure.
   Our automation infrastructure is colloquially referred to as "the bot".
 * `gitter: compilers <https://gitter.im/conda-forge/conda-forge-compilers>`__: Public chat room focused on the conda-forge compiler stack.
-* `element: general <https://app.element.io/#/room/#conda-forge-space:matrix.org>`__: A general chat room for all things conda-forge on Element.
+* `element: conda-forge-space <https://app.element.io/#/room/#conda-forge-space:matrix.org>`__: An element space listing all conda-forge rooms.
 * `element: interns <https://app.element.io/#/room/#conda-forge_conda-forge-interns:gitter.im>`__: Public chat room for conda-forge interns to discuss projects and seek guidance from the community.
-* `element: community <https://app.element.io/#/room/#conda-forge:matrix.org>`__: Public chat room for the conda-forge community to discuss anything related to conda-forge.
+* `element: general <https://app.element.io/#/room/#conda-forge:matrix.org>`__: Public chat room for the conda-forge community to discuss anything related to conda-forge.
 
 Mailing List
 -----------------


### PR DESCRIPTION
Fixes -  #1677
Added info about element rooms for [Get in touch](https://conda-forge.org/docs/orga/getting-in-touch.html?highlight=gitter) page.

