### PR TITLE
add myself to the docs team

### DIFF
--- a/src/orga/subteams.rst
+++ b/src/orga/subteams.rst
@@ -200,7 +200,7 @@ Members
 - Anthony Scopatz <scopatz@gmail.com>
 - Christian Roth <ch.m.roth@gmail.com>
 - Lori A. Burns <lori.burns@gmail.com>
-
+- Jaime Rodríguez-guerra <jrodriguez@quansight.com>
 
 Staging Sub-Team
 ================


### PR DESCRIPTION
AFAIK this team has no active members right now and I've been doing some documentation work, so I'd like to formally add myself.

The charter is dynamic which means that:

> * A *dynamic* charter means that the sub-team is self-organizing, with respect
  to its own internal policies, procedures, and membership. A sub-team may choose
  to modify its membership independent of the core team

So I guess I'll ask @conda-forge/conda-forge-docs to vote and see what happens :D 