### PR TITLE
ENH: Add example of conda_build_config.yaml python_min map

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1511,9 +1511,24 @@ at the top of your recipe like this
 {% set python_min = "3.10" %}
 ```
 
-It also possible to achieve the same effect by adding a `conda_build_config.yaml` file to your recipe. If you go that route,
-you will need to [rerender the feedstock](../infrastructure/#conda-forge-admin-please-rerender) after adding the
-`conda_build_config.yaml` file.
+It also possible to achieve the same effect by adding a `conda_build_config.yaml` file to your recipe that
+contains a map like
+
+```yaml title="recipe/conda_build_config.yaml"
+python_min:
+- "3.10"
+```
+
+If you go that route, you will need to [rerender the feedstock](../infrastructure/#conda-forge-admin-please-rerender)
+after adding the `conda_build_config.yaml` file.
+
+:::tip[Hint]
+
+Adding an explicit `python_min` to your `noarch: python` recipe can be an effective way to ensure the required
+Python in your package's metadata is enforced at `conda-build` time, as the build will fail if the package's
+required Python version is newer than `python_min`.
+
+:::
 
 :::note
 


### PR DESCRIPTION
* Add example of the map that is required for python_min to be manually enforced if it exists in `recipe/conda_build_config.yaml`.
* Add a tip that adding an explicit `python_min` also ensures that `python_min` used by `conda-build` does not deviate from the required Python metadata in the Python package. If the Python package required Python metadata is updated and the feedstock's recipe is not the build will fail, signalling that there is a metadata mismatch that needs to be corrected.
* Addresses discussion in https://github.com/conda-forge/uproot-feedstock/pull/161 (c.f. https://github.com/conda-forge/uproot-feedstock/pull/161#discussion_r1833558548).

PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below:

Relevant section of the netlify docs preview: https://deploy-preview-2370--conda-forge-previews.netlify.app/docs/maintainer/knowledge_base/#noarch-python