### PR TITLE
add announcement for dropping MacOS<10.13

### DIFF
--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -11,13 +11,13 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2023-08-24: Bumping Minimum MacOS version to 10.13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We will bump the minimum MacOS version from 10.9 (released in Oct. 2013, end-of-life
-since Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020).
-The main reason we managed to support 10.9 this long at all, is that conda-forge is able to ship
-an up-to-date C++ standard library for OSX, ``libcxx``, in its environments, replacing the old one
-in the SDK.
+We will bump the minimum MacOS version from 10.9 (released in Oct. 2013, end-of-life since
+Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020). The main reason we
+managed to support 10.9 this long at all, is that conda-forge is able to ship an up-to-date
+C++ standard library for OSX, ``libcxx``, superseding the old one present in the MacOS SDK
+on the system (at least from the point-of-view of the respective conda environments).
 
-However, several core packages in the ecosystem either now, or will soon, require at least 10.13,
+However, several core packages in the ecosystem now require at least 10.13 (or will very soon),
 in a way that we cannot be circumvent. These packages include ``libcxx``,
 `starting <https://discourse.llvm.org/t/libc-bumping-minimal-deployment-target-for-building-the-dylib-static-library-on-macos/68912>`_
 with version 17.0.

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -13,8 +13,12 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 
 We will bump the minimum MacOS version from 10.9 (released in Oct. 2013, end-of-life
 since Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020).
-Several core packages in the ecosystem either now, or will soon, require at least 10.13.
-These packages include the C++ standard library for OSX itself, ``libcxx``,
+The main reason we managed to support 10.9 this long at all, is that conda-forge is able to ship
+an up-to-date C++ standard library for OSX, ``libcxx``, in its environments, replacing the old one
+in the SDK.
+
+However, several core packages in the ecosystem either now, or will soon, require at least 10.13,
+in a way that we cannot be circumvent. These packages include ``libcxx``,
 `starting <https://discourse.llvm.org/t/libc-bumping-minimal-deployment-target-for-building-the-dylib-static-library-on-macos/68912>`_
 with version 17.0.
 This change will not affect already published artifacts, but in the near future, all new builds

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,6 +8,18 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2023
 ----
 
+2023-08-xx: Dropping support for MacOS <10.13
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Conda-forge tries to support OS versions as long as possible, often far beyond the support of the
+OS vendor. For the last seven years, we have supported a minimal MacOS version of 10.9, despite
+the fact that Apple has released new versions on a yearly basis, and aggressively pushes its users
+to upgrade. One big reason that we have been able to do this at all, is that conda-forge is able
+to ship an up-to-date C++ standard library in its environments, but we have now reached the end of
+the road, as several key projects in the ecosystem are breaking (despite this measure) when
+compiling against such old versions of the SDK.
+
+
 2023-07-12: End-of-life for CentOS 6
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,7 +8,7 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2023
 ----
 
-2023-08-xx: Dropping support for MacOS <10.13
+2023-08-24: Dropping support for MacOS <10.13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Conda-forge tries to support OS versions as long as possible, often far beyond the support of the

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -19,6 +19,9 @@ to ship an up-to-date C++ standard library in its environments, but we have now 
 the road, as several key projects in the ecosystem are breaking (despite this measure) when
 compiling against such old versions of the SDK.
 
+As most things in conda-forge, support for such old versions happens on a best-effort basis, and
+we reserve the right to drop support for old versions as it becomes necessary for various reasons.
+
 
 2023-07-12: End-of-life for CentOS 6
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -23,7 +23,7 @@ in a way that we cannot be circumvent. These packages include ``libcxx``,
 with version 17.0.
 This change will not affect already published artifacts, but in the near future, all new builds
 for OSX will require at least 10.13. This constraint will be implemented through the ``__osx``
-virtual package, but the details of how we will achieve this are still being worked out. Only conda versions 4.8.0 or newer have this virtual package. If you are using a system with MacOS older than 10.13 and are using conda older than 4.8.0, you will need to either upgrade `conda` to at least `4.8.0` or upgrade your system to at least MacOS 10.13.
+virtual package, but the details of how we will achieve this are still being worked out. Only ``conda`` versions 4.8.0 or newer have this virtual package. If you are using a system with MacOS older than 10.13 and are using ``conda`` older than 4.8.0, you will need to either upgrade ``conda`` to at least 4.8.0 or upgrade your system to at least MacOS 10.13.
 
 
 2023-07-12: End-of-life for CentOS 6

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -11,8 +11,15 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2023-08-24: Bumping Minimum MacOS version to 10.13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We will bump the minimum MacOS version from 10.9 (released in
-Oct. 2013, end-of-life since Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020). Several core packages in the ecosystem either now, or will soon, require at least 10.13. These packages include the C++ standard library for OSX itself, ``libcxx``, starting with version 17. (**TODO: link to RFC from llvm**) This change will not affect already published artifacts, but in the near future, all new builds for OSX will require at least 10.13. This constraint will be implemented through the ``__osx`` virtual package, but the details of how we will achieve this are still being worked out.
+We will bump the minimum MacOS version from 10.9 (released in Oct. 2013, end-of-life
+since Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020).
+Several core packages in the ecosystem either now, or will soon, require at least 10.13.
+These packages include the C++ standard library for OSX itself, ``libcxx``,
+`starting <https://discourse.llvm.org/t/libc-bumping-minimal-deployment-target-for-building-the-dylib-static-library-on-macos/68912>`_
+with version 17.0.
+This change will not affect already published artifacts, but in the near future, all new builds
+for OSX will require at least 10.13. This constraint will be implemented through the ``__osx``
+virtual package, but the details of how we will achieve this are still being worked out.
 
 
 2023-07-12: End-of-life for CentOS 6

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -20,7 +20,7 @@ the road, as several key projects in the ecosystem are breaking (despite this me
 compiling against such old versions of the SDK.
 
 As most things in conda-forge, support for such old versions happens on a best-effort basis, and
-we reserve the right to drop support for old versions as it becomes necessary for various reasons.
+and unfortunately there comes a point when it is no longer practical to support certain systems.
 
 
 2023-07-12: End-of-life for CentOS 6

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -23,7 +23,7 @@ in a way that we cannot be circumvent. These packages include ``libcxx``,
 with version 17.0.
 This change will not affect already published artifacts, but in the near future, all new builds
 for OSX will require at least 10.13. This constraint will be implemented through the ``__osx``
-virtual package, but the details of how we will achieve this are still being worked out.
+virtual package, but the details of how we will achieve this are still being worked out. Only conda versions 4.8.0 or newer have this virtual package. If you are using a system with MacOS older than 10.13 and are using conda older than 4.8.0, you will need to either upgrade `conda` to at least `4.8.0` or upgrade your system to at least MacOS 10.13.
 
 
 2023-07-12: End-of-life for CentOS 6

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -12,12 +12,18 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Conda-forge tries to support OS versions as long as possible, often far beyond the support of the
-OS vendor. For the last seven years, we have supported a minimal MacOS version of 10.9, despite
-the fact that Apple has released new versions on a yearly basis, and aggressively pushes its users
-to upgrade. One big reason that we have been able to do this at all, is that conda-forge is able
-to ship an up-to-date C++ standard library in its environments, but we have now reached the end of
-the road, as several key projects in the ecosystem are breaking (despite this measure) when
-compiling against such old versions of the SDK.
+OS vendor. For the last seven years, we have supported a minimal MacOS version of 10.9 (released in
+Oct. 2013, end-of-life since Dec. 2016), despite the fact that Apple has released new versions on a
+yearly basis, and aggressively pushes its users to upgrade.
+
+One big reason that we have been able to do this at all, is that conda-forge is able to ship an
+up-to-date C++ standard library in its environments. However, have now reached the end of the road
+on this, as several key projects in the ecosystem are breaking despite this measure when compiling
+(or even just running!) against such old versions of the SDK.
+
+For now we are doing the absolute minimum bump which is necessary to unblock those key packages.
+It's worth noting that this does not affect already-published artifacts, but going forward, our
+builds will require at least MacOS 10.13 (released Sept. 2017, end-of-life since Dec. 2020).
 
 As most things in conda-forge, support for such old versions happens on a best-effort basis, and
 and unfortunately there comes a point when it is no longer practical to support certain systems.

--- a/src/user/announcements.rst
+++ b/src/user/announcements.rst
@@ -8,25 +8,11 @@ Our announcements are published to an RSS feed `here <https://conda-forge.org/do
 2023
 ----
 
-2023-08-24: Dropping support for MacOS <10.13
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2023-08-24: Bumping Minimum MacOS version to 10.13
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Conda-forge tries to support OS versions as long as possible, often far beyond the support of the
-OS vendor. For the last seven years, we have supported a minimal MacOS version of 10.9 (released in
-Oct. 2013, end-of-life since Dec. 2016), despite the fact that Apple has released new versions on a
-yearly basis, and aggressively pushes its users to upgrade.
-
-One big reason that we have been able to do this at all, is that conda-forge is able to ship an
-up-to-date C++ standard library in its environments. However, have now reached the end of the road
-on this, as several key projects in the ecosystem are breaking despite this measure when compiling
-(or even just running!) against such old versions of the SDK.
-
-For now we are doing the absolute minimum bump which is necessary to unblock those key packages.
-It's worth noting that this does not affect already-published artifacts, but going forward, our
-builds will require at least MacOS 10.13 (released Sept. 2017, end-of-life since Dec. 2020).
-
-As most things in conda-forge, support for such old versions happens on a best-effort basis, and
-and unfortunately there comes a point when it is no longer practical to support certain systems.
+We will bump the minimum MacOS version from 10.9 (released in
+Oct. 2013, end-of-life since Dec. 2016) to 10.13 (released Sept. 2017, end-of-life since Dec. 2020). Several core packages in the ecosystem either now, or will soon, require at least 10.13. These packages include the C++ standard library for OSX itself, ``libcxx``, starting with version 17. (**TODO: link to RFC from llvm**) This change will not affect already published artifacts, but in the near future, all new builds for OSX will require at least 10.13. This constraint will be implemented through the ``__osx`` virtual package, but the details of how we will achieve this are still being worked out.
 
 
 2023-07-12: End-of-life for CentOS 6


### PR DESCRIPTION
First step according to the TODO List [here](https://github.com/conda-forge/conda-forge.github.io/issues/1844#issuecomment-1675953297).

While the stance of upstream CPython does not affect our infrastructure & metadata per se, it's worth noting that [discussion](https://discuss.python.org/t/moving-packaging-and-installers-to-macos-10-13-as-a-minimum/31907) on DPO started by @jakirkham to this effect is still fresh, and it sounds like CPython will also upgrade "in the not too distant future", and might jump even further (e.g. 10.15 or 11.0). We can still choose to follow suit with such a step later on, but moving to 10.13 now is (effectively) necessary to unblock abseil, grpc, protobuf, (and soon) libcxx etc., so IMO we shouldn't wait for however long CPython takes to come to a decision on that.

I've added a second commit that clarifies our support stance (pointing out how it is "best effort"), but I can drop that if anyone disagrees.