### PR TITLE
fix: Quote python_version wildcard

### DIFF
--- a/docs/maintainer/example_recipes/pure-python.md
+++ b/docs/maintainer/example_recipes/pure-python.md
@@ -170,12 +170,12 @@ tests:
         - example-package
       python_version:
         - ${{ python_min }}.*
-        - *
+        - "*"
       pip_check: true
 ```
 
 - `imports`: List the Python modules to import to verify the package installed correctly. This ensures basic functionality.
-- `python_version`: Test against the minimum supported Python version to ensure compatibility. Also test against the latest Python version (`*`) to catch any issues with newer releases.
+- `python_version`: Test against the minimum supported Python version to ensure compatibility. Also test against the latest Python version (`"*"`) to catch any issues with newer releases.
 - `pip_check`: Runs `pip check` to ensure all dependencies are satisfied and there are no conflicts.
 
 #### Command line tests


### PR DESCRIPTION
* If an unquoted wildcard is used for python_version the rattler-build recipe will fail.
* Amends PR https://github.com/conda-forge/conda-forge.github.io/pull/2739

Example:

```console
$ git clone git@github.com:conda-forge/contur-feedstock.git && contur-feedstock
$ git diff
diff --git a/recipe/recipe.yaml b/recipe/recipe.yaml
index 5cc7585..ec228f7 100644
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -93,7 +93,7 @@ tests:
       pip_check: true
       python_version:
         - ${{ python_min }}.*
-        - "*"
+        - *
   - script:
       - contur --version
       - contur --help
$ pixi run build-locally
...
Error:   × Failed to parse recipe
  ╰─▶ parse error: Failed to parse YAML: 96:11: while scanning an anchor or alias, did not find expected alphabetic or numeric character
   ╭─[/home/conda/recipe_root/recipe.yaml:1:1]
 1 │ schema_version: 1
   · ▲
   · ╰── Failed to parse YAML: 96:11: while scanning an anchor or alias, did not find expected alphabetic or numeric character
 2 │ 
   ╰────

Traceback (most recent call last):
  File "/home/feickert/Code/GitHub/conda-forge/hep-packaging-coordination/contur-feedstock/./build-locally.py", line 125, in <module>
    main()
  File "/home/feickert/Code/GitHub/conda-forge/hep-packaging-coordination/contur-feedstock/./build-locally.py", line 113, in main
    run_docker_build(ns)
  File "/home/feickert/Code/GitHub/conda-forge/hep-packaging-coordination/contur-feedstock/./build-locally.py", line 34, in run_docker_build
    subprocess.check_call([script])
  File "/home/feickert/Code/GitHub/conda-forge/hep-packaging-coordination/contur-feedstock/.pixi/envs/smithy/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['.scripts/run_docker_build.sh']' returned non-zero exit status 1.
```

PR Checklist:

- [N/A] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below
