### PR TITLE
Fix width of stacktraces foldout

### DIFF
--- a/src/components/MigrationDetails/index.jsx
+++ b/src/components/MigrationDetails/index.jsx
@@ -270,7 +270,7 @@ function Row({ children }) {
       </td>
     </tr>
     {details && !collapsed && (<tr>
-      <td colSpan={3}><pre dangerouslySetInnerHTML={{ __html: details}} /></td>
+      <td colSpan={4}><pre dangerouslySetInnerHTML={{ __html: details}} /></td>
     </tr>)}
   </>);
 }


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

This PR aims at fixing task 8 of issue https://github.com/conda-forge/conda-forge.github.io/issues/2137
It sets the colSpan number from 3 to 4 to spread the details of not solvable section on the full width of the migrations details table.


Before
![Screenshot from 2024-07-17 21-07-03](https://github.com/user-attachments/assets/e7628841-76a1-41ed-bc29-8ebd6dc10b24)

 Now
![Screenshot from 2024-07-17 21-13-23](https://github.com/user-attachments/assets/ff5f1e2e-70b0-4b73-b887-7d49caeb267b)
