### PR TITLE
Do not render error boxes for empty payloads

### DIFF
--- a/src/pages/status/migration/index.jsx
+++ b/src/pages/status/migration/index.jsx
@@ -559,7 +559,7 @@ function Row({ children }) {
       {href && isSafeUrl(href) ? (
         <a href={href}>{name}</a>
       ) : (
-        details ? (
+        details && Object.keys(details).length > 0 ? (
           <span className={`${collapsed ? styles.collapsed : styles.expanded}`}
             onClick={() => setState(!collapsed)}>
             {name}
@@ -595,8 +595,8 @@ function Row({ children }) {
         </React.Fragment>))}
       </td>
     </tr>
-    {details && !collapsed && (
-      <tr><td colSpan={6}><ErrorMessageDetails details={details}/></td></tr>
+    {details && Object.keys(details).length > 0 && !collapsed && (
+      <tr ><td colSpan={6}><ErrorMessageDetails details={details}/></td></tr>
     )}
   </>);
 }


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [ ] put any other relevant information below

Fixes error where `main` shows `[object Object]` for "Awaiting parents" rows in migration status details. These are empty payloads and should not be rendered at all.

<img width="1318" height="393" alt="image" src="https://github.com/user-attachments/assets/6bc6a8e1-3563-409c-827d-e289dfe82f25" />
