### PR TITLE
add announcement to drop CUDA 11.8

### DIFF
--- a/news/2025-05-29-cuda-118.md
+++ b/news/2025-05-29-cuda-118.md
@@ -1,0 +1,61 @@
+# Dropping CUDA 11.8 as a default CUDA version
+
+CUDA 11.8 is the last holdover from the old days before conda-forge
+[switched](https://github.com/conda-forge/conda-forge.github.io/issues/1963)
+to the new and shiny CUDA 12+ infrastructure, where the CUDA toolchain
+is provided as native conda-packages, rather than a blob in an image.
+
+For CUDA-enabled feedstocks, we've been building both 11.8 and 12.6 by default
+for a while now, but many feedstocks (notably pytorch, tensorflow, onnx, jax etc.)
+have dropped CUDA 11.8 for many months already.
+
+Due to various constraints (details below), we are dropping CUDA 11.8 as a default
+version in our global pinning in one week. It will still be possible to opt into
+building CUDA 11.8 on a per-feedstock basis where this is necessary or beneficial.
+
+<!-- truncate -->
+
+The above-mentioned contraints are mainly:
+
+* it complicates our pinning due to needing to switch images and compilers with 11.8.
+* it keeps us from [migrating](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7005)
+  to newer CUDA 12.x versions necessary to support new architectures.
+* it's not compatible with VS2022, which is due to become the default toolchain on windows
+  in conda-forge soon (the previous VS2019 has reached end-of-life more than a year ago).
+* it complicates our infrastructure in several places, due to the big differences between the
+  before/after of the new CUDA architecture.
+
+After we have removed CUDA 11.8 from the pinning, any feedstock still building that version
+will drop the respective CI jobs upon rerendering. For feedstocks wanting to keep building
+CUDA 11.8 a bit longer, here's a sample configuration you can put under
+`recipe/conda_build_config.yaml` (and then rerender).
+
+```yaml
+cuda_compiler:
+  - None
+  - nvcc                    # [linux or win]
+  - cuda-nvcc               # [linux or win]
+cuda_compiler_version:
+  - None
+  - 11.8                    # [linux or win]
+  - 12.4                    # [linux and ppc64le]
+  - 12.8                    # [(linux and not ppc64le) or win]
+# CUDA 11.8 is not compatible with current compilers
+c_compiler:                 # [win]
+  - vs2019                  # [win]
+cxx_compiler:               # [win]
+  - vs2019                  # [win]
+c_compiler_version:         # [linux]
+  - 11                      # [linux]
+cxx_compiler_version:       # [linux]
+  - 11                      # [linux]
+fortran_compiler_version:   # [linux]
+  - 11                      # [linux]
+```
+
+Due to changes in the pinning structure (which keys are zipped together), it's possible that
+further adaptations are necessary; you can ping conda-forge/core for that. Also, please let us
+know in the [issue](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/7404)
+if your feedstock still needs to support CUDA 11.8 and why (later down the line we'll want to
+drop support also in conda-forge-ci-setup, and knowing what feedstocks - if any - still need
+CUDA 11.8 will help guide the decision on timing).


### PR DESCRIPTION
For https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/7404, as discussed in core call today.