### PR TITLE
feat: suggest using jinja2/context vars instead of variants for python_min overrides

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1504,14 +1504,16 @@ test:
 ```
 
 See [CFEP-25](https://github.com/conda-forge/cfep/blob/main/cfep-25.md) for more details on this syntax. If you
-need to override this syntax, you can add a `conda_build_config.yaml` file in your recipe like this:
+need to override this syntax, you can add a Jinja2 `set` statement (or equivalent `context` variable for v1 recipes)
+at the top of your recipe like this
 
-```yaml title="recipe/conda_build_config.yaml"
-python_min:
-  - 3.10
+```yaml title="recipe/meta.yaml"
+{% set python_min = "3.10" %}
 ```
 
-You will need to [rerender the feedstock](../infrastructure/#conda-forge-admin-please-rerender) after making this change.
+It also possible to achieve the same effect by adding a `conda_build_config.yaml` file to your recipe. If you go that route,
+you will need to [rerender the feedstock](../infrastructure/#conda-forge-admin-please-rerender) after adding the
+`conda_build_config.yaml` file.
 
 :::note
 


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

This PR is to change the suggested syntax top match the discussion in https://github.com/conda-forge/conda-forge.github.io/issues/2351