### PR TITLE
FIX: Add closing quote to match condition

### DIFF
--- a/docs/maintainer/adding_pkgs.mdx
+++ b/docs/maintainer/adding_pkgs.mdx
@@ -393,7 +393,7 @@ You can e.g. specify not to build …
 
   ```recipe
   build:
-      skip: match(python, "<3.12)
+      skip: match(python, "<3.12")
   ```
   </RecipeTabs>
 
@@ -454,8 +454,8 @@ These options should be used to ensure a clean installation of the package witho
 dependencies. This helps make sure that we're only including this package,
 and not accidentally bringing any dependencies along into the conda package.
 
-Usually pure-Python packages only require `python`, `setuptools` and `pip`
-as `host` requirements; the real package dependencies are only
+Usually pure-Python packages only require `python`, a build system (e.g. `setuptools`),
+and `pip` as `host` requirements; the real package dependencies are only
 `run` requirements.
 
 <a id="requirements"></a>


### PR DESCRIPTION
* Add missing `"` to close the match condition.
* As setuptools is not the only build system that exists after PEP 517/518 use the term "build system" and then provide setuptools as an example.

PR Checklist:

- [N/A] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

This PR addresses multiple things on a single docs page. If it is preferable to split this between multiple PRs I can split out the doc improvements (`--no-deps --no-build-isolation` and build systems) from the syntax fix.