### PR TITLE
fix _static files location

### DIFF
--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -22,7 +22,7 @@ popd
 # Move rendered Sphinx markdown to Docusaurus
 python "$BASE_DIR/.ci_scripts/sphinx_markdown_to_docusaurus.py" "$BASE_DIR/sphinx/src/_build/markdown" docs/
 mkdir -p "$BASE_DIR/static-sphinx/_static"
-cp -r "$BASE_DIR/sphinx/src/_static" "$BASE_DIR/static-sphinx/"
+cp -r "$BASE_DIR/sphinx/src/_static/" "$BASE_DIR/static-sphinx/_static"
 # Build docusaurus site
 npm install
 npm run build

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -22,7 +22,7 @@ popd
 # Move rendered Sphinx markdown to Docusaurus
 python "$BASE_DIR/.ci_scripts/sphinx_markdown_to_docusaurus.py" "$BASE_DIR/sphinx/src/_build/markdown" docs/
 mkdir -p "$BASE_DIR/static-sphinx/_static"
-cp -r "$BASE_DIR/sphinx/src/_static/" "$BASE_DIR/static-sphinx/_static/"
+cp -r "$BASE_DIR/sphinx/src/_static/" "$BASE_DIR/static-sphinx/_static"
 # Build docusaurus site
 npm install
 npm run build
@@ -30,3 +30,6 @@ npm run build
 # Serve the announcements RSS feed in this old location too
 # we can't redirect with the Docusaurus plugin, so just copy it
 cp build/news/rss.xml build/docs/news.rss
+
+echo "Built website! Preview at http://localhost:8000 with:"
+echo "  python -m http.server -d build/"

--- a/.ci_scripts/update_docs
+++ b/.ci_scripts/update_docs
@@ -22,7 +22,7 @@ popd
 # Move rendered Sphinx markdown to Docusaurus
 python "$BASE_DIR/.ci_scripts/sphinx_markdown_to_docusaurus.py" "$BASE_DIR/sphinx/src/_build/markdown" docs/
 mkdir -p "$BASE_DIR/static-sphinx/_static"
-cp -r "$BASE_DIR/sphinx/src/_static/" "$BASE_DIR/static-sphinx/_static"
+cp -r "$BASE_DIR/sphinx/src/_static" "$BASE_DIR/static-sphinx/"
 # Build docusaurus site
 npm install
 npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           lycheeVersion: '0.14.3'
           args: >
             --no-progress
+            --base "$(pwd)/build"
             --exclude 'https://polys.me/?$'
             --exclude 'https://kb43fqob7u-dsn.algolia.net/'
             --exclude '.*/404.html/'


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] put any other relevant information below

Part of #1971. I had tested this locally but oh surprise, `cp` behaviour differs in macOS and Linux. We were also missing the relative paths 404 checks, but that's fixed here too. This shouldn't happen again :)