### PR TITLE
infrastructure: Update `staged-recipes` workflows description

### DIFF
--- a/docs/maintainer/infrastructure.mdx
+++ b/docs/maintainer/infrastructure.mdx
@@ -56,8 +56,7 @@ The actual creation of the feedstock is run in [conda-forge/admin-requests](#adm
 
 Additional workflows help users set up their recipes correctly. They react to events in PRs:
 
-- [`automate-review-labels`](https://github.com/conda-forge/staged-recipes/blob/main/.github/workflows/automate-review-labels.yml): Updates PR labels to streamline reviews and requests for help.
-- [`linter`](https://github.com/conda-forge/staged-recipes/blob/main/.github/workflows/linter.yml): General recipe linting plus some staged-recipes specific checks, like not editing the examples.
+- [`staged-recipes-linter`](https://github.com/conda-forge/staged-recipes/blob/main/.github/workflows/staged-recipes-linter.yml): General recipe linting plus some staged-recipes specific checks, like not editing the examples.
 
 External services connect to `staged-recipes` too:
 


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

Update the description for workflows run by `staged-recipes`, removing the removed `automate-review-labels` workflow and updating the name for the `staged-recipes-linter` workflow.  This fixes "check links" failures on the CI.

