### PR TITLE
ENH: Add warning that quoting CMAKE_ARGS can cause errors

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -86,6 +86,14 @@ Some optional, but useful CMake options:
 - `-DCMAKE_FIND_FRAMEWORK=NEVER` and `-DCMAKE_FIND_APPBUNDLE=NEVER` Prevent CMake from using system-wide macOS packages.
 - `${CMAKE_ARGS}` Add variables defined by conda-forge internally. This is required to enable various conda-forge enhancements, like [CUDA builds](#cuda).
 
+:::warning
+
+As `${CMAKE_ARGS}` is a space separated list of options, quoting `${CMAKE_ARGS}`
+(`"${CMAKE_ARGS}"`) in recipes can lead to build errors as quoting makes the shell
+treat the contents of the variable as a single argument.
+
+:::
+
 Here are some basic commands for you to get started. These are dependent on your source
 code layout and aren't intended to be used "as is".
 


### PR DESCRIPTION
* Add warning after `${CMAKE_ARGS}` is first introduced that quoting this variable in recipes can lead to build errors as it is a space separated list of options.
   - c.f. https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/.E2.9C.94.20Validation.20C.2FFortran.20compatibility.20with.20CMAKE_ARGS/with/524918138 for motivation.

PR Checklist:

- [N/A] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below
   - c.f. https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/.E2.9C.94.20Validation.20C.2FFortran.20compatibility.20with.20CMAKE_ARGS/with/524918138 for motivation.