### PR TITLE
Frontpage: Report total channel size

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -40,12 +40,12 @@ export default function Stats() {
 
     const stats2 = [
         {
-            number: stats ? stats.n_members_core : "",
-            content: "Core Developers",
-        },
-        {
             number: stats ? `${(stats.n_artifacts / 1e6).toFixed(1)}M` : "",
             content: "Artifacts",
+        },
+        {
+            number: stats ? `${(stats.total_packages_size / 1e12).toFixed(1)}TB` : "",
+            content: "Channel Size",
         },
         {
             number: stats ? `${(stats.n_members / 1e3).toFixed(1)}K` : "",


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

Thanks to the recent additions in https://github.com/conda-forge/conda-forge-metadata/pull/102 and https://github.com/conda-forge/by-the-numbers/pull/49.

Removed the cell displaying number of total core members because that number doesn't change that often and can be easily retrieved anyway from [core.csv](https://github.com/conda-forge/governance/blob/main/teams/core.csv)