### PR TITLE
Update snippets to use `files.pythonhosted.org` for PyPI sources

### DIFF
--- a/docs/maintainer/example_recipes/pure-python.md
+++ b/docs/maintainer/example_recipes/pure-python.md
@@ -30,7 +30,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/e/example-package/example_package-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/e/example-package/example_package-${{ version }}.tar.gz
   sha256: 12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a
 
 build:
@@ -96,11 +96,11 @@ package:
 
 ```recipe
 source:
-  url: https://pypi.org/packages/source/e/example-package/example_package-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/e/example-package/example_package-${{ version }}.tar.gz
   sha256: 12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a
 ```
 
-- `url`: The PyPI source URL follows the pattern `https://pypi.org/packages/source/<first-letter>/<package-name>/<package-name>-<version>.tar.gz`. Note that the package name in the URL may use underscores instead of hyphens (e.g., `example_package` vs `example-package`).
+- `url`: The PyPI source URL follows the pattern `https://files.pythonhosted.org/packages/source/<first-letter>/<package-name>/<package-name>-<version>.tar.gz`. Note that the package name in the URL may use underscores instead of hyphens (e.g., `example_package` vs `example-package`).
 - `sha256`: The SHA256 hash of the source archive. Run `openssl sha256 <artifact>` to get its hash after downloading the source file.
 
 ### The `build` section

--- a/docs/tutorials/adding-tests.md
+++ b/docs/tutorials/adding-tests.md
@@ -37,14 +37,14 @@ context:
 # ...
 
 source:
-  url: https://pypi.org/packages/source/x/xmltodict/xmltodict-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/x/xmltodict/xmltodict-${{ version }}.tar.gz
   sha256: 6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61
 ```
 
 Let's start by downloading and unpacking the source distribution, then enter the unpacked directory:
 
 ```bash
-wget https://pypi.org/packages/source/x/xmltodict/xmltodict-1.0.4.tar.gz
+wget https://files.pythonhosted.org/packages/source/x/xmltodict/xmltodict-1.0.4.tar.gz
 tar -x -f xmltodict-1.0.4.tar.gz
 cd xmltodict-1.0.4/
 ```

--- a/docs/tutorials/first-recipe.md
+++ b/docs/tutorials/first-recipe.md
@@ -110,7 +110,7 @@ that we're using the `version` variable that was defined earlier.
 
 ```recipe
 source:
-  url: https://pypi.org/packages/source/p/pylast/pylast-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/p/pylast/pylast-${{ version }}.tar.gz
   sha256: 319251236ba5c3e907232aacf1d6a7ff831f2243e85ace6ec6623a552ec2e0eb
 ```
 


### PR DESCRIPTION
PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

Update the snippets referencing PyPI sources to fetch them via the canonical `files.pythonhosted.org` domain per upstream documentation: https://docs.pypi.org/api/#predictable-urls

It saves a single unnecessary redirect and reduces load off pypi.org, though it seems that currently both hostnames are served off the same server. It also follows suit with what other distributions are doing, e.g. Arch Linux and Gentoo:
- https://wiki.archlinux.org/title/Python_package_guidelines#Source
- https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/pypi.eclass#n173

xref https://github.com/conda-forge/conda-forge.github.io/issues/2878
