### PR TITLE
Document backports.zstd

### DIFF
--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -1204,6 +1204,7 @@ Currently available packages:
 
 | Name               | Available on:            | Empty on:        |
 | ------------------ | ------------------------ | ---------------- |
+| backports.zstd     | python >=3.10,\<3.14     | python >=3.14    |
 | backports.strenum  | python >=3.8,\<3.11      | python >=3.12    |
 | dataclasses        | python >=3.6,\<3.7       | python >=3.7     |
 | enum34             | python =2.7              | python >=3.4     |

--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -1204,8 +1204,8 @@ Currently available packages:
 
 | Name               | Available on:            | Empty on:        |
 | ------------------ | ------------------------ | ---------------- |
-| backports.zstd     | python >=3.10,\<3.14     | python >=3.14    |
 | backports.strenum  | python >=3.8,\<3.11      | python >=3.12    |
+| backports.zstd     | python >=3.10,\<3.14     | python >=3.14    |
 | dataclasses        | python >=3.6,\<3.7       | python >=3.7     |
 | enum34             | python =2.7              | python >=3.4     |
 | pywin32-on-windows | windows                  | unix             |


### PR DESCRIPTION
This adds backports.zstd to the list of packages that are empty starting from certain Python versions.

This is correct according to the recipe (and a comment explaining it):
https://github.com/conda-forge/backports.zstd-feedstock/blob/1217c251d3a82b07913b04e9a4a585b93c91253b/recipe/recipe.yaml#L18-L25


PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below
