### PR TITLE
Clarify output validation failures for long-dormant feedstocks

### DIFF
--- a/docs/maintainer/infrastructure.mdx
+++ b/docs/maintainer/infrastructure.mdx
@@ -832,7 +832,7 @@ Output packages that match these patterns will be automatically registered for y
 
 ### Package validation failed for an existing output name
 
-This commonly happens when the feedstock has not been built and uploaded in a long time,
+This may happen when the feedstock has not been built and uploaded in a long time,
 so its output was never registered. Feedstocks created before output registration existed only
 get their outputs registered on their next successful upload, so a build fails validation until
 the mapping is added. Register the output via the

--- a/docs/maintainer/infrastructure.mdx
+++ b/docs/maintainer/infrastructure.mdx
@@ -832,19 +832,20 @@ Output packages that match these patterns will be automatically registered for y
 
 ### Package validation failed for an existing output name
 
-We attempt to report errors in this process to users via comments on commits/issues in the feedstocks.
-Sometimes these reports fail. If you think you are having trouble with uploads, make sure to check/try
-the following things:
+This commonly happens when the feedstock has not been built and uploaded in a long time,
+so its output was never registered. Feedstocks created before output registration existed only
+get their outputs registered on their next successful upload, so a build fails validation until
+the mapping is added. Register the output via the
+[admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
+
+If the output is already registered and you are still having trouble with uploads, note that we
+attempt to report errors in this process to users via comments on commits/issues in the feedstocks,
+and sometimes these reports fail. In that case, make sure to check/try the following things:
 
 - Ensure that `conda_forge_output_validation: true` is set in your `conda-forge.yml`.
-- If the feedstock has not been built and uploaded in a long time, its output may never
-  have been registered. Feedstocks created before output registration existed only get
-  their outputs registered on their next successful upload, so a build will fail validation
-  until the mapping is added. Register the output via the
-  [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
 - Retry the package build and upload by pushing an empty commit to the feedstock.
 - Rerender the feedstock in a PR from a fork of the feedstock and merge.
-- If none of the above apply, request a feedstock token reset via our
+- Request a feedstock token reset via our
   [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
   A token reset only re-authenticates uploads; it does not register outputs.
 

--- a/docs/maintainer/infrastructure.mdx
+++ b/docs/maintainer/infrastructure.mdx
@@ -837,9 +837,16 @@ Sometimes these reports fail. If you think you are having trouble with uploads, 
 the following things:
 
 - Ensure that `conda_forge_output_validation: true` is set in your `conda-forge.yml`.
+- If the feedstock has not been built and uploaded in a long time, its output may never
+  have been registered. Feedstocks created before output registration existed only get
+  their outputs registered on their next successful upload, so a build will fail validation
+  until the mapping is added. Register the output via the
+  [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
 - Retry the package build and upload by pushing an empty commit to the feedstock.
 - Rerender the feedstock in a PR from a fork of the feedstock and merge.
-- Request a feedstock token reset via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
+- If none of the above apply, request a feedstock token reset via our
+  [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
+  A token reset only re-authenticates uploads; it does not register outputs.
 
 ## Stages of package building and involved infrastructure
 


### PR DESCRIPTION
The "Package validation failed for an existing output name" section currently ends at "request a feedstock token reset." But a feedstock that has not built in a long time can fail validation on an *existing* name simply because its output was never registered (feedstocks predating output registration only get registered on their next successful upload). The right fix there is `add_feedstock_output`, not a token reset, and it is easy to take the token-reset wrong turn from this section.

Changes to that section:
- Add a step directing users to register the output via `add_feedstock_output` when the feedstock has been dormant.
- Keep the token reset step (it can still be genuinely needed) but move it to a last-resort "if none of the above apply" and note it only re-authenticates uploads and does not register outputs.

Companion admin-requests README clarification: conda-forge/admin-requests#2215.

Docs only, no behavior change.