### PR TITLE
Fix a few errant runtime errors

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -70,8 +70,9 @@ export default function Stats() {
             <div className={styles.stats_container}>
                 <div className={styles.stats1_card}>
                     {stats1.map(({ number, content }, index) => (
-                        <Link to="https://github.com/conda-forge/by-the-numbers">
-                            <div className={styles.card} key={index}>
+                        <Link key={index}
+                            to="https://github.com/conda-forge/by-the-numbers">
+                            <div className={styles.card}>
                                 <h1 className="gradient_text">{number}</h1>
                                 <h3>{content}</h3>
                             </div>
@@ -80,8 +81,9 @@ export default function Stats() {
                 </div>
                 <div className={styles.stats2_card}>
                     {stats2.map(({ number, content }, index) => (
-                        <Link to="https://github.com/conda-forge/by-the-numbers">
-                            <div className={styles.card} key={index}>
+                        <Link key={index}
+                            to="https://github.com/conda-forge/by-the-numbers">
+                            <div className={styles.card}>
                                 <h1 className="gradient_text">{number}</h1>
                                 <h3>{content}</h3>
                             </div>
@@ -104,9 +106,9 @@ export default function Stats() {
                 <iframe
                     src="https://www.youtube.com/embed/EWh-BtdYE7M"
                     title="Episode 23: conda-forge - Open Source Directions hosted By Quansight"
-                    frameborder="0"
+                    style={{ border: 0 }}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    allowfullscreen
+                    allowFullScreen
                 ></iframe>
             </div>
         </div>

--- a/src/components/Contributing/index.jsx
+++ b/src/components/Contributing/index.jsx
@@ -37,16 +37,8 @@ const contributing = [
         href: "https://app.element.io/#/room/#conda-forge:matrix.org",
         content: (
             <>
-                Join the{" "}
-                <a
-                    href="https://app.element.io/#/room/#conda-forge:matrix.org"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    {" "}
-                    conda-forge community{" "}
-                </a>{" "}
-                on Element and reach out for assistance whenever needed.
+                Join the conda-forge community on Element and reach out for{" "}
+                assistance whenever needed.
             </>
         ),
         width: 50,

--- a/src/components/Supporters/index.jsx
+++ b/src/components/Supporters/index.jsx
@@ -180,8 +180,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {financial.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link to={link} key={index}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}
@@ -205,8 +205,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {infrastructure.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link key={index} to={link}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}
@@ -230,8 +230,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {developer.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link key={index} to={link}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}


### PR DESCRIPTION
There are a few runtime errors in the front page of the new site. This PR fixes those. There are no visible changes to for end users.

They are primarily React `key` errors (where the `key` was one layer deeper than it should have been, probably after a refactor.

There was also one errant `<a>` tag embedded within a `<Link>` component, which generates an error because it results in:

```
<a href...>
  <a href...></a>
</a>
```

<img width="402" alt="Screenshot 2024-03-12 at 09 34 53" src="https://github.com/conda-forge/conda-forge.github.io/assets/159529/8efd3206-7169-4fa7-8d1f-a78719230472">
