### PR TITLE
MNT: Use prek as pre-commit replacement

### DIFF
--- a/.ci_scripts/environment.yml
+++ b/.ci_scripts/environment.yml
@@ -5,6 +5,6 @@ channels:
 dependencies:
 - curl *
 - nodejs 24.*
-- pre-commit *
+- prek >=0.5.0,<1.0
 - python 3.*
 - requests *

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,12 +9,12 @@ install = { cmd = "npm install", description = "Install Node packages."}
 start = { cmd = "npm run start", description = "Live-reload deployment for local development.", depends-on = ["install"]}
 build-production = { cmd = "bash ./.ci_scripts/update_docs", description = "Build site for production." }
 serve-production = { cmd = "python -m http.server -d build/", description = "Serve site built for production." }
-lint = { cmd = "pre-commit run --all-files", description = "Run pre-commit hooks to lint the codebase." }
+lint = { cmd = "prek run --all-files", description = "Run prek hooks to lint the codebase." }
 
 [dependencies]
 curl = "*"
 nodejs = "24.*"
-pre-commit = "*"
+prek = ">=0.5.0,<1.0"
 python = "3.*"
 requests = "*"
 


### PR DESCRIPTION
* Replace 'pre-commit' with 'prek' for significantly faster pre-commit tooling.
   - c.f. https://github.com/j178/prek

PR Checklist:

- [x] note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [N/A] if you are adding a new page under `docs/` or `community/`, you have added it to the sidebar in the corresponding `_sidebar.json` file
- [x] put any other relevant information below
