### PR TITLE
DOC updated links for autotick-bot

### DIFF
--- a/docs/maintainer/infrastructure.md
+++ b/docs/maintainer/infrastructure.md
@@ -237,7 +237,7 @@ Bugs or suggestions regarding the service functionality should therefore be open
 The code and logic behind [`autotick-bot`](#autotick-bot).
 
 - 📜 Source at [`regro/cf-scripts`](https://github.com/regro/cf-scripts)
-- 📖 [Documentation](https://regro.github.io/cf-scripts/)
+- 📖 [Documentation](https://github.com/regro/cf-scripts/blob/master/README.md)
 
 ### Automated maintenance
 

--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -2269,7 +2269,7 @@ Once the PR is merged, the migration bot goes through the list of feedstocks in 
 When any changes are made in the global pinnings of a package, then the entire stack of the packages that need that package on their `host` section would need to be updated and rebuilt.
 Doing it manually can be quite tedious, and that's where migrations come to help. Migrations automate the process of submitting changes to a feedstock and are an integral part of the `regro-cf-autotick-bot`'s duties.
 
-There are several kinds of migrations, which you can read about in [Making Migrators](https://regro.github.io/cf-scripts/migrators.html). To generate these migrations, you use migrators, which are bots that automatically create pull requests for the affected packages in conda-forge.
+There are several kinds of migrations, which you can read about in [Making Migrators](https://github.com/regro/cf-scripts/blob/master/README.md#making-migrators). To generate these migrations, you use migrators, which are bots that automatically create pull requests for the affected packages in conda-forge.
 To propose a migration in one or more pins, the migrator issues a PR into the pinning feedstock using a yaml file expressing the changes to the global pinning file in the migrations folder.
 Once the PR is merged, the dependency graph is built. After that, the bot walks through the graph, migrates all the nodes (feedstocks) one by one, and issues PRs for those feedstocks.
 

--- a/docs/maintainer/pinning_deps.md
+++ b/docs/maintainer/pinning_deps.md
@@ -132,4 +132,4 @@ be added by hand. To do this, follow these steps:
      - Bump the version in meta.yaml to the current date
 
 Details of how the migration yaml is setup are provided in an [example](https://github.com/conda-forge/conda-forge-pinning-feedstock/tree/master/recipe/migrations/example.exyaml)
-and documentation [here](https://regro.github.io/cf-scripts/migrators.html#making-migrators).
+and documentation [here](https://github.com/regro/cf-scripts/blob/master/README.md#making-migrators).

--- a/docs/maintainer/updating_pkgs.md
+++ b/docs/maintainer/updating_pkgs.md
@@ -77,7 +77,7 @@ When a new version of a package is released on PyPI/CRAN/.., we have a bot that 
 
 ##### **How does regro-cf-autotick-bot create automatic version updates?**
 
-The [regro-cf-autotick-bot](https://github.com/regro/autotick-bot) continuously searches on a loop for any PyPI releases, GitHub releases, and any other sources of versions when any updates are released. The source code that gets executed in the loop comes from the [cf-scripts repository](https://github.com/regro/cf-scripts), which contains the code to detect versions and submit PRs. Visit [cf-scripts](https://regro.github.io/cf-scripts/index.html) to read more about it.
+The [regro-cf-autotick-bot](https://github.com/regro/autotick-bot) continuously searches on a loop for any PyPI releases, GitHub releases, and any other sources of versions when any updates are released. The source code that gets executed in the loop comes from the [cf-scripts repository](https://github.com/regro/cf-scripts), which contains the code to detect versions and submit PRs. Visit [cf-scripts](https://github.com/regro/cf-scripts/blob/master/README.md) to read more about it.
 
 The bot creates updates via inspection of the upstream release and will always update the `source` section and build version in the [recipe metadata](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#).
 As an experimental feature, the autotick bot can also be configured to verify or update the recipe's requirements for [Grayskull](https://github.com/conda-incubator/grayskull)-compatible recipes.


### PR DESCRIPTION
The bot website was taken down in favor of putting documentation directly in the readme.md since it is easier to maintain. This PR fixes link checking for that.