### PR TITLE
Fix category page titles for how-to guides

### DIFF
--- a/docs/how-to/advanced.mdx
+++ b/docs/how-to/advanced.mdx
@@ -2,7 +2,7 @@
 tags: [how-to, advanced]
 ---
 
-# Emergencies
+# Advanced
 
 The following how-to guides are available in this category:
 

--- a/docs/how-to/basics.mdx
+++ b/docs/how-to/basics.mdx
@@ -2,7 +2,7 @@
 tags: [how-to, basic]
 ---
 
-# Emergencies
+# Basics
 
 The following how-to guides are available in this category:
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below
