### PR TITLE
Increase timeout for link checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           lycheeVersion: "0.14.3"
           args: >
             --no-progress
+            --timeout 60
             --base "$(pwd)/build"
             --accept 100..399,401,403,429
             --exclude '.*/status/migration/.*'


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

Anaconda.org can be a bit slow some times (specially in heavy URLs like `/conda-forge`), so let's give it some more time before timing out.