### PR TITLE
fix naming inconsistency in convenience wrapper

### DIFF
--- a/blog/2024-09-26-python-313.md
+++ b/blog/2024-09-26-python-313.md
@@ -30,7 +30,7 @@ build, you can do:
 Analogous to this package we also have a metapackage to explicitly
 install the GIL variant:
 
-    conda create -n py313 python=3.13 cpython-gil -c conda-forge/label/python_rc -c conda-forge
+    conda create -n py313 python=3.13 python-gil -c conda-forge/label/python_rc -c conda-forge
 
 Note that there are no conda packages for freethreading Python extensions yet and
 we hope to start a migration for freethreading extensions in the


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/python-feedstock/pull/732

CC @isuruf