### PR TITLE
Fix the download links for macos

### DIFF
--- a/src/components/Download/index.jsx
+++ b/src/components/Download/index.jsx
@@ -10,14 +10,14 @@ export default function Download() {
       {
           arch: "arm64 (Apple Silicon)",
           dark: "img/download/apple.svg",
-          href: "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh",
+          href: "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Darwin-arm64.sh",
           light: "img/download/apple.svg",
           os: "macOS",
       },
       {
           arch: "x86_64 (Intel)",
           dark: "img/download/apple.svg",
-          href: "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh",
+          href: "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Darwin-x86_64.sh",
           light: "img/download/apple.svg",
           os: "macOS",
       },


### PR DESCRIPTION
The download page linked to installers with `MacOSX` in the filename, but then told people to execute the script on macos by running `bash Miniforge3-$(uname)[...]` which returns `Darwin` not `MacOSX`. This fix changes the URL to match the script.

Fixes https://github.com/conda-forge/miniforge/issues/808

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
