### PR TITLE
Add llvm-openmp as recommended OpenMP runtime for Windows

### DIFF
--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -782,8 +782,8 @@ corresponding compilers in `requirements/build` as normal.
 
 The default OpenMP runtime used depends on the compiler and platform used. GCC (on Linux and the Windows MinGW
 toolchain) uses the `libgomp` runtime. Clang (on all platforms) and GNU Fortran on macOS default to the `llvm-openmp`
-runtime. MSVC may use its own runtime or `llvm-openmp`. However, individual projects may force building against
-a different runtime through their build system configuration.
+runtime. For MSVC `llvm-openmp` is recommended, though `llvm-openmp` requires use of the `/openmp:llvm` option.
+However, individual projects may force building against a different runtime through their build system configuration.
 
 On Linux, building against `libgomp` is recommended as the other OpenMP providers are backwards compatible with it.
 When packages are built against `libgomp`, it is possible to use both `libgomp` and `llvm-openmp` provider at runtime.
@@ -794,19 +794,31 @@ to the defaults, though individual packages may require a different set:
 <RecipeTabs>
 
 ```recipe
+build:
+   script:
+    - set "CXXFLAGS=%CXXFLAGS% /openmp:llvm"  # [win]
+
+...
+
 requirements:
   host:
-    - llvm-openmp  # [osx]
     - libgomp      # [linux]
+    - llvm-openmp  # [not linux]
 ```
 
 ```recipe
+build:
+   script:
+    - if: win
+      then: set "CXXFLAGS=%CXXFLAGS% /openmp:llvm"
+
+...
+
 requirements:
   host:
-    - if: osx
-      then: llvm-openmp
     - if: linux
       then: libgomp
+      else: llvm-openmp
 ```
 
 </RecipeTabs>


### PR DESCRIPTION
* Add recommendation of having `llvm-openmp` be a host requirement for Windows builds that need an OpenMP runtime and note that for this to work the `/openmp:llvm` option must be added.
   - c.f. https://learn.microsoft.com/en-us/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-170
* c.f. [#general > ✔ Help with Windows, CMake, Ninja, and overlinking @ 💬](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/.E2.9C.94.20Help.20with.20Windows.2C.20CMake.2C.20Ninja.2C.20and.20overlinking/near/584590316)

PR Checklist:

- [N/A] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [N/A] put any other relevant information below
