### PR TITLE
FIX: Remove redundant pip flags from examples

### DIFF
--- a/docs/maintainer/adding_pkgs.mdx
+++ b/docs/maintainer/adding_pkgs.mdx
@@ -67,7 +67,7 @@ There are, currently, three ways to generate a recipe:
    You do _not_ necessarily have to use `grayskull`, and the recipes produced by `grayskull` might need to be reviewed and edited.
    Read more about `grayskull` and how to use it [here](https://github.com/conda-incubator/grayskull#introduction).
 
-3. If it's none of the above, generate a recipe with the help of [the example v1 recipe](https://github.com/conda-forge/staged-recipes/tree/main/recipes/example-v1) (or [the example v0 recipe](https://github.com/conda-forge/staged-recipes/tree/main/recipes/example-v0-deprecated), if you wish to use the v0 format) in the [staged-recipes repository](https://github.com/conda-forge/staged-recipes) and modify it as necessary.
+3. If it's none of the above, generate a recipe with the help of [the example v1 recipe](https://github.com/conda-forge/staged-recipes/tree/main/recipes/example-v1) in the [staged-recipes repository](https://github.com/conda-forge/staged-recipes) and modify it as necessary.
 
 Your final recipe should have no comments (unless they're actually relevant to the recipe, and not generic instruction comments), and follow the order in the example.
 

--- a/docs/maintainer/example_recipes/pure-python.md
+++ b/docs/maintainer/example_recipes/pure-python.md
@@ -36,7 +36,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -109,7 +109,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 ```
 
 - `noarch: python`: Indicates that this is a pure-Python package and can be installed on any architecture.
@@ -117,8 +117,11 @@ build:
 - `script`: The build script uses pip to install the package:
   - `${{ PYTHON }} -m pip install`: Ensures the correct Python interpreter is used.
   - `-vv`: Verbose output for debugging build issues.
-  - `--no-deps`: Prevents pip from installing dependencies itself, as these are specified in the `requirements.run` section.
-  - `--no-build-isolation`: Ensures that the `host` environment is used to build the package (instead of creating a new virtualenv).
+
+Note that the `pip` flags `--no-deps` and `--no-build-isolation` are automatically applied by `rattler-build`.
+
+- `--no-deps`: Prevents pip from installing dependencies itself, as these are specified in the `requirements.run` section.
+- `--no-build-isolation`: Ensures that the `host` environment is used to build the package (instead of creating a new virtualenv).
 
 #### Entry points
 

--- a/docs/tutorials/adding-tests.md
+++ b/docs/tutorials/adding-tests.md
@@ -170,7 +170,7 @@ The build number can be found in the `build:` section:
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 ```
 
 Increase it by one, making it:
@@ -179,7 +179,7 @@ Increase it by one, making it:
 build:
   number: 1
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 ```
 
 Note that in some recipes, the build number will be referenced via a variable rather than directly.

--- a/docs/tutorials/first-recipe.md
+++ b/docs/tutorials/first-recipe.md
@@ -122,7 +122,7 @@ you change the version, you won't have to update both the package version and th
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 ```
 
 Here, three important bits of information are specified:
@@ -133,7 +133,8 @@ Here, three important bits of information are specified:
 2. The `noarch` key that indicates that we're building a pure Python package, and so we do not need
    to build separate packages for different conda-forge platforms and Python versions.
 3. The actual build command invocation. We're using the Python package manager `pip` to build
-   and install our package into the workspace. We are passing `--no-deps` to stop `pip` from trying
+   and install our package into the workspace.
+   Note that `rattler-build` is automatically passing `--no-deps` to stop `pip` from trying
    to automatically install its dependencies (they are already preinstalled in the environment), and
    `--no-build-isolation` to make the build use our build environment rather than creating a new
    one.


### PR DESCRIPTION
Resolves https://github.com/conda-forge/conda-forge.github.io/issues/2869

* Remove the `pip` flags `--no-deps` and `--no-build-isolation` from example `pip install` commands as these are automatically applied by rattler-build and conda-build now. Note this explicitly and keep the explanations of what the flags do.
* The v0 recipe example `recipes/example/meta.yaml` was renamed to `recipes/example-v0-deprecated/meta.yaml` in https://github.com/conda-forge/staged-recipes/pull/34414.   Remove the link as it now not recommended.
* c.f. https://github.com/conda/grayskull/pull/584 for corresponding `grayskull` PR.

PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below

Resvoles https://github.com/conda-forge/conda-forge.github.io/issues/2869 which started from https://github.com/conda-forge/conda-forge.github.io/pull/2864#discussion_r3437602561. This combined with https://github.com/conda-forge/staged-recipes/pull/34445 means that `v0` recipes shouldn't be a concern anymore and so this should be able to cover everything.

Relevant pages for inspection for reviewers:

* https://deploy-preview-2913--conda-forge-previews.netlify.app/docs/maintainer/example_recipes/pure-python/#the-build-section
* https://deploy-preview-2913--conda-forge-previews.netlify.app/docs/tutorials/adding-tests/#bump-the-build-number
* https://deploy-preview-2913--conda-forge-previews.netlify.app/docs/tutorials/first-recipe/#look-at-the-recipe-file
* https://deploy-preview-2913--conda-forge-previews.netlify.app/docs/maintainer/adding_pkgs/#generating-the-recipe