### PR TITLE
Update transitioning_from_defaults.md to recent python3

### DIFF
--- a/docs/user/transitioning_from_defaults.md
+++ b/docs/user/transitioning_from_defaults.md
@@ -22,7 +22,7 @@ Miniforge.
 ## Trying conda-forge in an isolated environment
 
 1. Create a conda environment with very few dependencies. The following
-   command will only use packages from `conda-forge` to install Python 3.14. You
+   command will only use packages from `conda-forge` to install Python. You
    may adjust the version of Python to the one of your liking:
 
    ```bash


### PR DESCRIPTION
PR Checklist:

- [ X] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords) -- none
- [X] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file -- no new page
- [X] put any other relevant information below

The current documentation at https://conda-forge.org/docs/user/transitioning_from_defaults/ indicates that a default python=3 environment created by `conda create --name conda-forge-env python=3 --channel conda-forge --override-channels` will install python 3.11.  However, the current conda-forge python default is 3.14.

I'm not sure whether it is better to make the doc revision match the default, or to drop the revision out of the text.  Before, someone chose the explicit revision in the text, which makes sens, but is now outdated.
