### PR TITLE
Add a note about the appropriateness of being added as a maintainer

### DIFF
--- a/docs/maintainer/infrastructure.md
+++ b/docs/maintainer/infrastructure.md
@@ -372,6 +372,23 @@ that adds the given user to the feedstock. A maintainer or member of `core` can 
 this PR to add the user. Please do not modify this PR or adjust the commit message. This
 PR is designed to skip building the package.
 
+:::note[Using this command]
+
+This is not the recommended way to start to help with a feedstock.
+If you are interested in helping with a particular recipe, it is better to start by
+submitting a PR with a new version or a fix. This way, you can get feedback on your
+work and learn about some of the historical context of the feedstock.
+
+Once you have established a working relationship with the maintainers, you can ask
+them to add you to the feedstock team. They can then use this command
+to add you to the team. There isn't any official requirement for how to add new
+maintainers so it may take a while for concensus to be reached
+on when to add new maintainers. Do not let this discourage you from contributing!
+
+PRs are free to be opened by anyone!!! Thank you for your time and effort!!!
+
+:::
+
 ### @conda-forge-admin, please update version
 
 Entering the above phrase in the title of an issue on a feedstock will request the bot

--- a/docs/maintainer/updating_pkgs.md
+++ b/docs/maintainer/updating_pkgs.md
@@ -307,6 +307,19 @@ To contact core, ping them by mentioning @conda-forge/core in a comment or, if y
 
 This PR is designed to skip building the package. Please do **not** modify it or adjust the commit message.
 
+This is not the recommended way to start to help with a feedstock.
+If you are interested in helping with a particular recipe, it is better to start by
+submitting a PR with a new version or a fix. This way, you can get feedback on your
+work and learn about some of the historical context of the feedstock.
+
+Once you have established a working relationship with the maintainers, you can ask
+them to add you to the feedstock team. They can then use this command
+to add you to the team. There isn't any official requirement for how to add new
+maintainers so it may take a while for concensus to be reached
+on when to add new maintainers. Do not let this discourage you from contributing!
+
+PRs are free to be opened by anyone!!! Thank you for your time and effort!!!
+
 :::
 
 For an example see [this](https://github.com/conda-forge/cudnn-feedstock/issues/20) issue.


### PR DESCRIPTION
With conda-forge gaining popularity, I think it might be good to encourage users to contribute before requesting to be added.

Let me know what you all think!

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
