### PR TITLE
add announcement for new GCC/Clang default versions

### DIFF
--- a/news/2025-07-01-moving-to-gcc-14-clang-19.md
+++ b/news/2025-07-01-moving-to-gcc-14-clang-19.md
@@ -1,0 +1,6 @@
+# Moving to GCC 14 and Clang 19 as default compiler versions
+
+As part of our regular toolchain updates, we're planning to update the default
+versions of GCC (for linux) to v14 and of Clang (for OSX) to v19, in one week.
+
+For more details, see https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7421.


### PR DESCRIPTION
This was already discussed a month ago
https://github.com/conda-forge/conda-forge.github.io/blob/57bdfbc18fce6a77871f55013d12db8785c56bcf/community/minutes/2025-05-28.md?plain=1#L51-L52

Now that all pieces are in place (https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7421), make the announcement.