### PR TITLE
Update ci skip documentation in infrastructure.md

### DIFF
--- a/docs/maintainer/infrastructure.md
+++ b/docs/maintainer/infrastructure.md
@@ -445,7 +445,7 @@ repo [README.md](https://github.com/conda-forge/webservices-dispatch-action) for
 
 ### Skipping CI builds
 
-To skip a CI build for a given commit, put `[ci skip] ***NO_CI***` in the commit message.
+To skip a CI build for a given commit, put `[ci skip]` in the commit message.
 
 :::note[Related links]
 


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

I noticed that when you use the bot to do non-packaging changes like update maintainer it only uses `[ci skip]`. So is it safe for the documentation to suggest only `[ci skip]` now?

Also, are the linked issues still relevant? https://github.com/conda-forge/conda-forge.github.io/issues/629 does not seem useful to me. It talks about some nuances with Travis, Circle, and Azure, but I am not sure what to take away as actionable. All my feedstocks only use Azure now. I think https://github.com/conda-forge/staged-recipes/issues/1148 is similarly linked for nuances between CI systems.

Also, I think #498 can be closed since skipping CI is already in the docs.