### PR TITLE
Update knowledge_base.md

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1397,10 +1397,10 @@ package will have the necessary runtime requirements to ensure the most adequate
 ### Matplotlib
 
 `matplotlib` on conda-forge comes in two parts. The core library is in `matplotlib-base`. The
-actual `matplotlib` package is this core library plus `pyqt`. Most, if not all, packages that have
+actual `matplotlib` package is this core library plus `pyside6`. Most, if not all, packages that have
 dependence at runtime on `matplotlib` should list this dependence as `matplotlib-base` unless they
-explicitly need `pyqt`. The idea is that a user installing `matplotlib` explicitly would get a full
-featured installation with `pyqt`. However, `pyqt` is a rather large package, so not requiring it
+explicitly need `pyside6`. The idea is that a user installing `matplotlib` explicitly would get a full
+featured installation with `pyside6`. However, `pyside6` is a rather large package, so not requiring it
 indirectly is better for performance. Note that you may need to include a `yum_requirements.txt` file
 in your recipe with
 


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

The matplotlib feedstock changed the qt wrapper from pyqt to pyside6. So the hint towards the pyqt requirement is outdated. See this commit:
https://github.com/conda-forge/matplotlib-feedstock/commit/330c36ec6422f95df9b7997dd1c7ef7c45d3b341

