### PR TITLE
Change migration table to only have one header for the 3 types of migrations

### DIFF
--- a/src/components/StatusDashboard/current_migrations.jsx
+++ b/src/components/StatusDashboard/current_migrations.jsx
@@ -8,7 +8,7 @@ import Link from "@docusaurus/Link";
 const COLLAPSED_KEY = "migration-collapsed";
 const SORT_KEY = "migration-sort";
 
-export default function CurrentMigrations({ onLoad }) {
+export default function CurrentMigrations({ onLoad, collapsed, name, rows, sort }) {
   const [state, setState] = useState({
     closed: [],
     collapsed: { closed: true, longterm: true, regular: true },
@@ -49,6 +49,7 @@ export default function CurrentMigrations({ onLoad }) {
       }
       return { ...prev, collapsed: updated };
     });
+  
   useEffect(fetchContent(onLoad, setState), []);
   const { closed, longterm, regular } = state;
   const total = closed.length + longterm.length + regular.length;
@@ -62,6 +63,61 @@ export default function CurrentMigrations({ onLoad }) {
       </div>
       <div className="card__body">
         <table className={styles.migrations_table}>
+        <thead>
+        <tr>
+          <th colSpan={1} 
+         
+            onClick={() => resort("name")}
+            className={state.sort.by === "name" ? styles[state.sort.order] : undefined}
+          >
+            Name
+          </th>
+          <th colSpan={1}
+            onClick={() => resort("status")}
+            className={state.sort.by === "status" ? styles[state.sort.order] : undefined}
+          >
+            PRs made
+          </th>
+          <th colSpan={1}
+            onClick={() => resort("done")}
+            className={state.sort.by === "done" ? styles[state.sort.order] : undefined}
+          >
+            Done
+          </th>
+          <th colSpan={1}     
+            onClick={() => resort("in-pr")}
+            className={state.sort.by === "in-pr" ? styles[state.sort.order] : undefined}
+          >
+            In PR
+          </th>
+          <th colSpan={1}   
+            onClick={() => resort("awaiting-pr")}
+            className={state.sort.by === "awaiting-pr" ? styles[state.sort.order] : undefined}
+          >
+            Awaiting PR
+          </th>
+          <th colSpan={1}  
+            onClick={() => resort("awaiting-parents")}
+            className={state.sort.by === "awaiting-parents" ? styles[state.sort.order] : undefined}
+          >
+            Awaiting parents
+          </th>
+          <th colSpan={1} 
+            onClick={() => resort("not-solvable")}
+            className={state.sort.by === "not-solvable" ? styles[state.sort.order] : undefined}
+          >
+            Not solvable
+          </th>
+          <th colSpan={1}  
+            onClick={() => resort("bot-error")}
+            className={state.sort.by === "bot-error" ? styles[state.sort.order] : undefined}
+          >
+            Bot error
+          </th>
+        </tr>
+       
+     
+      </thead>
           <TableContent
             collapsed={state.collapsed.longterm}
             name="Long-running migrations"
@@ -102,56 +158,6 @@ function TableContent({ collapsed, name, resort, rows, select, sort }) {
           <th colSpan={8} className={collapsed ? styles.collapsed : undefined}>
             {name}{" "}
             <span className="badge badge--secondary">{rows.length || "…"}</span>
-          </th>
-        </tr>
-        <tr className={collapsed ? styles.collapsed : undefined}>
-          <th
-            onClick={() => resort("name")}
-            className={sort.by === "name" ? styles[sort.order] : undefined}
-          >
-            Name
-          </th>
-          <th
-            onClick={() => resort("status")}
-            className={sort.by === "status" ? styles[sort.order] : undefined}
-          >
-            PRs made
-          </th>
-          <th
-            onClick={() => resort("done")}
-            className={sort.by === "done" ? styles[sort.order] : undefined}
-          >
-            Done
-          </th>
-          <th
-            onClick={() => resort("in-pr")}
-            className={sort.by === "in-pr" ? styles[sort.order] : undefined}
-          >
-            In PR
-          </th>
-          <th
-            onClick={() => resort("awaiting-pr")}
-            className={sort.by === "awaiting-pr" ? styles[sort.order] : undefined}
-          >
-            Awaiting PR
-          </th>
-          <th
-            onClick={() => resort("awaiting-parents")}
-            className={sort.by === "awaiting-parents" ? styles[sort.order] : undefined}
-          >
-            Awaiting parents
-          </th>
-          <th
-            onClick={() => resort("not-solvable")}
-            className={sort.by === "not-solvable" ? styles[sort.order] : undefined}
-          >
-            Not solvable
-          </th>
-          <th
-            onClick={() => resort("bot-error")}
-            className={sort.by === "bot-error" ? styles[sort.order] : undefined}
-          >
-            Bot error
           </th>
         </tr>
       </thead>

--- a/src/components/StatusDashboard/current_migrations.jsx
+++ b/src/components/StatusDashboard/current_migrations.jsx
@@ -49,7 +49,7 @@ export default function CurrentMigrations({ onLoad, collapsed, name, rows, sort 
       }
       return { ...prev, collapsed: updated };
     });
-  
+
   useEffect(fetchContent(onLoad, setState), []);
   const { closed, longterm, regular } = state;
   const total = closed.length + longterm.length + regular.length;
@@ -65,8 +65,8 @@ export default function CurrentMigrations({ onLoad, collapsed, name, rows, sort 
         <table className={styles.migrations_table}>
         <thead>
         <tr>
-          <th colSpan={1} 
-         
+          <th colSpan={1}
+
             onClick={() => resort("name")}
             className={state.sort.by === "name" ? styles[state.sort.order] : undefined}
           >
@@ -84,39 +84,39 @@ export default function CurrentMigrations({ onLoad, collapsed, name, rows, sort 
           >
             Done
           </th>
-          <th colSpan={1}     
+          <th colSpan={1}
             onClick={() => resort("in-pr")}
             className={state.sort.by === "in-pr" ? styles[state.sort.order] : undefined}
           >
             In PR
           </th>
-          <th colSpan={1}   
+          <th colSpan={1}
             onClick={() => resort("awaiting-pr")}
             className={state.sort.by === "awaiting-pr" ? styles[state.sort.order] : undefined}
           >
             Awaiting PR
           </th>
-          <th colSpan={1}  
+          <th colSpan={1}
             onClick={() => resort("awaiting-parents")}
             className={state.sort.by === "awaiting-parents" ? styles[state.sort.order] : undefined}
           >
             Awaiting parents
           </th>
-          <th colSpan={1} 
+          <th colSpan={1}
             onClick={() => resort("not-solvable")}
             className={state.sort.by === "not-solvable" ? styles[state.sort.order] : undefined}
           >
             Not solvable
           </th>
-          <th colSpan={1}  
+          <th colSpan={1}
             onClick={() => resort("bot-error")}
             className={state.sort.by === "bot-error" ? styles[state.sort.order] : undefined}
           >
             Bot error
           </th>
         </tr>
-       
-     
+
+
       </thead>
           <TableContent
             collapsed={state.collapsed.longterm}


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below


This PR aims at fixing task 11 of issue https://github.com/conda-forge/conda-forge.github.io/issues/2137
Its objective is to modify the migration table in order to have only one header for the three type of migrations `Long-running`, `Regular` and `Closed`. In this way, we avoid the previous repetition of the row with mention of `Name` and the different categories `PRs made`, `Done`, `In PR`, `Awaiting PRs`, `Awaiting parents`, `Not solvable`, `Bot error`.
The rendering of the PR is the following.
[Screencast from 30-07-2024 17:59:45.webm](https://github.com/user-attachments/assets/0b452679-6ee7-4791-b070-729f80ba3609)

Before
![Screenshot from 2024-07-30 18-03-40](https://github.com/user-attachments/assets/ca16709f-c604-47f7-91e0-bd6f3577ca57)

Now
![Screenshot from 2024-07-30 18-01-36](https://github.com/user-attachments/assets/3a3b6146-34e2-479c-a56a-3c61ee73d160)
