### PR TITLE
Add back done column to migrations table

### DIFF
--- a/src/components/StatusDashboard/current_migrations.jsx
+++ b/src/components/StatusDashboard/current_migrations.jsx
@@ -118,6 +118,12 @@ function TableContent({ collapsed, name, resort, rows, select, sort }) {
             PRs made
           </th>
           <th
+            onClick={() => resort("done")}
+            className={sort.by === "done" ? styles[sort.order] : undefined}
+          >
+            Done
+          </th>
+          <th
             onClick={() => resort("in-pr")}
             className={sort.by === "in-pr" ? styles[sort.order] : undefined}
           >
@@ -173,6 +179,7 @@ function TableContent({ collapsed, name, resort, rows, select, sort }) {
                   </span>
                 </label>
               </td>
+              <td>{row.details["done"].length}</td>
               <td>{row.details["in-pr"].length}</td>
               <td>{row.details["awaiting-pr"].length}</td>
               <td>{row.details["awaiting-parents"].length}</td>

--- a/src/components/StatusDashboard/current_migrations.jsx
+++ b/src/components/StatusDashboard/current_migrations.jsx
@@ -99,7 +99,7 @@ function TableContent({ collapsed, name, resort, rows, select, sort }) {
     <>
       <thead>
         <tr onClick={select}>
-          <th colSpan={7} className={collapsed ? styles.collapsed : undefined}>
+          <th colSpan={8} className={collapsed ? styles.collapsed : undefined}>
             {name}{" "}
             <span className="badge badge--secondary">{rows.length || "…"}</span>
           </th>


### PR DESCRIPTION
It looks like we lost the done column in the migration table. Attempting to add it back here.

xref: https://github.com/conda-forge/conda-forge.github.io/pull/2090

<hr>

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
