### PR TITLE
Fix capitalization of "conda" and make it a link to conda.org.

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -21,7 +21,7 @@ export default function Header() {
                     Community-led <span className="gradient_text">recipes</span>
                     , <span className="gradient_text">infrastructure</span> and{" "}
                     <span className="gradient_text">distributions</span> for
-                    Conda.
+                    <Link to="https://conda.org/">conda</Link>.
                 </h1>
                 <div className={styles.header_content_input}>
                     <Link


### PR DESCRIPTION
PR Checklist:

- ~[ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)~
- [x] put any other relevant information below

Reference: https://github.com/conda-incubator/ceps#conda-capitalization-standards

