### PR TITLE
Add abi3 example recipes page linking to python-abi3-feedstock

### DIFF
--- a/docs/_sidebar.json
+++ b/docs/_sidebar.json
@@ -67,7 +67,8 @@
         "items": [
           "maintainer/example_recipes/go",
           "maintainer/example_recipes/rust",
-          "maintainer/example_recipes/pure-python"
+          "maintainer/example_recipes/pure-python",
+          "maintainer/example_recipes/abi3"
         ]
       }
     ]

--- a/docs/maintainer/example_recipes/abi3.md
+++ b/docs/maintainer/example_recipes/abi3.md
@@ -1,0 +1,10 @@
+---
+title: 'Python abi3 packages'
+---
+
+Packages built against Python's [stable ABI (`abi3`)](https://docs.python.org/3/c-api/stable.html) are compiled once and run on every supported Python version, so a single build covers them all.
+
+conda-forge keeps full example recipes in the [`python-abi3-feedstock`](https://github.com/conda-forge/python-abi3-feedstock) repository:
+
+- [`example-recipe.yaml`](https://github.com/conda-forge/python-abi3-feedstock/blob/main/recipe/example-recipe.yaml) (v1 format)
+- [`example-meta.yaml`](https://github.com/conda-forge/python-abi3-feedstock/blob/main/recipe/example-meta.yaml) (v0 format)


### PR DESCRIPTION
Closes #2877.

Adds a short `abi3` page under Example recipes that links to the two examples in `python-abi3-feedstock` (`example-recipe.yaml` and `example-meta.yaml`). No recipe content is copied, as requested in the issue.
