### PR TITLE
DOC: remove numpy `pin_compatible` reference

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -761,17 +761,16 @@ Other OpenGL API variants such as `libegl-devel`, `libgles-devel`, `libglx-devel
 
 ### Building Against NumPy
 
-Packages that link against NumPy need special treatment in the dependency section.
 Finding `numpy.get_include()` in `setup.py` or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
 
-In the case of linking, you need to use the `pin_compatible` function to ensure having a compatible numpy version at run time:
+Adding `numpy` in the `host:` section is sufficient to have a compatible NumPy version at run time:
 
 ```yaml
 host:
   - numpy
 ```
 
-At the time of writing (June 2025), above is equivalent to the following,
+At the time of writing (June 2025), the above is equivalent to the following:
 
 ```yaml title="recipe/conda_build_config.yaml"
 host:
@@ -779,7 +778,7 @@ host:
 ```
 
 See the pinning repository for
-[what the pinning corresponds to](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L742) at any given time.
+[what the pinning corresponds to](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml) at any given time.
 
 In either case, the actual runtime requirements are determined through numpy's
 run-export, which is:


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

I noticed `pin_compatible` was still mentioned in this section (in submitting this [PR](https://github.com/conda-forge/staged-recipes/pull/30212#discussion_r2124349741)). I removed the reference and the "special treatment" line as it's not necessarily true now.

The pinning feedstock link isn't a permalink and has the wrong line number for `numpy:` so I removed the line reference. For something you want to see the latest version, a permalink is probably the wrong choice. And keeping the `numpy:` line number up-to-date isn't likely worth it.