### PR TITLE
microarch example: List at least one microarch_level

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1339,8 +1339,8 @@ Before learning how to use it, please read these considerations:
 To implement microarchitecture-optimized builds in your feedstock, you'll end up with something like:
 
 ```yaml title="recipe/conda_build_config.yaml"
-microarch_level:  # [unix and x86_64]
-  - 1  # [unix and x86_64]
+microarch_level:
+  - 1
   - 3  # [unix and x86_64]
   - 4  # [unix and x86_64]
 ```


### PR DESCRIPTION
Avoids a (presumed) bug in conda-build, as [described here](https://github.com/conda-forge/conda-forge.github.io/pull/2091#issuecomment-2137763342).
