### PR TITLE
docs: tweak build flags in example Go recipe

### DIFF
--- a/docs/maintainer/example_recipes/go.md
+++ b/docs/maintainer/example_recipes/go.md
@@ -23,8 +23,8 @@ build:
     - cd src
     - go-licenses save . --save_path ../library_licenses
     - if: unix
-      then: go build -v -o $PREFIX/bin/example-package -ldflags="-s -w"
-      else: go build -v -o %LIBRARY_BIN%\example-package.exe -ldflags="-s"
+      then: go build -v -o $PREFIX/bin/example-package -ldflags="-s -w" -trimpath .
+      else: go build -v -o %LIBRARY_BIN%\example-package.exe -ldflags="-s -w" -trimpath .
     - if: unix
       then:
         - mkdir -p $PREFIX/share/zsh/site-functions $PREFIX/share/bash-completion/completions $PREFIX/share/fish/vendor_completions.d


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

### Summary

- Added the `-w` ldflag to tell the linker to omit the DWARF symbol table and thereby reduce binary size on Windows, too (not an issue anymore these days, IIUC).
- Added the `-trimpath` flag to make the compiler replace all local build system paths in the binary with generic, relative paths, thereby improving build reproducibility.