### PR TITLE
Add links to URLs in status incidents

### DIFF
--- a/src/components/StatusDashboard/incidents.jsx
+++ b/src/components/StatusDashboard/incidents.jsx
@@ -3,6 +3,7 @@ import moment from "moment";
 import { Octokit } from "octokit";
 import React, { useEffect, useState } from "react";
 import Markdown from "react-markdown";
+import remarkGfm from 'remark-gfm'
 import styles from "./styles.module.css";
 
 // This label indicates warning.
@@ -25,16 +26,16 @@ const REPO = { owner: "conda-forge", repo: "status" };
 
 // The badge color for each severity level.
 const SEVERITY = {
-  "investigating": "info",
+  investigating: "info",
   [DEGRADED]: "warning",
   [MAJOR]: "danger",
-  "maintenance": "info"
+  maintenance: "info",
 };
 
 export default function Incidents({ ongoing, onLoad, ...props }) {
   const [{ closed, current, open }, setState] = useState(() => {
     const { current, open } = props;
-    return { closed: [], current: current ?? new Set(), open: open ?? [] }
+    return { closed: [], current: current ?? new Set(), open: open ?? [] };
   });
   useEffect(() => {
     void (async (initialized = current.size && ongoing && open.length) => {
@@ -48,7 +49,9 @@ export default function Incidents({ ongoing, onLoad, ...props }) {
       let current = new Set();
       try {
         const issues = await octokit.rest.issues.listForRepo({
-          ...REPO, per_page: 100, state: "all"
+          ...REPO,
+          per_page: 100,
+          state: "all",
         });
         for (const issue of issues.data) {
           const labels = new Set(issue.labels.map(({ name }) => name));
@@ -74,24 +77,33 @@ export default function Incidents({ ongoing, onLoad, ...props }) {
     <div className="card margin-top--xs">
       <div className="card__header">
         <h3>
-          Incidents
-          {" "}
+          Incidents{" "}
           {!!current.size && (
-            <span className={
-              `badge badge--${
-                current.has(MAJOR) ? "danger" : current.has(DEGRADED) ? "warning" : "info"
-              }`}>
-              {
-                current.has(MAJOR) ? MAJOR :
-                current.has(DEGRADED) ? DEGRADED :
-                current.values().next().value}
+            <span
+              className={`badge badge--${
+                current.has(MAJOR)
+                  ? "danger"
+                  : current.has(DEGRADED)
+                  ? "warning"
+                  : "info"
+              }`}
+            >
+              {current.has(MAJOR)
+                ? MAJOR
+                : current.has(DEGRADED)
+                ? DEGRADED
+                : current.values().next().value}
             </span>
           )}
         </h3>
       </div>
       <div className={`card__body ${styles.incidents}`}>
-        {open.map((issue, i) => <Incident key={i}>{issue}</Incident>)}
-        {closed.map((issue, i) => <Incident key={i}>{issue}</Incident>)}
+        {open.map((issue, i) => (
+          <Incident key={i}>{issue}</Incident>
+        ))}
+        {closed.map((issue, i) => (
+          <Incident key={i}>{issue}</Incident>
+        ))}
       </div>
     </div>
   );
@@ -101,15 +113,18 @@ function Incident({ children }) {
   const issue = children;
   const open = issue.state === "open";
   const date = moment(issue.created_at);
+  console.log("issue.body:", issue.body);
   return (
     <div className={styles.incident}>
       <div>
-        <span className={
-          `badge badge--${open ? SEVERITY[issue.severity] : "success"}
-        `}>
+        <span
+          className={`badge badge--${
+            open ? SEVERITY[issue.severity] : "success"
+          }
+        `}
+        >
           {open ? "ongoing" : "resolved"}
-        </span>
-        {" "}
+        </span>{" "}
         <span className={`badge badge--${SEVERITY[issue.severity]}`}>
           {issue.severity}
         </span>
@@ -126,7 +141,13 @@ function Incident({ children }) {
         </Markdown> (#{issue.number})
       </Link>
       <div className={styles.incident_body}>
-        <Markdown>{issue.body}</Markdown>
+      
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+          >
+            {issue.body}
+          </Markdown>
+        
       </div>
     </div>
   );
@@ -137,4 +158,4 @@ const intersection = (one, two) => {
   const [bigger, smaller] = one.size >= two.size ? [one, two] : [two, one];
   for (const item of smaller) if (bigger.has(item)) intersection.add(item);
   return intersection;
-}
+};

--- a/src/components/StatusDashboard/incidents.jsx
+++ b/src/components/StatusDashboard/incidents.jsx
@@ -3,8 +3,8 @@ import moment from "moment";
 import { Octokit } from "octokit";
 import React, { useEffect, useState } from "react";
 import Markdown from "react-markdown";
-import remarkGfm from 'remark-gfm'
 import styles from "./styles.module.css";
+import remarkGfm from 'remark-gfm'
 
 // This label indicates warning.
 const DEGRADED = "degraded performance";
@@ -26,16 +26,16 @@ const REPO = { owner: "conda-forge", repo: "status" };
 
 // The badge color for each severity level.
 const SEVERITY = {
-  investigating: "info",
+  "investigating": "info",
   [DEGRADED]: "warning",
   [MAJOR]: "danger",
-  maintenance: "info",
+  "maintenance": "info"
 };
 
 export default function Incidents({ ongoing, onLoad, ...props }) {
   const [{ closed, current, open }, setState] = useState(() => {
     const { current, open } = props;
-    return { closed: [], current: current ?? new Set(), open: open ?? [] };
+    return { closed: [], current: current ?? new Set(), open: open ?? [] }
   });
   useEffect(() => {
     void (async (initialized = current.size && ongoing && open.length) => {
@@ -49,9 +49,7 @@ export default function Incidents({ ongoing, onLoad, ...props }) {
       let current = new Set();
       try {
         const issues = await octokit.rest.issues.listForRepo({
-          ...REPO,
-          per_page: 100,
-          state: "all",
+          ...REPO, per_page: 100, state: "all"
         });
         for (const issue of issues.data) {
           const labels = new Set(issue.labels.map(({ name }) => name));
@@ -77,33 +75,24 @@ export default function Incidents({ ongoing, onLoad, ...props }) {
     <div className="card margin-top--xs">
       <div className="card__header">
         <h3>
-          Incidents{" "}
+          Incidents
+          {" "}
           {!!current.size && (
-            <span
-              className={`badge badge--${
-                current.has(MAJOR)
-                  ? "danger"
-                  : current.has(DEGRADED)
-                  ? "warning"
-                  : "info"
-              }`}
-            >
-              {current.has(MAJOR)
-                ? MAJOR
-                : current.has(DEGRADED)
-                ? DEGRADED
-                : current.values().next().value}
+            <span className={
+              `badge badge--${
+                current.has(MAJOR) ? "danger" : current.has(DEGRADED) ? "warning" : "info"
+              }`}>
+              {
+                current.has(MAJOR) ? MAJOR :
+                current.has(DEGRADED) ? DEGRADED :
+                current.values().next().value}
             </span>
           )}
         </h3>
       </div>
       <div className={`card__body ${styles.incidents}`}>
-        {open.map((issue, i) => (
-          <Incident key={i}>{issue}</Incident>
-        ))}
-        {closed.map((issue, i) => (
-          <Incident key={i}>{issue}</Incident>
-        ))}
+        {open.map((issue, i) => <Incident key={i}>{issue}</Incident>)}
+        {closed.map((issue, i) => <Incident key={i}>{issue}</Incident>)}
       </div>
     </div>
   );
@@ -113,18 +102,15 @@ function Incident({ children }) {
   const issue = children;
   const open = issue.state === "open";
   const date = moment(issue.created_at);
-  console.log("issue.body:", issue.body);
   return (
     <div className={styles.incident}>
       <div>
-        <span
-          className={`badge badge--${
-            open ? SEVERITY[issue.severity] : "success"
-          }
-        `}
-        >
+        <span className={
+          `badge badge--${open ? SEVERITY[issue.severity] : "success"}
+        `}>
           {open ? "ongoing" : "resolved"}
-        </span>{" "}
+        </span>
+        {" "}
         <span className={`badge badge--${SEVERITY[issue.severity]}`}>
           {issue.severity}
         </span>
@@ -141,13 +127,11 @@ function Incident({ children }) {
         </Markdown> (#{issue.number})
       </Link>
       <div className={styles.incident_body}>
-      
-          <Markdown
-            remarkPlugins={[remarkGfm]}
-          >
-            {issue.body}
-          </Markdown>
-        
+        <Markdown
+          remarkPlugins={[remarkGfm]}
+        >
+          {issue.body}
+        </Markdown>
       </div>
     </div>
   );
@@ -158,4 +142,4 @@ const intersection = (one, two) => {
   const [bigger, smaller] = one.size >= two.size ? [one, two] : [two, one];
   for (const item of smaller) if (bigger.has(item)) intersection.add(item);
   return intersection;
-};
+}


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

Add links to URLs in status incidents using remarkPlugins properties of Markdown component and remarkGfm from remark-gfm plugin.

This PR aims at fixing issue #2181