### PR TITLE
Remove blas-devel from packages required to compile against blas

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1214,7 +1214,9 @@ If a package needs a specific implementation's internal API for more control you
 ```yaml
 requirements:
   host:
-    - {{ blas_impl }}
+    # Keep mkl-devel here for pinning
+    - mkl-devel         {{ blas_impl == "mkl" }}
+    - {{ blas_impl }}   {{ blas_impl != "mkl" }}
   run:
     - libblas * *{{ blas_impl }}
     - {{ blas_impl }}

--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1188,7 +1188,6 @@ host of the recipe,
 requirements:
   host:
     - libblas
-    - blas-devel
     - libcblas
     - liblapack
     - liblapacke


### PR DESCRIPTION
`blas-devel` was added in https://github.com/conda-forge/conda-forge.github.io/pull/2171, to solve https://github.com/conda-forge/blas-feedstock/issues/120, but it was requested to remove it in https://github.com/conda-forge/conda-forge.github.io/pull/2171#issuecomment-2106300622 .

As discussed in https://github.com/conda-forge/blas-feedstock/issues/120, `mkl-devel` is indeed required when building against `mkl`, so @isuruf added  a section on how to correctly link to `mkl` in case the `mkl` blas variant is explicitly needed. For all other cases, it should not be necessary as in the conda-forge global pinnings, the `netlib` blas is pinned (see https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/f1dab7b908410aece14498b258cabf52b6a3c352/recipe/conda_build_config.yaml#L214-L222). 


PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below
