### PR TITLE
Use youtube-nocookie embed

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -104,7 +104,7 @@ export default function Stats() {
             </div>
             <div className={styles.conda_forge_video}>
                 <iframe
-                    src="https://www.youtube.com/embed/EWh-BtdYE7M"
+                    src="https://www.youtube-nocookie.com/embed/EWh-BtdYE7M"
                     title="Episode 23: conda-forge - Open Source Directions hosted By Quansight"
                     style={{ border: 0 }}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [X] put any other relevant information below

The frontpage is embedding this YouTube video, which sets cookies on the browser. There's an [alternative which involves using youtube-nocookie.com](https://decareto.com/en/embed-youtube-in-a-dsgvo-compliant-way/). This is what this PR implements.

However:

- The `nocookie` approach is not perfect. It still writes some data to local storage and sends visualization data to Google (more info the linked blog post).
- The video is from 2019, so some things are out of date.

We could either:

- Remove it.
- Link to the YouTube link with a screenshot.

cc @SylvainCorlay @afshin 