### PR TITLE
update announcement to explain custom migrator for continuing to build CUDA 11.8

### DIFF
--- a/news/2025-05-29-cuda-118.md
+++ b/news/2025-05-29-cuda-118.md
@@ -27,56 +27,17 @@ The above-mentioned contraints are mainly:
 
 After we have removed CUDA 11.8 from the pinning, any feedstock still building that version
 will drop the respective CI jobs upon rerendering. For feedstocks wanting to keep building
-CUDA 11.8 a bit longer, here's a sample configuration you can put under
-`recipe/conda_build_config.yaml` (and then rerender).
+CUDA 11.8 a bit longer, we have provided a custom migrator.
 
-```yaml
-cuda_compiler:
-  - None
-  - nvcc                    # [linux or win]
-  - cuda-nvcc               # [linux or win]
-cuda_compiler_version:
-  - None
-  - 11.8                    # [linux or win]
-  - 12.4                    # [linux and ppc64le]
-  - 12.8                    # [(linux and not ppc64le) or win]
+The way to make use of this is to copy
+[`cuda118.yaml`](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/migrations/cuda118.yaml)
+from the global pinning into `.ci_support/migrations` on your feedstock.
+If the `migrations` subfolder doesn't exist, please create it. Once that's committed
+(and there are no skips in the recipe for CUDA 11.8), rerendering the feedstock
+will reinstate the builds for CUDA 11.8. If you have trouble with that, please open
+a thread on https://conda-forge.zulipchat.com/.
 
-# use the same 11.8-enabled image for all variants (changes to ubi8,
-# down from default alma9, also for non-CUDA and CUDA 12 builds)
-docker_image:                                               # [linux]
-  # CUDA 11.8 builds
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [linux64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  # CUDA 11.8 arch: native compilation (build == target)
-  - quay.io/condaforge/linux-anvil-aarch64-cuda11.8:ubi8    # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-aarch64"]
-  - quay.io/condaforge/linux-anvil-ppc64le-cuda11.8:ubi8    # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-ppc64le"]
-  # CUDA 11.8 arch: cross-compilation (build != target)
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [aarch64 and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8     # [ppc64le and os.environ.get("BUILD_PLATFORM") == "linux-64"]
-
-# CUDA 11.8 is not compatible with current compilers
-c_compiler:                 # [win]
-  - vs2019                  # [win]
-cxx_compiler:               # [win]
-  - vs2019                  # [win]
-c_compiler_version:         # [linux]
-  - 13                      # [linux]
-  - 11                      # [linux]
-  - 12                      # [linux and ppc64le]
-  - 13                      # [linux and not ppc64le]
-cxx_compiler_version:       # [linux]
-  - 13                      # [linux]
-  - 11                      # [linux]
-  - 12                      # [linux and ppc64le]
-  - 13                      # [linux and not ppc64le]
-fortran_compiler_version:   # [linux]
-  - 13                      # [linux]
-  - 11                      # [linux]
-  - 12                      # [linux and ppc64le]
-  - 13                      # [linux and not ppc64le]
-```
-
-Due to changes in the pinning structure (which keys are zipped together), it's possible that
-further adaptations are necessary; you can ping conda-forge/core for that. Also, please let us
+Finally, please let us
 know in the [issue](https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/7404)
 if your feedstock still needs to support CUDA 11.8 and why (later down the line we'll want to
 drop support also in conda-forge-ci-setup, and knowing what feedstocks - if any - still need


### PR DESCRIPTION
Follow-up to #2532 now that https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7472 has been merged.