### PR TITLE
FAQ: document additional tools required for C/C++ development

### DIFF
--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -94,6 +94,12 @@ x86_64-apple-darwin13.4.0-clang: No such file or directory
 
 are a telltale sign that you are lacking compilers.
 
+Depending on the specific tools that you use for building C/C++ code, you may need some additional tools, for example:
+
+~~~
+compilers cmake pkg-config make ninja meson
+~~~
+
 <a id="faq-compiler-required-options"></a>
 
 <a id="why-don-t-the-c-c-compilers-automatically-know-how-to-find-libraries-installed-by-conda"></a>


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below


Whenever I suggest users to use conda-forge for C/C++ development, I almost always suggest them to install the packages:

~~~
compilers cmake pkg-config make ninja meson
~~~

while this list is quite an arbitrary choice (for example, most Windows users do not actually need make, and typically only one of cmake or meson is used) I found it useful to have a simple list of packages that users need to install, without having to think too much about it, so I thought it would be useful to have it in the main conda-forge docs.

I think this is particularly useful as sometimes the reason of why you need all this packages are really far from intuitive or obvious. Some examples:
* `compilers` instead of `cxx-compiler`: A user wants to develop a C++ library with CMake, so intuitively it just installs `cxx-compiler` and `cmake` packages. If it does that, CMake may fail complaining that a C compiler is not found, as CMake always look for a C compiler unless `LANGUAGES CXX` is not explicitly passed to the `project` command invocation. And even if a user sets `LANGUAGES CXX` in its root CMakeLists.txt, C language support could still be used in a `Find<pkg>` script or in a dependency included (even transitively) via `FetchContent`, so it is difficult to anticipate when `c-compiler` is also require, and when not.
* `cmake pkg-config` instead of `cmake`: many `Find<pkg>.cmake` scripts, either provided by CMake or in third party projects, rely on pkg-config being available for finding projects that install `.pc` files. Not having `pkg-config` may result in enigmatic `find_package(...)` failures, especially for not experienced users.


I sometimes wonder if it could make sense to a `build-essential` meta-package similar to the similar package available in Debian, but I guess that would be a longer discussion, as a first step just adding some details in the docs seemed the easiest thing to do.

I opened this PR just encountered users on Twitter confused by how to do C/C++ dev with conda-forge (see https://x.com/sitraversaro/status/1858085950078746697), and I realized it could be convenient to have this info in conda-forge docs.