### PR TITLE
Share table sorting component & update sortable keys

### DIFF
--- a/src/components/SortableTable/index.jsx
+++ b/src/components/SortableTable/index.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useState } from "react";
+
+/**
+ * Custom hook for managing table sorting state with secondary sort support
+ * @param {string} initialSortBy - Initial sort column
+ * @param {string} initialOrder - Initial sort order ("ascending" or "descending")
+ * @returns {{ sort: object, previousSort: object, resort: function }} - Sort state, previous sort state, and resort function
+ */
+export function useSorting(initialSortBy, initialOrder = "ascending") {
+  const [sort, setSort] = useState({ by: initialSortBy, order: initialOrder });
+  const [previousSort, setPreviousSort] = useState(null);
+
+  const resort = (by) => {
+    setSort((prev) => {
+      let order = "ascending";
+      order = by === prev.by && order === prev.order ? "descending" : order;
+      // Save previous sort state (but only if it's a different column)
+      if (by !== prev.by) {
+        setPreviousSort(prev);
+      }
+      return { by, order };
+    });
+  };
+
+  return { sort, previousSort, resort };
+}
+
+/**
+ * Sortable table header component
+ * @param {string} sortKey - The key to sort by when clicked
+ * @param {object} currentSort - Current sort state { by, order }
+ * @param {function} onSort - Callback function when header is clicked
+ * @param {object} styles - CSS module styles object
+ * @param {object} style - Inline styles for the header
+ * @param {React.ReactNode} children - Header content
+ */
+export function SortableHeader({ sortKey, currentSort, onSort, styles, style, children }) {
+  const isActive = currentSort.by === sortKey;
+  const className = isActive ? styles[currentSort.order] : undefined;
+
+  return (
+    <th
+      style={{ cursor: "pointer", userSelect: "none", ...style }}
+      className={className}
+      onClick={() => onSort(sortKey)}
+    >
+      {children}
+    </th>
+  );
+}

--- a/src/pages/status/migration/styles.module.css
+++ b/src/pages/status/migration/styles.module.css
@@ -193,3 +193,17 @@
   align-items: center;
   gap: 8px;
 }
+
+.migration_details table th {
+  position: relative;
+}
+
+.migration_details table th.ascending::after {
+  content: " △";
+  font-size: smaller;
+}
+
+.migration_details table th.descending::after {
+  content: " ▽";
+  font-size: smaller;
+}


### PR DESCRIPTION
on top of #2668

-- 
- This extract the sorting tables into their own components.
- Use that also in /status/migrations/?name=....

Therefore it adds logic to also sort by CI status and updated_at,
as ci status is an enum, we now track the previous column we sort with
so that you can sort by status (and break tie by updated_at), or any
other tie break with the second to last sorted column.

CI status and updated_at that are null are always sorted last.

I guess the sorting table coudl take a mapping from field name to a
comparison function, but it would be starting to be a bit of a heavy
handed approach I think.
