### PR TITLE
remove remaining leftovers of old numpy pinning

### DIFF
--- a/docs/maintainer/adding_pkgs.md
+++ b/docs/maintainer/adding_pkgs.md
@@ -1174,7 +1174,6 @@ Jinja expressions serve following purposes in the meta.yaml:
       - numpy
     run:
       - python
-      - {{ pin_compatible('numpy') }}
   ```
 
 For more information please refer to the [Templating with Jinja](https://docs.conda.io/projects/conda-build/en/stable/resources/define-metadata.html#templating-with-jinja) section in the conda-build docs.

--- a/docs/maintainer/pinning_deps.md
+++ b/docs/maintainer/pinning_deps.md
@@ -44,8 +44,22 @@ Should be replaced by
 requirements:
   host:
     - gmp
+  # most libraries will automatically add the corresponding runtime requirement using
+  # a so-called "run-export" from the gmp build pulled into the host environment.
+  # In that case you can leave out the following run-requirement:
   run:
     - gmp
+```
+
+The run-export mechanism (see below) additionally ensures the correct version constraints
+(corresponding to the expected API/ABI stability of `gmp`) are added, so a recipe with an
+unpinned `gmp` dependency in the host environment will, in the end, work as follows:
+```yaml
+requirements:
+  host:
+    - gmp {{ version_from_global_pinning }}.*
+  run:
+    - gmp >={{ version_from_global_pinning }},<{{ next_version_with_breaking_changes }}
 ```
 
 When there's a new ABI version of gmp (say 7.0), then conda-forge-pinning will be updated. A re-rendering of a package using gmp will change. Therefore to check that a recipe needs to be rebuilt for updated pinnings, you only need to check if the package needs a rerender.
@@ -56,7 +70,11 @@ If a package is not pinned in [conda-forge-pinning](https://github.com/conda-for
 
 :::note
 
-If the constraints in `conda-forge-pinning` are not strict enough, you can override them by changing back to pinning the package with a version manually. You can make a pinning stricter by adding `{{ pin_compatible('gmp', max_pin='x.x.x') }}` to run requirements.
+If the constraints in `conda-forge-pinning` (resp. those coming from the package's run-exports)
+are not strict enough, you can override them by changing back to pinning the package with
+a version manually.
+You can make a pinning stricter by adding `{{ pin_compatible('gmp', max_pin='x.x.x') }}`
+to run requirements.
 
 :::
 

--- a/docs/maintainer/pinning_deps.md
+++ b/docs/maintainer/pinning_deps.md
@@ -50,10 +50,6 @@ requirements:
 
 When there's a new ABI version of gmp (say 7.0), then conda-forge-pinning will be updated. A re-rendering of a package using gmp will change. Therefore to check that a recipe needs to be rebuilt for updated pinnings, you only need to check if the package needs a rerender.
 
-:::note
-
-`NumPy` is an exception to this (See [Building Against NumPy](knowledge_base.md#linking-numpy)).
-
 :::
 
 If a package is not pinned in [conda-forge-pinning](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/conda_build_config.yaml), then the pinning needs to be done manually. If the package is a `C/C++` library with a `C/C++` API that is consumed and linked to by other libraries, then that package is a candidate to be added to `conda-forge-pinning`. Please open an issue in [conda-forge-pinning-feedstock](https://github.com/conda-forge/conda-forge-pinning-feedstock) for discussion.


### PR DESCRIPTION
This was mostly done in https://github.com/conda-forge/conda-forge.github.io/commit/6d6f846c4d6bd25146ab50b6ba674f96a93e5df2 and https://github.com/conda-forge/conda-forge.github.io/commit/585d0b4d8546a792d58bf6e7ae593c331fbbbfb1, but some other occurrences were hiding elsewhere.

Closes #2037
Closes #2156