### PR TITLE
Add reference for Wayland in Alma10

### DIFF
--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -1144,7 +1144,7 @@ if you import parts of `matplotlib` that link to `libX11`.
 Or, if your recipe is using Alma10 as the linux distribution (you can check in the `.ci_support/linux_64_.yaml` file under the `docker_image:` entry), Xorg is no longer available out of the box and you'll need to use Wayland instead:
 
 ```bash
-xorg-x11-server-Xwayland 
+xorg-x11-server-Xwayland
 ```
 
 <a id="pybind11-abi-constraints"></a>

--- a/docs/maintainer/knowledge_base.mdx
+++ b/docs/maintainer/knowledge_base.mdx
@@ -1141,6 +1141,12 @@ xorg-x11-server-Xorg
 
 if you import parts of `matplotlib` that link to `libX11`.
 
+Or, if your recipe is using Alma10 as the linux distribution (you can check in the `.ci_support/linux_64_.yaml` file under the `docker_image:` entry), Xorg is no longer available out of the box and you'll need to use Wayland instead:
+
+```bash
+xorg-x11-server-Xwayland 
+```
+
 <a id="pybind11-abi-constraints"></a>
 
 <a id="pybind11-swig-abi-constraints"></a>


### PR DESCRIPTION
PR Checklist:

- [ ] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [ ] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

Add a quick reference in the Knowledge Base to `xorg-x11-server-Xwayland` in the case when it's necessary to use `yum_requirements.txt` to install X11, which is not available in Alma10.