### PR TITLE
sort src/core.csv by github handle

### DIFF
--- a/src/core.csv
+++ b/src/core.csv
@@ -6,9 +6,12 @@ cj-wright,cjwright4242@gmail.com,Christopher J. 'CJ' Wright
 dopplershift,rmay@ucar.edu,Ryan May
 ericdill,ericdill@pm.me,Eric Dill
 h-vetinari,h.vetinari@gmx.com,Axel Obermeier
+hmaarrfk,mark.harfouche@gmail.com,Mark Harfouche
 isuruf,isuruf@gmail.com,Isuru Fernando
+jaimergp,jrodriguez@quansight.com,Jaime Rodríguez-Guerra
 jakirkham,jkirkham@nvidia.com,John Kirkham
 jezdez,jleidel@anaconda.com,Jannis Leidel
+kkraus14,keith.j.kraus@gmail.com,Keith Kraus
 loriab,lori.burns@gmail.com,Lori A. Burns
 marcelotrevisani,marceloduartetrevisani@gmail.com,Marcelo Duarte Trevisani
 mariusvniekerk,marius.v.niekerk@gmail.com,Marius van Niekerk
@@ -16,13 +19,10 @@ mbargull,marcel.bargull@udo.edu,Marcel Bargull
 minrk,benjaminrk@gmail.com,Min Ragan-Kelley
 mwcraig,mattwcraig@gmail.com,Matt Craig
 ocefpaf,ocefpaf@gmail.com,Filipe Pires Alvarenga Fernandes
+soapy1,scastellarin@quansight.com,Sophia Castellarin
+sodre,psodre@gmail.com,Patrick Sodré
 SylvainCorlay,sylvain.corlay@gmail.com,Sylvain Corlay
 synapticarbors,joshua.adelman@gmail.com,Joshua Adelman
-sodre,psodre@gmail.com,Patrick Sodré
-soapy1,scastellarin@quansight.com,Sophia Castellarin
 viniciusdc,vinicius.douglas.cerutti9@gmail.com,Vinicius Douglas Cerutti
 wolfv,w.vollprecht@gmail.com,Wolf Vollprecht
 xhochy,mail@uwekorn.com,Uwe L. Korn
-kkraus14,keith.j.kraus@gmail.com,Keith Kraus
-jaimergp,jrodriguez@quansight.com,Jaime Rodríguez-Guerra
-hmaarrfk,mark.harfouche@gmail.com,Mark Harfouche


### PR DESCRIPTION
I was looking at https://github.com/conda-forge/conda-forge.github.io/blob/main/src/core.csv today and noticed that the table isn't sorted. It used to be in the past (c.f. https://github.com/conda-forge/conda-forge.github.io/commit/b7be54cc4f8dab0b0e93e55219cd7b5954390404), so let's sort it.