### PR TITLE
Adding Discourse Link in the documentation website

### DIFF
--- a/src/orga/getting-in-touch.rst
+++ b/src/orga/getting-in-touch.rst
@@ -14,6 +14,14 @@ The main issue trackers that you will interact with are
 * `Our main docs repo <https://github.com/conda-forge/conda-forge.github.io/issues>`__: You'll use this repo as a catch-all for issues where you're not sure where else to put them
 * `Our enhancement proposals repo <https://github.com/conda-forge/cfep/issues>`__: You'll use the enhancement proposals repo if you're interested in substantially changing the way conda-forge operates.
 
+Discussion Forum
+-----------------
+
+The primary discussion areas that you will engage with is
+
+* `discourse forum <https://conda.discourse.group/c/pkg-building/conda-forge/25>`__: We are using discourse as our main communication channel. To ask a question regarding usage of conda we encourage posting to our Discourse forum.
+
+
 Gitter and Element
 -------------------------
 


### PR DESCRIPTION
PR Checklist:
closes #1938
Added Discourse Link in Discussion Forum Section in Getting In Touch Page:

![image](https://github.com/conda-forge/conda-forge.github.io/assets/43810146/2a357ccf-4d64-4d82-a95a-bab8134860bc)

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below
