### PR TITLE
Status page: do not error if migration details can't be fetched; show zeros instead

### DIFF
--- a/src/components/StatusDashboard/current_migrations.jsx
+++ b/src/components/StatusDashboard/current_migrations.jsx
@@ -277,15 +277,24 @@ function fetchContent(onLoad, setState) {
           for (const { name } of fetched[status]) {
             promises.push(
               (async (index) => {
+                let details;
                 try {
                   const url = urls.migrations.details.replace("<NAME>", name);
                   const response = await fetch(url);
-                  const details = await response.json();
-                  fetched[status][index].details = details;
-                  fetched[status][index].progress = measureProgress(details);
+                  details = await response.json();
                 } catch (error) {
                   console.warn(`error loading migration: ${name}`, error);
+                  details = {
+                    "done": [],
+                    "in-pr": [],
+                    "awaiting-pr": [],
+                    "awaiting-parents": [],
+                    "not-solvable": [],
+                    "bot-error": [],
+                  }
                 }
+                fetched[status][index].details = details;
+                fetched[status][index].progress = measureProgress(details);
               })(count++)
             );
           }
@@ -301,6 +310,7 @@ function fetchContent(onLoad, setState) {
           regular: patch.sort?.regular || prev.sort.regular,
           paused: patch.sort?.paused || prev.sort.paused
         };
+        console.log(fetched);
         const result = {
           ...prev,
           ...patch,


### PR DESCRIPTION
PR Checklist:

- [X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

Closes https://github.com/conda-forge/conda-forge.github.io/issues/2389. If the URLs are missing, all migrations will have progress 0. See screenshot for simulated failure mode (I changed the URLs in `constants.js` locally for this):

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/1433a02c-1ffc-4e38-b374-ff8c0120c711">
