### PR TITLE
Render latest package updates in `/packages` search

### DIFF
--- a/src/components/Packages/index.jsx
+++ b/src/components/Packages/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import Admonition from "@docusaurus/theme-classic/lib/theme/Admonition";
 
 // Function to calculate the Levenshtein distance between two strings
 function levenshteinDistance(a, b) {
@@ -49,13 +50,16 @@ function highlightSubstring(str, substr) {
 }
 
 const Packages = () => {
-  const [packages, setPackages] = useState([]);
+  const [allPackages, setAllPackages] = useState([]);
+  const [latestPackages, setLatestPackages] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchAllData = async () => {
       try {
-        const response = await fetch("https://raw.githubusercontent.com/conda-forge/feedstock-outputs/gh-pages/feedstock-outputs.json");
+        const response = await fetch(
+          "https://raw.githubusercontent.com/conda-forge/feedstock-outputs/single-file/feedstock-outputs.json"
+        );
         const data = await response.json();
 
         if (typeof data === "object" && data !== null) {
@@ -65,7 +69,7 @@ const Packages = () => {
             repos,
           }));
 
-          setPackages(packagesArray);
+          setAllPackages(packagesArray);
         } else {
           console.error("Invalid data format. Expected an object.");
         }
@@ -73,21 +77,48 @@ const Packages = () => {
         console.error("Error fetching packages:", error);
       }
     };
-
-    fetchData();
+    const fetchLatestData = async () => {
+      try {
+        const response = await fetch(
+          "https://conda.anaconda.org/conda-forge/rss.xml"
+        );
+        // parse the RSS feed into an XML document
+        const xml = await response.text();
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(xml, "text/xml");
+        const titles = doc.querySelectorAll("title");
+        const dates = doc.querySelectorAll("pubDate");
+        // Convert the object into an array of { name, date } objects
+        var latestPackagesArray = [];
+        // The first 'title' element is the feed title, so we skip it
+        titles.forEach(
+          (title, index) =>
+            index &&
+            latestPackagesArray.push({
+              name: title.textContent.split(" ")[0],
+              date: dates[index - 1].textContent,
+            })
+        );
+        setLatestPackages(latestPackagesArray);
+      } catch (error) {
+        console.error("Error fetching latest packages:", error);
+      }
+    };
+    fetchLatestData();
+    fetchAllData();
   }, []);
 
   const searchTermLower = searchTerm.toLowerCase();
   var filteredPackages = [];
   if (searchTerm.length >= 3) {
     // For queries with three or more characters, search the entire string for a match
-    filteredPackages = packages.filter((pkg) =>
+    filteredPackages = allPackages.filter((pkg) =>
       pkg.name.toLowerCase().includes(searchTermLower)
     );
   } else if (searchTerm.length > 0) {
     // For queries with less than three characters,
     // only search if the package name starts with the query for performance reasons
-    filteredPackages = packages.filter((pkg) =>
+    filteredPackages = allPackages.filter((pkg) =>
       pkg.name.toLowerCase().startsWith(searchTermLower)
     );
   }
@@ -108,16 +139,122 @@ const Packages = () => {
     setSearchTerm(event.target.value);
   };
 
+  var renderResultsBlock;
+  var resultsPill;
+  if (searchTerm.length) {
+    // This is the results table, displayed when the user enters a search term
+    renderResultsBlock = (
+      <table>
+        <thead>
+          <tr>
+            <th>Package</th>
+            <th>Feedstock(s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(filteredPackages.length &&
+            filteredPackages.map((pkg) => (
+              <tr key={pkg.name}>
+                <td>
+                  <a
+                    href={`https://anaconda.org/conda-forge/${pkg.name}`}
+                    target="_blank"
+                    title={`View ${pkg.name} on anaconda.org`}
+                  >
+                    {highlightSubstring(pkg.name, searchTermLower)}
+                  </a>
+                </td>
+                <td>
+                  {pkg.repos.map((repo) => (
+                    <span>
+                      <a
+                        href={`https://github.com/conda-forge/${repo}-feedstock`}
+                        target="_blank"
+                        title={`View ${repo}-feedstock on GitHub`}
+                      >
+                        {repo}-feedstock
+                      </a>
+
+                      <br />
+                    </span>
+                  ))}
+                </td>
+              </tr>
+            ))) || (
+            <tr>
+              <td colSpan="2">No packages found</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    );
+    resultsPill = (
+      <span className="badge badge--info margin-left--sm">
+        {filteredPackages.length} package(s) found
+      </span>
+    );
+  } else {
+    // Without a search term, display the most recently updated feedstocks
+    renderResultsBlock = (
+      <div>
+        <Admonition type="tip" coll>
+          <p>
+            The following packages have been published to{" "}
+            <a href="https://anaconda.org/conda-forge" target="_blank">
+              Anaconda.org
+            </a>{" "}
+            recently.
+            Check{" "}
+            <a href="https://github.com/conda-forge/feedstock/commits">
+              conda-forge/feedstocks
+            </a>{" "}
+            for the last updates in our feedstocks.
+          </p>
+        </Admonition>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Package</th>
+              <th>Feedstock</th>
+              <th>Last updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {latestPackages.map((item, index) => (
+              <tr key={item.name}>
+                <td>{index + 1}</td>
+                <td>
+                  <a
+                    href={`https://anaconda.org/conda-forge/${item.name}`}
+                    target="_blank"
+                  >
+                    {item.name}
+                  </a>
+                </td>
+                <td>...</td>
+                <td>{item.date}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+    resultsPill = (
+      <span className="badge badge--success margin-left--sm">
+        {allPackages.length} packages loaded
+      </span>
+    );
+  }
+
   return (
-    <div
-      className={["container", "margin-vert--lg"].join(" ")}
-    >
+    <div className={["container", "margin-vert--lg"].join(" ")}>
       <div className="row">
         <main className="col col--12">
           <h1>Packages in conda-forge</h1>
-          <form className="margin-vert--md">
+          <form id="filterPackages" className="margin-vert--md">
             <div className="navbar__search">
-              <label htmlFor="search">
+              <label htmlFor="filterPackages">
                 <input
                   type="text"
                   placeholder="Filter items..."
@@ -125,61 +262,11 @@ const Packages = () => {
                   onChange={handleSearchChange}
                   className="navbar__search-input"
                 />
-                {(searchTerm.length && (
-                  <span class="badge badge--info margin-left--sm">
-                    {filteredPackages.length} package(s) found
-                  </span>
-                )) || (
-                  <span class="badge badge--success margin-left--sm">
-                    {packages.length} packages loaded
-                  </span>
-                )}
+                {resultsPill}
               </label>
             </div>
           </form>
-          <table>
-            <thead>
-              <tr>
-                <th>Package</th>
-                <th>Feedstock(s)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {(filteredPackages.length &&
-                filteredPackages.map((pkg) => (
-                  <tr key={pkg.name}>
-                    <td>
-                        <a
-                          href={`https://anaconda.org/conda-forge/${pkg.name}`}
-                          target="_blank"
-                          title={`View ${pkg.name} on anaconda.org`}
-                        >
-                          {highlightSubstring(pkg.name, searchTermLower)}
-                        </a>
-                    </td>
-                    <td>
-                      {pkg.repos.map((repo) => (
-                        <span>
-                          <a
-                            href={`https://github.com/conda-forge/${repo}-feedstock`}
-                            target="_blank"
-                            title={`View ${repo}-feedstock on GitHub`}
-                          >
-                            {repo}-feedstock
-                          </a>
-
-                          <br />
-                        </span>
-                      ))}
-                    </td>
-                  </tr>
-                ))) || (
-                <tr>
-                  <td colSpan="2">Use the search bar to find packages</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+          {renderResultsBlock}
         </main>
       </div>
     </div>

--- a/src/components/Packages/index.jsx
+++ b/src/components/Packages/index.jsx
@@ -273,8 +273,9 @@ const Packages = () => {
           <h1>Packages in conda-forge</h1>
           <form id="filterPackages" className="margin-vert--md">
             <div className="navbar__search">
-              <label htmlFor="filterPackages">
+              <label htmlFor="filterPackagesInput">
                 <input
+                  id="filterPackagesInput"
                   type="text"
                   placeholder="Filter items..."
                   value={searchTerm}

--- a/src/components/Packages/index.jsx
+++ b/src/components/Packages/index.jsx
@@ -186,7 +186,7 @@ const Packages = () => {
       </table>
     );
     resultsPill = (
-      <span className="badge badge--info margin-left--sm">
+      <span className="badge badge--secondary margin-left--sm">
         {filteredPackages.length} package(s) found
       </span>
     );
@@ -260,7 +260,7 @@ const Packages = () => {
       </div>
     );
     resultsPill = (
-      <span className="badge badge--success margin-left--sm">
+      <span className="badge badge--secondary margin-left--sm">
         {Object.keys(allPackages).length} packages loaded
       </span>
     );

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,7 +63,7 @@
   --ifm-color-info: #64b5f6;
   --ifm-color-warning: #ffb74d;
   --ifm-color-danger: #ff8a65;
-  --ifm-badge-color: var(--ifm-background-color);
+  --ifm-badge-color: var(--ifm-color-black);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --gradient: linear-gradient(
     60deg,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -63,6 +63,7 @@
   --ifm-color-info: #64b5f6;
   --ifm-color-warning: #ffb74d;
   --ifm-color-danger: #ff8a65;
+  --ifm-badge-color: var(--ifm-background-color);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --gradient: linear-gradient(
     60deg,


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] put any other relevant information below

- Follow up on #2064 
- Part of #1971 


We fetch Anaconda.org's RSS feed and parse it, to render a welcome page in the `/packages` browser. This should also help folks see which packages have been recently uploaded, in case they are investigating a CI breakage or similar :) 

This is how it looks:

![image](https://github.com/conda-forge/conda-forge.github.io/assets/2559438/2b599b98-06f8-4932-bbde-0ad236e5c47f)

![image](https://github.com/conda-forge/conda-forge.github.io/assets/2559438/fa7321be-52e4-4967-ab3a-f13d8b8c2aea)

