### PR TITLE
docs: Move "Building Against NumPy" to a dedicated how-to page

### DIFF
--- a/docs/_sidebar_diataxis.json
+++ b/docs/_sidebar_diataxis.json
@@ -102,9 +102,9 @@
         },
         "items": [
           {
-            "type": "link",
+            "type": "doc",
             "label": "Deal with numpy",
-            "href": "/docs/maintainer/knowledge_base/#building-against-numpy"
+            "id": "how-to/advanced/numpy"
           },
           {
             "type": "doc",

--- a/docs/how-to/advanced/numpy.mdx
+++ b/docs/how-to/advanced/numpy.mdx
@@ -1,0 +1,80 @@
+---
+tags: [howto, advanced]
+---
+
+import { RecipeTabs } from "@site/src/components/RecipeTabs";
+
+# Building Against NumPy
+
+Finding `numpy.get_include()` in `setup.py` or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
+
+Adding `numpy` in the `host:` section is sufficient to have a compatible NumPy version at run time:
+
+<RecipeTabs>
+
+```recipe
+requirements:
+  host:
+    - numpy
+```
+
+```recipe
+requirements:
+  host:
+    - numpy
+```
+
+</RecipeTabs>
+
+At the time of writing (June 2025), the above is equivalent to the following:
+
+<RecipeTabs>
+
+```recipe
+requirements:
+  host:
+    - numpy 2.*
+```
+
+```recipe
+requirements:
+  host:
+    - numpy 2.*
+```
+
+</RecipeTabs>
+
+See the pinning repository for
+[what the pinning corresponds to](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml) at any given time.
+
+In either case, the actual runtime requirements are determined through numpy's
+run-export, which is:
+
+- `>=1.2x,<2` if you're building against numpy 1.2x
+- `>=1.19,<3` if you're building against numpy 2.0
+- `>=1.21,<3` if you're building against numpy 2.1 or 2.2
+- `>=1.23,<3` if you're building against numpy 2.3
+
+If the package you are building has a higher minimum requirement for numpy, please add this under `run`:
+
+<RecipeTabs>
+
+```recipe
+requirements:
+  host:
+    # leave this unpinned!
+    - numpy
+  run:
+    - numpy >={{ the_lower_bound_your_package_needs }}
+```
+
+```recipe
+requirements:
+  host:
+    # leave this unpinned!
+    - numpy
+  run:
+    - numpy >=${{ the_lower_bound_your_package_needs }}
+```
+
+</RecipeTabs>

--- a/docs/how-to/advanced/numpy.mdx
+++ b/docs/how-to/advanced/numpy.mdx
@@ -6,7 +6,7 @@ import { RecipeTabs } from "@site/src/components/RecipeTabs";
 
 # Building Against NumPy
 
-Finding `numpy.get_include()` in `setup.py` or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
+Finding `numpy.get_include()` in `setup.py`, `dependency('numpy')` in `meson.build`, or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
 
 Adding `numpy` in the `host:` section is sufficient to have a compatible NumPy version at run time:
 

--- a/docs/how-to/advanced/numpy.mdx
+++ b/docs/how-to/advanced/numpy.mdx
@@ -6,7 +6,7 @@ import { RecipeTabs } from "@site/src/components/RecipeTabs";
 
 # Building Against NumPy
 
-Finding `numpy.get_include()` in `setup.py`, `dependency('numpy')` in `meson.build`, or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
+Finding `numpy.get_include()` in `setup.py`, `numpy` in `build-system.requires` of `pyproject.toml`, `dependency('numpy')` in `meson.build`, or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
 
 Adding `numpy` in the `host:` section is sufficient to have a compatible NumPy version at run time:
 

--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -308,78 +308,7 @@ Other OpenGL API variants such as `libegl-devel`, `libgles-devel`, `libglx-devel
 
 ### Building Against NumPy
 
-Finding `numpy.get_include()` in `setup.py` or `cimport` statements in `.pyx` or `.pyd` files are a telltale sign that the package links against NumPy.
-
-Adding `numpy` in the `host:` section is sufficient to have a compatible NumPy version at run time:
-
-<RecipeTabs>
-
-```recipe
-requirements:
-  host:
-    - numpy
-```
-
-```recipe
-requirements:
-  host:
-    - numpy
-```
-
-</RecipeTabs>
-
-At the time of writing (June 2025), the above is equivalent to the following:
-
-<RecipeTabs>
-
-```recipe
-requirements:
-  host:
-    - numpy 2.*
-```
-
-```recipe
-requirements:
-  host:
-    - numpy 2.*
-```
-
-</RecipeTabs>
-
-See the pinning repository for
-[what the pinning corresponds to](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml) at any given time.
-
-In either case, the actual runtime requirements are determined through numpy's
-run-export, which is:
-
-- `>=1.2x,<2` if you're building against numpy 1.2x
-- `>=1.19,<3` if you're building against numpy 2.0
-- `>=1.21,<3` if you're building against numpy 2.1 or 2.2
-- `>=1.23,<3` if you're building against numpy 2.3
-
-If the package you are building has a higher minimum requirement for numpy, please add this under `run`:
-
-<RecipeTabs>
-
-```recipe
-requirements:
-  host:
-    # leave this unpinned!
-    - numpy
-  run:
-    - numpy >={{ the_lower_bound_your_package_needs }}
-```
-
-```recipe
-requirements:
-  host:
-    # leave this unpinned!
-    - numpy
-  run:
-    - numpy >=${{ the_lower_bound_your_package_needs }}
-```
-
-</RecipeTabs>
+Please refer to [How-to > Advanced > Build against NumPy](/docs/how-to/advanced/numpy/).
 
 <a id="jupyterlab-extension"></a>
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

# Description

https://github.com/Quansight-Labs/conda-ecosystem-sta-mgmt/issues/123#issuecomment-4119259085 (refer 3rd item of **Suggested First Migration Batch**)



Moves the "Building Against NumPy" section out of the Knowledge Base and into its own page at `docs/how-to/advanced/numpy.mdx`.

## Changes

- Add `docs/how-to/advanced/numpy.mdx` with the full "Building Against NumPy" content.
- Replace the section in `docs/maintainer/knowledge_base.mdx` with a short redirect link to the new page.
- Update the sidebar entry in `docs/_sidebar_diataxis.json` from a `link` (pointing to the knowledge base anchor) to a `doc` entry pointing to the new page.