### PR TITLE
fix: update `noarch: python` syntax to use more compatible form

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1483,8 +1483,6 @@ In order to qualify as a noarch python package, all of the following criteria mu
 All recipes employing `noarch: python` should use the `python_min` variable per the following example:
 
 ```yaml title="recipe/meta.yaml"
-{% set python_min = python_min|default("0.1a0") %}
-
 name: package
 source:
   # ...
@@ -1493,7 +1491,7 @@ build:
   # ...
 requirements:
   host:
-    - python {{ python_min }}.*
+    - python {{ python_min }}
     # ...
   run:
     - python >={{ python_min }}
@@ -1501,7 +1499,7 @@ requirements:
 
 test:
   requires:
-    - python ={{ python_min }}
+    - python {{ python_min }}
     # ...
 ```
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

This PR updates the `noarch: python` syntax to use a more compatible form that does not require a default to be set in jinja2.