### PR TITLE
Add status passing/failing/unknown/... in migration table

### DIFF
--- a/src/pages/status/migration/styles.module.css
+++ b/src/pages/status/migration/styles.module.css
@@ -180,3 +180,16 @@
   position: relative;
   left: 14px;
 }
+
+.ci_status_legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.ci_status_item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
This adds a CI status column to https://conda-forge.org/status/migration/?name=python314t, (the value is already present in the data and the graph), and I mostly care about failing ones to help fixing them.

While at it, makes the column sortable because it's nice.
<img width="681" height="627" alt="Screenshot 2025-11-25 at 13 49 39" src="https://github.com/user-attachments/assets/ca18813c-c270-4eb2-a2ba-baecb5a3ac45" />
