### PR TITLE
Suggest rerendering after C stdlib recipe changes

### DIFF
--- a/news/2024-03-24-stdlib-migration.md
+++ b/news/2024-03-24-stdlib-migration.md
@@ -45,6 +45,9 @@ all feedstock maintainers are free to apply independently:
   `- __osx >={{ MACOSX_DEPLOYMENT_TARGET }}  # [osx and x86_64]`, as this will
   henceforth be handled through `- {{ stdlib("c") }}`.
 
+Following the application of any of the above changes, the feedstock should be
+rerendered.
+
 As these mechanisms begin rolling out, we will also update the maintainer
 documentation in the conda-forge knowledge base. For more details, see this
 [issue](https://github.com/conda-forge/conda-forge.github.io/issues/2102).

--- a/news/2024-03-24-stdlib-migration.md
+++ b/news/2024-03-24-stdlib-migration.md
@@ -46,7 +46,7 @@ all feedstock maintainers are free to apply independently:
   henceforth be handled through `- {{ stdlib("c") }}`.
 
 Following the application of any of the above changes, the feedstock should be
-rerendered.
+[rerendered](https://conda-forge.org/docs/maintainer/updating_pkgs/#rerendering-feedstocks).
 
 As these mechanisms begin rolling out, we will also update the maintainer
 documentation in the conda-forge knowledge base. For more details, see this


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [X] put any other relevant information below

Rerendering is required after making the listed changes, and it may not be obvious to inexperienced / casual maintainers that this is the case, so it is explicitly mentioned.

I was caught out by this when updating the llvmlite feedstock: https://github.com/conda-forge/llvmlite-feedstock/pull/86#issuecomment-2113937582