### PR TITLE
update expected feedstocks for gfortran on osx

### DIFF
--- a/docs/maintainer/infrastructure.mdx
+++ b/docs/maintainer/infrastructure.mdx
@@ -752,8 +752,12 @@ OSX (Clang + GNU Fortran):
   [openmp](https://github.com/conda-forge/openmp-feedstock),
   [lld](https://github.com/conda-forge/lld-feedstock),
   [cctools](https://github.com/conda-forge/cctools-and-ld64-feedstock)
-- [Fortran] Activation: https://github.com/conda-forge/gfortran_osx-64-feedstock/
-- [Fortran] Implementation: https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/
+- [Fortran] Activation
+  - as of GCC v15: https://github.com/conda-forge/ctng-compiler-activation-feedstock
+  - until GCC v14: https://github.com/conda-forge/gfortran_osx-64-feedstock
+- [Fortran] Implementation
+  - as of GCC v15: https://github.com/conda-forge/ctng-compilers-feedstock
+  - until GCC v14: https://github.com/conda-forge/gfortran_impl_osx-64-feedstock
 
 Windows (MSVC + Flang):
 


### PR DESCRIPTION
There was a lot of work in the context of https://github.com/Quansight-Labs/conda-ecosystem-sta-mgmt/issues/38 to move the content of https://github.com/conda-forge/gfortran_impl_osx-64-feedstock as well as https://github.com/conda-forge/gfortran_osx-64-feedstock to https://github.com/conda-forge/ctng-compilers-feedstock. However, this only takes effect for v15+. The old feedstocks will be archivable once we drop GCC 14 next year. In the meantime, document this state of affairs.