### PR TITLE
KB: attempt updating the OpenMP documentation

### DIFF
--- a/docs/maintainer/knowledge_base.md
+++ b/docs/maintainer/knowledge_base.md
@@ -1170,13 +1170,13 @@ a different runtime through their build system configuration.
 On Linux, building against `libgomp` is recommended as the other OpenMP providers are backwards compatible with it.
 When packages are built against `libgomp`, it is possible to use both `libgomp` and `llvm-openmp` provider at runtime.
 
-Dependencies on OpenMP providers belong in the `build` section of recipe dependencies. The following snippet corresponds
+Dependencies on OpenMP providers belong in the `host` section of recipe dependencies. The following snippet corresponds
 to the defaults, though individual packages may require a different set:
 
 ```yaml
 # meta.yaml
 requirements:
-  build:
+  host:
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
 ```


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

------

Attempt to make the OpenMP entry in the Knowledge Base clearer. Notably:

- avoid suggesting that OpenMP gets enabled automatically (apparently this was the case up to gfortran-9, but not anymore) -- now it needs to be enabled by packages explicitly

- indicate which implementations are used by default but make it clear that different packages may be forcing other implementations

- explicitly recommend building against libgomp on Linux

- fill Windows support in

CC @isuruf, @jaimergp 