### PR TITLE
Fix some contrast issues in the filter buttons

### DIFF
--- a/src/pages/status/migration/index.jsx
+++ b/src/pages/status/migration/index.jsx
@@ -159,7 +159,6 @@ function Breadcrumbs({ children }) {
 }
 
 function Filters({ counts, filters, onFilter }) {
-  const icon = styles.migration_details_filter_icon;
   return (
     <div className={styles.migration_details_filter}>
       {ORDERED.map(([key, title], index) => {
@@ -176,13 +175,16 @@ function Filters({ counts, filters, onFilter }) {
           onClick={() => onFilter(key)}>
           {filters[key] ?
             <span className={[
-              styles[`${base}_on`],
-              styles.migration_details_filter_dot_on
+              styles[`${base}_hidden`],
+              styles.migration_details_filter_dot,
+              styles[`${base}_dot`],
             ].join(" ")}></span>
             :
             <span className={[
               styles[base],
-              styles.migration_details_filter_dot].join(" ")}>
+              styles.migration_details_filter_dot,
+              styles[`${base}_dot`],
+            ].join(" ")}>
             </span>
           }
           <div className={styles.migration_details_filter_title_container}>

--- a/src/pages/status/migration/styles.module.css
+++ b/src/pages/status/migration/styles.module.css
@@ -52,7 +52,7 @@
   background-color: var(--ifm-color-success);
 }
 
-.migration_details_filter_done_on {
+.migration_details_filter_done_hidden {
   background-color: var(--ifm-color-success);
   opacity: 0.6;
 }
@@ -61,7 +61,7 @@
   background-color: var(--ifm-color-emphasis-400);
 }
 
-.migration_details_filter_in_pr_on {
+.migration_details_filter_in_pr_hidden {
   background-color: var(--ifm-color-emphasis-400);
   opacity: 0.6;
 }
@@ -70,7 +70,7 @@
   background-color: var(--ifm-color-emphasis-600);
 }
 
-.migration_details_filter_awaiting_pr_on {
+.migration_details_filter_awaiting_pr_hidden {
   background-color: var(--ifm-color-emphasis-600);
   opacity: 0.6;
 }
@@ -79,7 +79,7 @@
   background-color: var(--ifm-color-emphasis-800);
 }
 
-.migration_details_filter_awaiting_parents_on {
+.migration_details_filter_awaiting_parents_hidden {
   background-color: var(--ifm-color-emphasis-800);
   opacity: 0.6;
 }
@@ -88,7 +88,7 @@
   background-color: var(--ifm-color-warning);
 }
 
-.migration_details_filter_not_solvable_on {
+.migration_details_filter_not_solvable_hidden {
   background-color: var(--ifm-color-warning);
   opacity: 0.6;
 }
@@ -97,7 +97,7 @@
   background-color: var(--ifm-color-danger);
 }
 
-.migration_details_filter_bot_error_on {
+.migration_details_filter_bot_error_hidden {
   background-color: var(--ifm-color-danger);
   opacity: 0.6;
 }
@@ -163,24 +163,16 @@
 .migration_details_filter_dot {
   display: flex;
   position: relative;
-  border: solid 2px var(--ifm-button-color);
   width: 16px;
   height: 16px;
-  border-radius: 50%;
   position: relative;
   left: 8px;
   top: 2px;
+  border-radius: 50%;
+  border: 2px solid var(--ifm-button-color);
 }
-
-.migration_details_filter_dot_on {
-  display: flex;
-  position: relative;
-  border: solid 2px red;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  left: 8px;
-  top: 2px;
+.migration_details_filter_in_pr_dot {
+  border: 2px solid var(--ifm-color-content);
 }
 
 .migration_details_filter_title_container {


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

Follow up to #2239, to remove the red/orange border which didn't play well with some greens:

![image](https://github.com/user-attachments/assets/96a355d5-8c05-45b9-87fd-2c33e4304bb9)


![image](https://github.com/user-attachments/assets/9278f05d-85e2-4ce4-ada6-2cbca3a61c78)


Now we use dark-mode aware blacks or whites, depending on the color at hand.