### PR TITLE
Add introduction to infrastucture page

### DIFF
--- a/docs/maintainer/infrastructure.md
+++ b/docs/maintainer/infrastructure.md
@@ -4,6 +4,15 @@ title: 'Infrastructure'
 
 # Infrastructure
 
+This page gives an overview of the conda-forge infrastructure, that is, an account of the various pieces maintained by the conda-forge contributors as well as third-party providers that collectively form the basis for the operation of conda-forge.
+
+We start with the different Github [repositories](#repositories) maintained by conda-forge itself, then describe the administrative commands available for use in those repositories, the [Admin web services](#admin-web-services), followed by [the CI services](#ci-build-services), i.e. the third-party providers used for building and maintaining packages together.
+After that, we turn to a description of some aspects of the build environment for packages in [Compilers and Runtimes](#compilers-and-runtimes), together with [details about the upload to the package server](#output-validation-and-feedstock-tokens).
+
+[Then](#how-package-building-interacts-with-infrastructure), we see how the process of building a package interacts with different parts of the infrastructure.
+
+The following depiction of [automation](#automated-maintenance) explains what makes conda-forge a smoothly running machine.
+
 ## Repositories
 
 ### Staged-recipes

--- a/docs/maintainer/infrastructure.md
+++ b/docs/maintainer/infrastructure.md
@@ -6,12 +6,12 @@ title: 'Infrastructure'
 
 This page gives an overview of the conda-forge infrastructure, that is, an account of the various pieces maintained by the conda-forge contributors as well as third-party providers that collectively form the basis for the operation of conda-forge.
 
-We start with the different Github [repositories](#repositories) maintained by conda-forge itself, then describe the administrative commands available for use in those repositories, the [Admin web services](#admin-web-services), followed by [the CI services](#ci-build-services), i.e. the third-party providers used for building and maintaining packages together.
+We start with the different Github [repositories](#repositories) maintained by conda-forge itself, then describe the administrative commands available for use in those repositories, the so-called [Admin web services](#admin-web-services), followed by [the CI services](#ci-build-services), i.e. the third-party providers used for building and maintaining packages together.
 After that, we turn to a description of some aspects of the build environment for packages in [Compilers and Runtimes](#compilers-and-runtimes), together with [details about the upload to the package server](#output-validation-and-feedstock-tokens).
 
-[Then](#how-package-building-interacts-with-infrastructure), we see how the process of building a package interacts with different parts of the infrastructure.
+[Then](#stages-of-package-building-and-involved-infrastructure), we see how the process of building a package interacts with different parts of the infrastructure.
 
-The following depiction of [automation](#automated-maintenance) explains what makes conda-forge a smoothly running machine.
+We close out with a brief [listing of involved entities](#inventory-of-services--providers).
 
 ## Repositories
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

This is the last bit of content from #2118. It simply adds a short introductory paragraph to the current infrastructure page.