### PR TITLE
docs: `native` CI Service in conda-forge.yml Provider Section

### DIFF
--- a/docs/maintainer/conda_forge_yml.md
+++ b/docs/maintainer/conda_forge_yml.md
@@ -571,7 +571,7 @@ The following CI services are available:
 * `github_actions`
 * `None` or `False` to disable a build platform.
 * `default` to choose an appropriate CI (only if available)
-* `native` to choose an appropriate CI for native compiling (only for `linux_aarch64` and `linux_ppc64le`)
+* `native` to choose an appropriate CI for native compiling (only if available)
 
 Note that `github_actions` is not available for the conda-forge github organization
 except for self-hosted runs to avoid a denial of service due to other critical

--- a/docs/maintainer/conda_forge_yml.md
+++ b/docs/maintainer/conda_forge_yml.md
@@ -571,6 +571,7 @@ The following CI services are available:
 * `github_actions`
 * `None` or `False` to disable a build platform.
 * `default` to choose an appropriate CI (only if available)
+* `native` to choose an appropriate CI for native compiling (only for `linux_aarch64` and `linux_ppc64le`)
 
 Note that `github_actions` is not available for the conda-forge github organization
 except for self-hosted runs to avoid a denial of service due to other critical


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/`, you have added it to the sidebar in `docs/sidebar.json`
- [x] put any other relevant information below

The `native` CI service option in the `provider` section of `conda-forge.yml` is currently undocumented. This is fixed by this PR.

Relevant source code: [conda_smithy/configure_feedstock.py](https://github.com/conda-forge/conda-smithy/blob/63ae4123df0a8b8ae035b0694a3f1e00d47d9ad0/conda_smithy/configure_feedstock.py#L2268-L2281)

Since the `linux_s930x` platform is not documented and used by not a single conda-forge feedstock, I intentionally did not add it to the list of supported platforms for the `native` option.
