### PR TITLE
Announce dropping python 3.10

### DIFF
--- a/news/2025-06-26-python-3-10.md
+++ b/news/2025-06-26-python-3-10.md
@@ -1,0 +1,10 @@
+# Dropping Python 3.10 support in conda-forge
+
+With Python 3.10 reaching end-of-life in Oct. 2026 and Python
+3.15 being released the same month, we have decided to drop
+3.10 from our default build matrix. This will be reflected
+in your feedstock configuration on the next rerender.
+
+The decision to drop support 1.5 months before its EOL is
+to avoid the strain on conda-forge CI while we begin rolling
+out support for 3.15.


### PR DESCRIPTION
Essentially a carbon-copy of #2585, for https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/8891