### PR TITLE
Add some explanatory text about the installers

### DIFF
--- a/src/components/Download/index.jsx
+++ b/src/components/Download/index.jsx
@@ -65,7 +65,7 @@ export default function Download() {
               }
           });
           console.log(latest);
-          if (latest.data ) {
+          if (latest.data) {
               setDescription(latest.data.body);
               setVersion(latest.data.tag_name);
           }

--- a/src/components/Download/index.jsx
+++ b/src/components/Download/index.jsx
@@ -1,8 +1,9 @@
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import Link from "@docusaurus/Link";
 import ThemedImage from "@theme/ThemedImage";
-import React from "react";
+import React, { setState, useState, useEffect } from "react";
 import styles from "./styles.module.css";
+import { Octokit } from "octokit";
 
 export default function Download() {
   const downloads = [
@@ -49,32 +50,63 @@ export default function Download() {
           os: "Windows",
       }
   ];
+  const [description, setDescription] = useState(null);
+  const [version, setVersion] = useState(null);
+
+  useEffect(() => {
+      async function getDescription() {
+          setDescription(null);
+          const octokit = new Octokit({});
+          const latest = await octokit.request('GET /repos/conda-forge/miniforge/releases/latest', {
+              owner: 'conda-forge',
+              repo: 'miniforge',
+              headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+              }
+          });
+          console.log(latest);
+          if (latest.data ) {
+              setDescription(latest.data.body);
+              setVersion(latest.data.tag_name);
+          }
+      }
+      getDescription();
+  }, [])
+
   return (
-    <div className={[styles.header, styles.section_padding].join(" ")}>
-        <div className={styles.header_content}>
-          {downloads.map(({ arch, dark, href, light, os }, index) => (
-            <Link to={href} key={index}>
-                <div className={styles.cardWrapper}>
-                  <div className={styles.card}>
-                    <ThemedImage
-                      className={styles.os_image}
-                      alt={`${os} logo`}
-                      title={`Download miniforge installer for ${os} ${arch}`}
-                      sources={{
-                        dark: useBaseUrl(`${dark}`),
-                        light: useBaseUrl(`${light}`),
-                      }}
-                      height={75}
-                      style={{ paddingRight: 20 }}
-                  />
-                  <div>
-                      <p className={styles.os}>{os}</p>
-                      <code className={styles.arch}>{arch}</code>
-                  </div>
-                  </div>
-                </div>
-            </Link>
-          ))}
+    <div>
+        <h2>
+            Miniforge Latest Release (Version {version})
+        </h2>
+        <p>
+            This version includes: {description}.
+        </p>
+        <div className={[styles.header, styles.section_padding].join(" ")}>
+          <div className={styles.header_content}>
+           {downloads.map(({ arch, dark, href, light, os }, index) => (
+             <Link to={href} key={index}>
+                 <div className={styles.cardWrapper}>
+                   <div className={styles.card}>
+                     <ThemedImage
+                       className={styles.os_image}
+                       alt={`${os} logo`}
+                       title={`Download miniforge installer for ${os} ${arch}`}
+                       sources={{
+                         dark: useBaseUrl(`${dark}`),
+                         light: useBaseUrl(`${light}`),
+                       }}
+                       height={75}
+                       style={{ paddingRight: 20 }}
+                   />
+                   <div>
+                       <p className={styles.os}>{os}</p>
+                       <code className={styles.arch}>{arch}</code>
+                   </div>
+                   </div>
+                 </div>
+             </Link>
+           ))}
+          </div>
         </div>
     </div>
   );

--- a/src/components/Download/index.jsx
+++ b/src/components/Download/index.jsx
@@ -51,15 +51,6 @@ export default function Download() {
   ];
   return (
     <div className={[styles.header, styles.section_padding].join(" ")}>
-        <div className={styles.header_image}>
-            <ThemedImage
-                alt="3D-Anvil illustration for conda-forge"
-                sources={{
-                  light: useBaseUrl("/img/anvil-light.svg"),
-                  dark: useBaseUrl("/img/anvil-dark.svg"),
-                }}
-            />
-        </div>
         <div className={styles.header_content}>
           {downloads.map(({ arch, dark, href, light, os }, index) => (
             <Link to={href} key={index}>

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -21,7 +21,23 @@ export default function Home() {
                     <p>
                         If more packages are needed, use the <code>conda install</code> or <code>mamba install</code> command to install from the thousands of packages available in the conda-forge distribution. Isolated environments can be created with <code>conda create</code> or <code>mamba create</code>.
                     </p>
-                <Download />
+                    <Download />
+                    <h1>
+                        Installation
+                    </h1>
+                    <p>Basic installation instructions are available below. More detailed instructions are available <a href="https://github.com/conda-forge/miniforge/?tab=readme-ov-file#install">here</a>.</p>
+                    <h2>
+                        Unix-like platforms (Mac OS & Linux)
+                    </h2>
+                    <p>
+                        Download the installer and run <code>bash Miniforge3-$(uname)-$(uname -m).sh</code>
+                    </p>
+                    <h2>
+                        Windows
+                    </h2>
+                    <p>
+                        Download and execute the Windows installer.
+                    </p>
                 </main>
             </div>
         </Layout>

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -10,14 +10,20 @@ export default function Home() {
             title={siteConfig.title}
             description="Download page for the conda-forge installer"
         >
-            <main>
-                <h1 style={{
-                    marginTop: 10, textAlign: "center"
-                }}>
-                    Download the conda-forge Installer
-                </h1>
+            <div className="container margin-vert--lg" >
+                <main>
+                    <h1>
+                        Download the conda-forge Installer
+                    </h1>
+                    <p>
+                        Miniforge is a minimal installer for a conda-forge-based distribution, including conda, mamba, and their dependencies.
+                    </p>
+                    <p>
+                        If more packages are needed, use the <code>conda install</code> or <code>mamba install</code> command to install from the thousands of packages available in the conda-forge distribution.
+                    </p>
                 <Download />
-            </main>
+                </main>
+            </div>
         </Layout>
     );
 }

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -19,7 +19,7 @@ export default function Home() {
                         Miniforge is a minimal installer for a conda-forge-based distribution, including conda, mamba, and their dependencies.
                     </p>
                     <p>
-                        If more packages are needed, use the <code>conda install</code> or <code>mamba install</code> command to install from the thousands of packages available in the conda-forge distribution.
+                        If more packages are needed, use the <code>conda install</code> or <code>mamba install</code> command to install from the thousands of packages available in the conda-forge distribution. Isolated environments can be created with <code>conda create</code> or <code>mamba create</code>.
                     </p>
                 <Download />
                 </main>

--- a/src/pages/download.jsx
+++ b/src/pages/download.jsx
@@ -16,7 +16,7 @@ export default function Home() {
                         Download the conda-forge Installer
                     </h1>
                     <p>
-                        Miniforge is a minimal installer for a conda-forge-based distribution, including conda, mamba, and their dependencies.
+                        Miniforge is the preferred conda-forge installer and includes conda, mamba, and their dependencies.
                     </p>
                     <p>
                         If more packages are needed, use the <code>conda install</code> or <code>mamba install</code> command to install from the thousands of packages available in the conda-forge distribution. Isolated environments can be created with <code>conda create</code> or <code>mamba create</code>.


### PR DESCRIPTION
This adds some explanatory text about what installers are, and removes the anvil from the download page, as it is taking a lot of space on the page.
