### PR TITLE
Status page: Link to JSON payloads, use tabs in migration details

### DIFF
--- a/src/components/StatusDashboard/version_updates.jsx
+++ b/src/components/StatusDashboard/version_updates.jsx
@@ -37,6 +37,12 @@ export default function VersionUpdates({ onLoad }) {
             <span className="badge badge--secondary">{Object.keys(queued).length}</span>
             {" "}
             <span className="badge badge--warning">{Object.keys(errors).length}</span>
+            {" "}
+            <small className="fa fa-fw">
+              <a href={urls.versions.api} target="_blank" title="View raw payload">
+                <i className="fa fa-fw fa-arrow-up-right-from-square"></i>
+              </a>
+            </small>
         </h3>
       </div>
       <div className="card__body">

--- a/src/pages/status/migration/index.jsx
+++ b/src/pages/status/migration/index.jsx
@@ -94,26 +94,26 @@ export default function MigrationDetails() {
             <div className={styles.migration_details_toggle}>
               <div class="tabs-container">
                 <ul role="tablist" aria-orientation="horizontal" class="tabs">
-                  <li 
-                    key="table" 
+                  <li
+                    key="table"
                     role="tab"
-                    class={["tabs__item", (view == "table" ? "tabs__item--active" : null)].join(" ")} 
+                    class={["tabs__item", (view == "table" ? "tabs__item--active" : null)].join(" ")}
                     onClick={() => toggle("table")}
                   >
                     Table
                   </li>
-                  <li 
-                    key="graph" 
+                  <li
+                    key="graph"
                     role="tab"
-                    class={["tabs__item", (view == "graph" ? "tabs__item--active" : null)].join(" ")} 
+                    class={["tabs__item", (view == "graph" ? "tabs__item--active" : null)].join(" ")}
                     onClick={() => toggle("graph")}
                   >
                     Graph
                   </li>
                   {name &&
                     <a href={urls.migrations.details.replace("<NAME>", name)} target="_blank">
-                      <li 
-                        key="raw" 
+                      <li
+                        key="raw"
                         role="tab"
                         class="tabs__item"
                       >

--- a/src/pages/status/migration/index.jsx
+++ b/src/pages/status/migration/index.jsx
@@ -100,25 +100,27 @@ export default function MigrationDetails() {
                     class={["tabs__item", (view == "table" ? "tabs__item--active" : null)].join(" ")} 
                     onClick={() => toggle("table")}
                   >
-                      Table
-                    </li>
+                    Table
+                  </li>
                   <li 
                     key="graph" 
                     role="tab"
                     class={["tabs__item", (view == "graph" ? "tabs__item--active" : null)].join(" ")} 
                     onClick={() => toggle("graph")}
                   >
-                      Graph
-                    </li>
-                  <li 
-                    key="raw" 
-                    role="tab"
-                    class="tabs__item"
-                  >
-                    <a href={urls.migrations.details.replace("<NAME>", name)} target="_blank">
-                      <span>Raw <i className="fa fa-fw fa-arrow-up-right-from-square"></i></span>
-                    </a>
+                    Graph
                   </li>
+                  {name &&
+                    <a href={urls.migrations.details.replace("<NAME>", name)} target="_blank">
+                      <li 
+                        key="raw" 
+                        role="tab"
+                        class="tabs__item"
+                      >
+                        <span>Raw <i className="fa fa-fw fa-arrow-up-right-from-square"></i></span>
+                      </li>
+                    </a>
+                  }
                 </ul>
               </div>
             </div>

--- a/src/pages/status/migration/index.jsx
+++ b/src/pages/status/migration/index.jsx
@@ -7,6 +7,8 @@ import React, { useEffect, useState } from "react";
 import SVG from 'react-inlinesvg';
 import styles from "./styles.module.css";
 import { Tooltip } from "react-tooltip";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 // { Done, In PR, Awaiting PR, Awaiting parents, Not solvable, Bot error }
 // The third value is a boolean representing the default display state on load
@@ -90,8 +92,35 @@ export default function MigrationDetails() {
         <div className={`card margin-top--xs`}>
           <div className="card__header">
             <div className={styles.migration_details_toggle}>
-              <button onClick={() => toggle("table")}>Table View</button>{" "}
-              <button onClick={() => toggle("graph")}>Graph View</button>
+              <div class="tabs-container">
+                <ul role="tablist" aria-orientation="horizontal" class="tabs">
+                  <li 
+                    key="table" 
+                    role="tab"
+                    class={["tabs__item", (view == "table" ? "tabs__item--active" : null)].join(" ")} 
+                    onClick={() => toggle("table")}
+                  >
+                      Table
+                    </li>
+                  <li 
+                    key="graph" 
+                    role="tab"
+                    class={["tabs__item", (view == "graph" ? "tabs__item--active" : null)].join(" ")} 
+                    onClick={() => toggle("graph")}
+                  >
+                      Graph
+                    </li>
+                  <li 
+                    key="raw" 
+                    role="tab"
+                    class="tabs__item"
+                  >
+                    <a href={urls.migrations.details.replace("<NAME>", name)} target="_blank">
+                      <span>Raw <i className="fa fa-fw fa-arrow-up-right-from-square"></i></span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
             <Breadcrumbs>{name}</Breadcrumbs>
             <div style={{ clear: "both" }}></div>


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

I wanted to check all version update errors at once and found that the easiest way was to Ctrl+F `raise` in the JSON payload. Linking it for convenience. I also did the same for the migration details so folks can have a quick overview of the different exceptions, and changed the UI so it uses tabs which has a better indicator of the active view.