### PR TITLE
Replace Gitter chat with Element channel for core team

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -126,7 +126,7 @@ linkcheck_exclude_documents = [r'.*/minutes/.*']
 linkcheck_ignore = [
     r'https://anaconda.org/?$',  # 403 forbidden
     r'https://cloudflare.com/learning/cdn/what-is-a-cdn/?$',  # 403 forbidden
-    r'https://gitter.im/conda-forge/core$',  # private team
+    r'https://app.element.io/#/room/#conda-forge_core:gitter.im$',  # private team
     r'https://polys.me/?$',  # 403 forbidden
     r'https://app.element.io/#/room/#conda-forge-space:matrix.org',  # needs login
     r'https://anacondacon.io/.*$',  # website is gone


### PR DESCRIPTION
Expanding the scope of - https://github.com/conda-forge/conda-forge.github.io/issues/1677

Replacing Gitter chatroom's  link with Element channel's  link.

cc: @jaimergp 

PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
