### PR TITLE
Add link to install Build Tools for Visual Studio 2019

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -197,8 +197,13 @@ Visual Studio Subscriptions page, you may also need to join the Dev Essentials
 program. Once that's done, you can click the "Download" tab and search for
 "Build Tools for Visual Studio 2022". Until conda-forge has completely
 [migrated to Visual Studio 2022](https://github.com/conda-forge/conda-forge.github.io/issues/2138),
-you may still need to install ["Build Tools for Visual Studio 2019"](https://aka.ms/vs/16/release/vs_BuildTools.exe)
-to locally build a feedstock.
+you may still need to install "Build Tools for Visual Studio 2019" to locally
+build a feedstock. Depending on your needs and available hard drive space, you
+can either directly install VC-2019 using the
+[Visual Studio Build Tools 2019 installer](https://aka.ms/vs/16/release/vs_BuildTools.exe),
+or you can install both VC-2022 and VC-2019 using the
+[Visual Studio Build Tools 2022 installer](https://aka.ms/vs/17/release/vs_BuildTools.exe),
+making sure to check the optional box for "MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.29)".
 
 If you need more information. Please refer [the Python wiki page on Windows compilers](https://wiki.python.org/moin/WindowsCompilers).
 

--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -195,7 +195,10 @@ Subscriptions](https://visualstudio.microsoft.com/vs/older-downloads/#visual-stu
 To download build tools, you'll need a Microsoft account. Once on the
 Visual Studio Subscriptions page, you may also need to join the Dev Essentials
 program. Once that's done, you can click the "Download" tab and search for
-"Build Tools for Visual Studio 2022".
+"Build Tools for Visual Studio 2022". Until conda-forge has completely
+[migrated to Visual Studio 2022](https://github.com/conda-forge/conda-forge.github.io/issues/2138),
+you may still need to install ["Build Tools for Visual Studio 2019"](https://aka.ms/vs/16/release/vs_BuildTools.exe)
+to locally build a feedstock.
 
 If you need more information. Please refer [the Python wiki page on Windows compilers](https://wiki.python.org/moin/WindowsCompilers).
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

---

I am locally building a feedstock to troubleshoot a Windows-specific failure. I got a new laptop, so I needed to re-install Build Tools for Visual Studio. Unfortunately, when I used the link that worked for me on my old laptop (it's also in the conda-forge docs),
https://visualstudio.microsoft.com/vs/older-downloads/#visual-studio-2019-and-other-products, I can no longer download Build Tools for Visual Studio 2019 using my free account:

![image](https://github.com/conda-forge/conda-forge.github.io/assets/1608317/6ef9fac9-e781-482b-b764-7f44b2214c77)

So I went to the current [conda-forge docs for local builds on Windows](https://conda-forge.org/docs/maintainer/knowledge_base/#particularities-on-windows), where it recommends installing Build Tools for Visual Studio 2022. This was surprising to me since I know that vs2019 is still the default (I opened the Issue about migrating to vs2022, https://github.com/conda-forge/conda-forge.github.io/issues/2138). I gave it a shot anyways, but as I suspected, the build still failed since the feedstock requires the [conda-forge default of vs2019](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/446c2a56a2caf948bc9e0fcd7662ac1da26d9385/recipe/conda_build_config.yaml#L4).

So how to install the older version of build tools? I noticed that the URL to download the build tools for VS2022 (aka 17) was https://aka.ms/vs/17/release/vs_BuildTools.exe, so I tried https://aka.ms/vs/16/release/vs_BuildTools.exe, and indeed that did allow me to download the build tools for VS2019 (aka 16).

Given how much time I had to spend to figure out this hack to finally install the correct build tools, and AFAIK the migration to vs2022 still hasn't begun, I wanted to share this link directly in the docs.

**Note on formatting:** I wasn't sure how to format my additions given that there are multiple different styles used throughout this doc. I went with a style that included line breaks but attempted to keep the links nicely highlighted when viewed in VS Code. Of course I'm happy to change them to whatever style is preferred.

xref: https://github.com/conda-forge/conda-forge.github.io/pull/1956, https://github.com/conda-forge/conda-forge.github.io/pull/1878