### PR TITLE
fix `docs/` link while we are serving raw Sphinx

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -96,7 +96,7 @@ export default function Stats() {
             <div className={styles.about_video_description}>
                 <p>
                     Learn more about conda-forge by reading our{" "}
-                    <Link to="/docs">docs</Link> or watching the following
+                    <Link to="pathname:///docs/">docs</Link> or watching the following
                     episode of{" "}
                     <Link to="https://www.quansight.com/open-source-directions">
                         Open Source Directions


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

And one more fix to alleviate SPA routing issues. This kind of workaround is only necessary while we are publishing the raw Sphinx sources. It will be just `/docs` when we serve it via native Docusaurus.