### PR TITLE
Add a dummy query parameter to the RSS feed URL to bypass the cache

### DIFF
--- a/src/components/Packages/index.jsx
+++ b/src/components/Packages/index.jsx
@@ -80,8 +80,10 @@ const Packages = () => {
     };
     const fetchLatestData = async () => {
       try {
+        // Fetch the RSS feed from conda-forge. We add a cache-busting query parameter
+        // to ensure we always get the latest data. Otherwise, the data gets stuck in time.
         const response = await fetch(
-          "https://conda.anaconda.org/conda-forge/rss.xml"
+          `https://conda.anaconda.org/conda-forge/rss.xml?bustcache=${Date.now()}`
         );
         // parse the RSS feed into an XML document
         const xml = await response.text();


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

Resolves issue where `/packages` gets stuck in time. I also tried setting `{ cache: 'no-store' }` and different kinds of headers, but it didn't work. Only this URL hack does it 🤷 