### PR TITLE
doc: shorten grayskull usage by one step

### DIFF
--- a/docs/maintainer/adding_pkgs.md
+++ b/docs/maintainer/adding_pkgs.md
@@ -55,9 +55,8 @@ There are, currently, three ways to generate a recipe:
 
    Installation and usage of `grayskull`:
 
-   - Create a new environment using : `conda create --name MY_ENV`. Replace `MY_ENV` with the environment name.
-   - Activate this new environment : `conda activate MY_ENV`.
-   - Run `conda install -c conda-forge grayskull` to install `grayskull`.
+   - Create a new environment named e.g. "grayskull" with grayskull installed : `conda create --name grayskull -c conda-forge grayskull`
+   - Activate this new environment : `conda activate grayskull`.
    - Followed by `grayskull pypi --strict-conda-forge YOUR_PACKAGE_NAME` to generate the recipe. Replace `YOUR_PACKAGE_NAME` with the package name.
 
    :::


### PR DESCRIPTION
- It's more user friendly to provide ready to execute commands, e.g. an environment named `grayskull` makes sense if it's just `grayskull` that's installed there.
- One can directly install grayskull upon env creation, this reduces the docs by one line, and also makes it faster to run
