### PR TITLE
Update migration details to also use "PRs made"

### DIFF
--- a/src/components/MigrationDetails/index.jsx
+++ b/src/components/MigrationDetails/index.jsx
@@ -107,7 +107,7 @@ function Bar({ details }) {
   const prefix = "migration_details_filter_";
   return (
     <>
-      <h4>Completion rate {details.progress.percentage.toFixed(0)}%</h4>
+      <h4>PRs made {details.progress.percentage.toFixed(0)}%</h4>
       <div className={styles.migration_details_bar}>
         {ORDERED.filter(([key]) => details[key]?.length)
           .map(([key], index) => (


### PR DESCRIPTION
Applies the same suggestion ( https://github.com/conda-forge/conda-forge.github.io/pull/2090#discussion_r1515284432 ) from the table of migrations to the details page for a specific migration

<hr>

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
