### PR TITLE
Exclude www.quansight.com from link checker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
             --exclude 'https://ss64.com/nt/syntax.html'
             --exclude 'https://www.mesa3d.org/'
             --exclude 'https://www.quansight.com/'
+            --exclude 'https://conda-forge.herokuapp.com/status-monitor'
             --exclude '.*/404.html/'
             --exclude '.*,.*'
             --exclude-path './build/community/minutes/'


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

The checks for Quansight website are repeatedly hitting timeouts from GitHub Actions.  Let's exclude them, so they don't cause the workflow to fail unnecessarily.

