### PR TITLE
Fix typo in `conda-smithy` command

### DIFF
--- a/docs/maintainer/updating_pkgs.md
+++ b/docs/maintainer/updating_pkgs.md
@@ -159,7 +159,7 @@ conda install -c conda-forge conda-smithy
 Commit all changes and from the root directory of the feedstock, type:
 
 ```shell-session
-conda smithy rerender -c auto
+conda-smithy rerender -c auto
 ```
 
 Optionally one can commit the changes manually.


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below


---

Just learning more about maintaining conda-forge feedstocks, and this seems like a typo? 