### PR TITLE
Fix incorrect config file for rust nightly in code snippet

### DIFF
--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -205,7 +205,7 @@ For a new version, please file an issue on that feedstock.
 
 To enable the rust nightly compiler in your feedstock, follow the section above and then add the `rust_dev` channel in the `conda_build_config.yaml` file:
 
-```yaml title="conda-forge.yml"
+```yaml title="conda_build_config.yaml"
 channel_sources:
   - conda-forge/label/rust_dev,conda-forge
 ```


### PR DESCRIPTION
This fixes an incorrect file in the code snippet for the rust nightly docs. With the change it matches the correct description directly above it in the text. 