### PR TITLE
Fix: Add space between "for" and "conda"

### DIFF
--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -20,7 +20,7 @@ export default function Header() {
                 <h1>
                     Community-led <span className="gradient_text">recipes</span>
                     , <span className="gradient_text">infrastructure</span> and{" "}
-                    <span className="gradient_text">distributions</span> for
+                    <span className="gradient_text">distributions</span> for{" "}
                     <Link to="https://conda.org/">conda</Link>.
                 </h1>
                 <div className={styles.header_content_input}>


### PR DESCRIPTION
Currently the homepage doesn't have a space between "for" and the "conda" link:
<img width="1750" alt="Screenshot 2024-01-13 at 9 19 56 AM" src="https://github.com/conda-forge/conda-forge.github.io/assets/1186124/9d05e0e7-e8bf-4e35-a5e4-f3ed2a95d982">

This PR adds an explicit space there.
