### PR TITLE
Adjust apple silicon migration instructions

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -2141,7 +2141,7 @@ To request a migration for a particular package and all its dependencies:
    especially if many dependencies need to be built as well.
 3. If nothing is under way, look at the current [conda-forge-pinning](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/osx_arm64.txt).
 4. If the package is not listed there, make a PR, adding the package
-   name to a random location in `osx_arm64.txt`.
+   name to `osx_arm64.txt` (preserving the alphabetical ordering).
    The migration bot should start making automated pull requests to the
    repo and its dependencies.
 5. Within a few hours, the [status page](https://conda-forge.org/status/#armosxaddition)


### PR DESCRIPTION
Howdy, just a small adjustment to the migration instructions - the pre-commit hook on conda-forge-pinning-feedstock complains if `osx_arm64.txt` is not sorted, e.g.:

https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7640/commits/85b317b5c69f6dd9b4be611179dfced1d25d0552
https://results.pre-commit.ci/run/github/113883111/1754561159.3DdDF25yT_qisYecIanz7A

PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
