### PR TITLE
Add announcement for clang support across platforms

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,7 +262,7 @@ const config = {
           },
           {
             from: "/news/2024/04/09/clang-everywhere/",
-            to: "/news/2024/04/30/clang-everywhere/"
+            to: "/news/2024/04/30/clang-everywhere/",
           },
           /* Docs redirects */
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -260,6 +260,10 @@ const config = {
             from: "/blog/posts/2023-07-13-installer-security-fixes/",
             to: "/blog/2023/07/13/installer-security-fixes/",
           },
+          {
+            from: "/news/2024/04/09/clang-everywhere/",
+            to: "/news/2024/04/30/clang-everywhere/"
+          },
           /* Docs redirects */
           {
             from: "/docs/user/announcements.html",

--- a/news/2024-04-09-clang-everywhere.md
+++ b/news/2024-04-09-clang-everywhere.md
@@ -1,1 +1,0 @@
-# Clang now available as compiler for all platforms

--- a/news/2024-04-30-clang-everywhere.md
+++ b/news/2024-04-30-clang-everywhere.md
@@ -19,7 +19,7 @@ cxx_compiler:
 was the only possible choice for C/C++ compilers.
 
 Recently, we finished adding preliminary support `clang` / `clangxx` as
-C/C++ compilers also on osx and windows, starting from clang 18.
+C/C++ compilers also on linux and windows, starting from clang 18.
 This is still very fresh, so bugs are possible, and we ask not to change
 the default compilers on feedstocks unless there are compelling reasons.
 

--- a/news/2024-04-30-clang-everywhere.md
+++ b/news/2024-04-30-clang-everywhere.md
@@ -5,7 +5,7 @@ platform, see e.g. [here](https://conda-forge.org/docs/maintainer/infrastructure
 
 In practice, this meant that
 
-```
+```yaml
 c_compiler:
   - gcc         # [linux]
   - clang       # [osx]
@@ -26,7 +26,7 @@ the default compilers on feedstocks unless there are compelling reasons.
 In any case, it is now possible to use the following configuration in
 `recipe/conda_build_config.yaml`:
 
-```
+```yaml
 # please consult @conda-forge/core before doing this
 c_compiler:
   - clang

--- a/news/2024-04-30-clang-everywhere.md
+++ b/news/2024-04-30-clang-everywhere.md
@@ -24,10 +24,9 @@ This is still very fresh, so bugs are possible, and we ask not to change
 the default compilers on feedstocks unless there are compelling reasons.
 
 In any case, it is now possible to use the following configuration in
-`recipe/conda_build_config.yaml`:
+`recipe/conda_build_config.yaml` (note the lack of platform selectors):
 
 ```yaml
-# please consult @conda-forge/core before doing this
 c_compiler:
   - clang
 c_compiler_version:

--- a/news/2024-04-30-clang-everywhere.md
+++ b/news/2024-04-30-clang-everywhere.md
@@ -4,6 +4,7 @@ Our compiler stack per platform generally uses the "default" compiler for that
 platform, see e.g. [here](https://conda-forge.org/docs/maintainer/infrastructure/#compilers-and-runtimes).
 
 In practice, this meant that
+
 ```
 c_compiler:
   - gcc         # [linux]
@@ -14,6 +15,7 @@ cxx_compiler:
   - clangxx     # [osx]
   - vs2019      # [win]
 ```
+
 was the only possible choice for C/C++ compilers.
 
 Recently, we finished adding preliminary support `clang` / `clangxx` as
@@ -23,6 +25,7 @@ the default compilers on feedstocks unless there are compelling reasons.
 
 In any case, it is now possible to use the following configuration in
 `recipe/conda_build_config.yaml`:
+
 ```
 # please consult @conda-forge/core before doing this
 c_compiler:

--- a/news/2024-04-30-clang-everywhere.md
+++ b/news/2024-04-30-clang-everywhere.md
@@ -1,0 +1,36 @@
+# Clang now available as compiler for all platforms
+
+Our compiler stack per platform generally uses the "default" compiler for that
+platform, see e.g. [here](https://conda-forge.org/docs/maintainer/infrastructure/#compilers-and-runtimes).
+
+In practice, this meant that
+```
+c_compiler:
+  - gcc         # [linux]
+  - clang       # [osx]
+  - vs2019      # [win]
+cxx_compiler:
+  - gxx         # [linux]
+  - clangxx     # [osx]
+  - vs2019      # [win]
+```
+was the only possible choice for C/C++ compilers.
+
+Recently, we finished adding preliminary support `clang` / `clangxx` as
+C/C++ compilers also on osx and windows, starting from clang 18.
+This is still very fresh, so bugs are possible, and we ask not to change
+the default compilers on feedstocks unless there are compelling reasons.
+
+In any case, it is now possible to use the following configuration in
+`recipe/conda_build_config.yaml`:
+```
+# please consult @conda-forge/core before doing this
+c_compiler:
+  - clang
+c_compiler_version:
+  - 18
+cxx_compiler:
+  - clangxx
+cxx_compiler_version:
+  - 18
+```


### PR DESCRIPTION
This fleshes out a skeleton that wrongly got committed in https://github.com/conda-forge/conda-forge.github.io/commit/e470f0dcb13abee6db8750f66374388483d3a28d - sorry about that.

I had wanted to wait for https://github.com/conda-forge/clang-win-activation-feedstock/pull/34 to land and _then_ raise a PR. @jaimergp kindly pointed out that this slipped in elsewhere.

Relevant xref: https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/102