### PR TITLE
add announcement for moving to VS2022

### DIFF
--- a/news/2025-06-11-moving-to-vs2022.md
+++ b/news/2025-06-11-moving-to-vs2022.md
@@ -1,0 +1,15 @@
+# Moving to Visual Studio 2022 as default windows compiler
+
+Microsoft's Visual Studio (VS) 2019 compiler has reached its
+[end of life](https://learn.microsoft.com/en-us/lifecycle/products/visual-studio-2019)
+over a year ago. In the meantime, several projects have moved on and
+fail to compile with VS2019.
+
+We are planning to update our default compilers on windows to the (fully compatible)
+successor VS2022 in one week from now.
+
+This will not affect you as a general user of conda-forge packages on windows;
+the only potential impact is that if you are compiling locally with VS2019 against
+artefacts produced by conda-forge, you might be required to upgrade.
+
+For more details see https://github.com/conda-forge/conda-forge.github.io/issues/2138.


### PR DESCRIPTION
As discussed in the core call two weeks ago
https://github.com/conda-forge/conda-forge.github.io/blob/39c236329d7b221165481b0e39ba011da04271e2/community/minutes/2025-05-28.md?plain=1#L53-L59

Now that CUDA 11.8 is dropped, there's no blocker anymore.