### PR TITLE
Add news: PyQt6 Designer plugin now on conda-forge

### DIFF
--- a/news/2026-06-18-pyqt6-designer-plugin.md
+++ b/news/2026-06-18-pyqt6-designer-plugin.md
@@ -4,7 +4,7 @@ After years of being silently missing from conda-forge builds, libpyqt6.so has b
 
 To install, run:
 
-mamba install -c conda-forge "pyqt6=*=*_1"
+mamba install -c conda-forge "pyqt6=_=_\_1"
 
 On Linux the plugin is at $CONDA_PREFIX/lib/qt6/plugins/designer/libpyqt6.so.
 On macOS it is at $CONDA_PREFIX/lib/qt6/plugins/designer/libpyqt6.dylib.

--- a/news/2026-06-18-pyqt6-designer-plugin.md
+++ b/news/2026-06-18-pyqt6-designer-plugin.md
@@ -8,12 +8,14 @@ To install:
 
 ```bash
 mamba install -c conda-forge "pyqt6=*=*_1"
-+
+```
+
 The plugin is automatically installed to
 $CONDA_PREFIX/lib/qt6/plugins/designer/ (Linux/macOS) or
 %PREFIX%\Library\plugins\designer\ (Windows).
 
 Available platforms: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
+
 Python versions: 3.10, 3.11, 3.12, 3.13, 3.14
 
 This fixes a long-standing issue reported upstream

--- a/news/2026-06-18-pyqt6-designer-plugin.md
+++ b/news/2026-06-18-pyqt6-designer-plugin.md
@@ -8,7 +8,7 @@ To install:
 
 ```bash
 mamba install -c conda-forge "pyqt6=*=*_1"
-```
+
 
 The plugin is automatically installed to
 $CONDA_PREFIX/lib/qt6/plugins/designer/ (Linux/macOS) or
@@ -19,9 +19,9 @@ Available platforms: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
 Python versions: 3.10, 3.11, 3.12, 3.13, 3.14
 
 This fixes a long-standing issue reported upstream
-(#44 (https://github.com/conda-forge/pyqt-feedstock/issues/44)) and enables
-projects like Taurus (https://taurus-scada.org) to use Qt Designer with
+([#44](https://github.com/conda-forge/pyqt-feedstock/issues/44)) and enables
+projects like [Taurus](https://taurus-scada.org) to use Qt Designer with
 custom Python widgets in conda environments.
 
-See PR #184 (https://github.com/conda-forge/pyqt-feedstock/pull/184) for
+See [PR #184](https://github.com/conda-forge/pyqt-feedstock/pull/184) for
 implementation details.

--- a/news/2026-06-18-pyqt6-designer-plugin.md
+++ b/news/2026-06-18-pyqt6-designer-plugin.md
@@ -1,0 +1,25 @@
+# Qt Designer Python plugin now available in conda-forge PyQt6
+
+After years of being silently missing from conda-forge builds, `libpyqt6.so` — the
+C++ bridge that lets Qt Designer load custom Python widgets — is now shipped as part
+of the official `pyqt6` package.
+
+To install:
+
+```bash
+mamba install -c conda-forge "pyqt6=*=*_1"
++
+The plugin is automatically installed to
+$CONDA_PREFIX/lib/qt6/plugins/designer/ (Linux/macOS) or
+%PREFIX%\Library\plugins\designer\ (Windows).
+
+Available platforms: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
+Python versions: 3.10, 3.11, 3.12, 3.13, 3.14
+
+This fixes a long-standing issue reported upstream
+(#44 (https://github.com/conda-forge/pyqt-feedstock/issues/44)) and enables
+projects like Taurus (https://taurus-scada.org) to use Qt Designer with
+custom Python widgets in conda environments.
+
+See PR #184 (https://github.com/conda-forge/pyqt-feedstock/pull/184) for
+implementation details.

--- a/news/2026-06-18-pyqt6-designer-plugin.md
+++ b/news/2026-06-18-pyqt6-designer-plugin.md
@@ -1,27 +1,16 @@
 # Qt Designer Python plugin now available in conda-forge PyQt6
 
-After years of being silently missing from conda-forge builds, `libpyqt6.so` — the
-C++ bridge that lets Qt Designer load custom Python widgets — is now shipped as part
-of the official `pyqt6` package.
+After years of being silently missing from conda-forge builds, libpyqt6.so has been added to the conda-forge pyqt6 package.
 
-To install:
+To install, run:
 
-```bash
 mamba install -c conda-forge "pyqt6=*=*_1"
 
+On Linux the plugin is at $CONDA_PREFIX/lib/qt6/plugins/designer/libpyqt6.so.
+On macOS it is at $CONDA_PREFIX/lib/qt6/plugins/designer/libpyqt6.dylib.
+On Windows it is at %PREFIX%\Library\plugins\designer\libpyqt6.dll.
 
-The plugin is automatically installed to
-$CONDA_PREFIX/lib/qt6/plugins/designer/ (Linux/macOS) or
-%PREFIX%\Library\plugins\designer\ (Windows).
+Platforms: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
+Python: 3.10, 3.11, 3.12, 3.13, 3.14
 
-Available platforms: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
-
-Python versions: 3.10, 3.11, 3.12, 3.13, 3.14
-
-This fixes a long-standing issue reported upstream
-([#44](https://github.com/conda-forge/pyqt-feedstock/issues/44)) and enables
-projects like [Taurus](https://taurus-scada.org) to use Qt Designer with
-custom Python widgets in conda environments.
-
-See [PR #184](https://github.com/conda-forge/pyqt-feedstock/pull/184) for
-implementation details.
+See PR #184 (https://github.com/conda-forge/pyqt-feedstock/pull/184) for details.


### PR DESCRIPTION
This update introduces the Qt Designer Python plugin in conda-forge for PyQt6, allowing the use of custom Python widgets. It resolves a long-standing issue and provides installation instructions along with supported platforms and Python versions.

News entry announcing that libpyqt6.so is now shipped with pyqt6 on conda-forge.
Closes no issues.

PR Checklist:

- [X ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ X] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [X ] put any other relevant information below
