### PR TITLE
Add blas-devel to the packages required to build against blas

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1188,6 +1188,7 @@ host of the recipe,
 requirements:
   host:
     - libblas
+    - blas-devel
     - libcblas
     - liblapack
     - liblapacke


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below


If you install just `libblas` on Windows (that installs the `mkl` variant), then for example in CMake `find_package(BLAS REQUIRED)` fails, so it is also necessary to add `blas-devel`. On the other hand, it is required to build against `libblas` as `libblas` has the correct `run_exports`, while `blas-devel` does not have them.