### PR TITLE
docs: `emulated` CI Service in conda-forge.yml Provider Section

### DIFF
--- a/docs/maintainer/conda_forge_yml.md
+++ b/docs/maintainer/conda_forge_yml.md
@@ -572,6 +572,7 @@ The following CI services are available:
 * `None` or `False` to disable a build platform.
 * `default` to choose an appropriate CI (only if available)
 * `native` to choose an appropriate CI for native compiling (only if available)
+* `emulated` to choose an appropriate CI for compiling inside an emulation of the target platform (only if avalable)
 
 Note that `github_actions` is not available for the conda-forge github organization
 except for self-hosted runs to avoid a denial of service due to other critical


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/`, you have added it to the sidebar in `docs/sidebar.json`
- [x] put any other relevant information below

The emulated CI service option in the provider section of conda-forge.yml is currently undocumented. This is fixed by this PR.

Relevant source code: [conda_smithy/configure_feedstock.py](https://github.com/conda-forge/conda-smithy/blob/63ae4123df0a8b8ae035b0694a3f1e00d47d9ad0/conda_smithy/configure_feedstock.py#L2301-L2305)

@xhochy